### PR TITLE
feat(ui): make summary bucket cards clickable and keyboard-accessible

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -302,7 +302,7 @@ function formatMoney(amount) {
 The UI consists of:
 1. **Trigger Button** - Fixed position button to open the viewer
 2. **Modal Overlay** - Full-screen overlay with backdrop blur
-3. **View Selector** - Dropdown to switch between Summary and Detail views
+3. **View Selector** - Dropdown to switch between Summary and Detail views, synced with summary card clicks
 4. **Data Display Area** - Dynamic content area for tables and cards
 
 ### Styling System

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -97,9 +97,10 @@ The script will automatically group all goals starting with the same bucket name
 - Shows all buckets with their totals, returns, and growth percentages
 - Displays breakdown by goal type (Investment, Cash, etc.) within each bucket
 - Perfect for a quick overview of your entire portfolio
+- Click any bucket card to jump directly to its detail view (syncs the dropdown selection)
 
 #### Bucket Detail View
-- Select a specific bucket from the dropdown
+- Select a specific bucket from the dropdown (or click a bucket card in the summary view)
 - See detailed information about each goal within that bucket
 - View individual goal performance metrics
 - Compare goals within the same bucket


### PR DESCRIPTION
### Motivation
- Improve discoverability and workflow by letting users click a bucket card in the summary to jump to the bucket detail view.
- Provide accessibility so keyboard users can activate bucket cards (`Enter` / `Space`).
- Keep view selector (`<select>`) and summary cards in sync so the dropdown reflects the currently-selected bucket.
- Small UX polish (cursor/focus styles) to indicate interactivity.

### Description
- Updated `renderSummaryView` to accept an `onBucketSelect` callback and attached `data-bucket`, `role="button"`, `tabindex="0"`, `click` and `keydown` handlers to each `.epv-bucket-card` to invoke the callback when activated.
- Added `onBucketSelect` and `renderView` logic in the overlay controller so clicking a card sets `select.value` and renders the corresponding bucket with `renderBucketView`.
- Added CSS pointer and `:focus-visible` styles for `.epv-bucket-card` to show hover and keyboard focus states.
- Bumped userscript version to `2.3.1` and updated `TECHNICAL_DESIGN.md` and `tampermonkey/README.md` to document the new interaction.

### Testing
- No automated tests were run because this is a UI-only change that does not modify pure logic covered by the Jest suite.
- The change is limited to DOM event wiring and styles, so existing unit tests for pure logic were not affected (no test updates required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a63249cd883268909bbaa2fd4ebf9)