### PR TITLE
docs(readme): clarify fund visualization gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **Track core-satellite portfolios the way they were meant to be seen — clean, goal-aware, and entirely private.**
 
+Investing today often means buying individual funds or managed funds across multiple goals. Most platforms still do not provide an easy way to visualize each of these purchases or track allocation across all of them, whether you follow core-satellite or a broader asset allocation framework. This userscript helps you spot imbalances early and organize everything around your real-life goals.
+
 > **Platform Support**: Currently works with Endowus (Singapore). This userscript enhances your portfolio visualization experience by organizing goals into custom buckets.
 
 ---
@@ -37,7 +39,7 @@ Core-satellite strategies complement this approach. The core anchors each goal w
 
 ## Why This View Matters
 
-Endowus and many other platforms already provides excellent low-cost investment options and thoughtfully designed thematic portfolios. The gap is in visualizing your portfolio using a core-satellite approach. When each asset is tracked as its own goal, a multi-goal, core-satellite strategy quickly becomes a long list of goals without a clear allocation view.
+Endowus and many other platforms already provides excellent low-cost investment options and thoughtfully designed thematic portfolios. The gap is in visualizing your portfolio using a core-satellite approach, especially when you are buying individual funds or managed funds across many goals. When each asset is tracked as its own goal, a multi-goal, core-satellite strategy quickly becomes a long list of goals without a clear allocation view.
 
 This overlay brings those assets back together so more sophisticated retail investors can see how each goal balances core holdings with focused exposures. That means it is easier to track satellite tilts such as China, Tech, or custom thematic portfolios built with FundSmart, while keeping the overall allocation aligned to each life goal.
 


### PR DESCRIPTION
### Motivation
- Clarify the README to better explain modern workflows where investors buy individual or managed funds across multiple goals.
- Highlight the visualization gap on platforms like Endowus that makes it hard to see allocations when each asset is tracked as its own goal.
- Emphasize the userscript’s role in spotting allocation imbalances early and organizing holdings around real-life goals.

### Description
- Updated `README.md` to add an introductory paragraph describing fund-purchase workflows and the lack of easy cross-goal visualization.
- Revised the `Why This View Matters` section to explicitly call out tracking for individual and managed fund purchases across many goals.
- Reinforced messaging about imbalance detection, core-satellite alignment, and life-goal organization in the value proposition.
- Documentation-only changes to copy and formatting; no runtime code was modified.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b917727288326aa2f8027c7b94dc3)