### PR TITLE
fix(performance): preserve zero summary metrics

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -20,7 +20,8 @@ const {
     getWindowStartDate,
     calculateReturnFromTimeSeries,
     mapReturnsTableToWindowReturns,
-    derivePerformanceWindows
+    derivePerformanceWindows,
+    summarizePerformanceMetrics
 } = require('../tampermonkey/endowus_portfolio_viewer.user.js');
 
 describe('getGoalTargetKey', () => {
@@ -226,6 +227,22 @@ describe('formatPercentage', () => {
 
     test('should return dash for invalid input', () => {
         expect(formatPercentage('invalid')).toBe('-');
+    });
+});
+
+describe('summarizePerformanceMetrics', () => {
+    test('should preserve zero-valued totals', () => {
+        const performanceResponses = [{
+            totalCumulativeReturnAmount: { amount: 0 },
+            netInvestmentAmount: { amount: 0 },
+            endingBalanceAmount: { amount: 0 }
+        }];
+
+        const result = summarizePerformanceMetrics(performanceResponses, []);
+
+        expect(result.totalReturnAmount).toBe(0);
+        expect(result.netInvestmentAmount).toBe(0);
+        expect(result.endingBalanceAmount).toBe(0);
     });
 });
 

--- a/tampermonkey/endowus_portfolio_viewer.user.js
+++ b/tampermonkey/endowus_portfolio_viewer.user.js
@@ -463,10 +463,13 @@
         const simpleReturns = [];
         const twrReturns = [];
         let totalReturnAmount = 0;
+        let totalReturnSeen = false;
         let netFeesAmount = 0;
         let netFeesSeen = false;
         let netInvestmentAmount = 0;
+        let netInvestmentSeen = false;
         let endingBalanceAmount = 0;
+        let endingBalanceSeen = false;
 
         responses.forEach(response => {
             const totalReturnValue = extractAmount(response?.totalCumulativeReturnAmount);
@@ -481,6 +484,7 @@
 
             if (isFinite(totalReturnValue)) {
                 totalReturnAmount += totalReturnValue;
+                totalReturnSeen = true;
             }
             if (isFinite(accessFeeValue) || isFinite(trailerFeeValue)) {
                 netFeesSeen = true;
@@ -489,9 +493,11 @@
             }
             if (isFinite(netInvestmentValue)) {
                 netInvestmentAmount += netInvestmentValue;
+                netInvestmentSeen = true;
             }
             if (isFinite(endingBalanceValue)) {
                 endingBalanceAmount += endingBalanceValue;
+                endingBalanceSeen = true;
             }
 
             const netWeight = isFinite(netInvestmentValue) ? netInvestmentValue : 0;
@@ -511,6 +517,7 @@
             const latest = mergedTimeSeries[mergedTimeSeries.length - 1];
             if (isFinite(latest?.amount)) {
                 endingBalanceAmount = latest.amount;
+                endingBalanceSeen = true;
             }
         }
 
@@ -522,6 +529,7 @@
             const earliest = mergedTimeSeries[0];
             if (isFinite(earliest?.amount)) {
                 netInvestmentAmount = earliest.amount;
+                netInvestmentSeen = true;
             }
         }
 
@@ -529,10 +537,10 @@
             totalReturnPercent,
             simpleReturnPercent,
             twrPercent,
-            totalReturnAmount: totalReturnAmount || null,
+            totalReturnAmount: totalReturnSeen ? totalReturnAmount : null,
             netFeesAmount: netFeesSeen ? netFeesAmount : null,
-            netInvestmentAmount: netInvestmentAmount || null,
-            endingBalanceAmount: endingBalanceAmount || null
+            netInvestmentAmount: netInvestmentSeen ? netInvestmentAmount : null,
+            endingBalanceAmount: endingBalanceSeen ? endingBalanceAmount : null
         };
     }
 
@@ -2904,7 +2912,8 @@
             getWindowStartDate,
             calculateReturnFromTimeSeries,
             mapReturnsTableToWindowReturns,
-            derivePerformanceWindows
+            derivePerformanceWindows,
+            summarizePerformanceMetrics
         };
     }
 


### PR DESCRIPTION
### Motivation

- The summary aggregation coerced zero amounts to `null` via `value || null`, causing legitimate `$0.00` values to render as “-” in the UI.
- Review feedback requested preserving explicit zero totals so users see accurate metrics for flat/new goals.

### Description

- Updated `summarizePerformanceMetrics` to track whether `totalReturn`, `netInvestment`, and `endingBalance` were observed (`totalReturnSeen`, `netInvestmentSeen`, `endingBalanceSeen`) and only return `null` when no value was present.
- Changed returned fields to use the new presence flags (`totalReturnAmount: totalReturnSeen ? totalReturnAmount : null`, etc.).
- Exported `summarizePerformanceMetrics` in the conditional `module.exports` so tests can import the real implementation.
- Added a Jest unit test `should preserve zero-valued totals` in `__tests__/utils.test.js` that verifies zero totals are preserved.

### Testing

- Ran the test suite with `npm test` and all tests passed (`PASS __tests__/utils.test.js`, 57 tests passed).
- The new unit test `summarizePerformanceMetrics -> should preserve zero-valued totals` was executed and succeeded.
- No other automated test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b3402fd88326b5f3cc6dc25b7269)