### PR TITLE
fix(ui): teardown performance chart observers on overlay close and bump versions to 2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "View and organize your investment portfolio by buckets with a modern interface",
   "main": "tampermonkey/goal_portfolio_viewer.user.js",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Prevent lingering `ResizeObserver` timers/observers created by the performance charts when the overlay is closed or replaced.
- Centralize cleanup so all chart teardown callbacks are invoked reliably on overlay removal.
- Avoid attempting cleanup after the overlay has been detached from the DOM to prevent errors.
- Keep package and userscript version numbers aligned by bumping from `2.3.2` to `2.3.3`.

### Description
- `renderGoalTypePerformance(typeSection, goalIds, cleanupCallbacks)` now captures the cleanup function returned by `initializePerformanceChart` and pushes it into `cleanupCallbacks` when provided.
- `renderBucketView` signature updated to accept `cleanupCallbacks` and forwards it into each `renderGoalTypePerformance` call so per-chart hooks are collected.
- `showOverlay` creates a shared `cleanupCallbacks` array, attaches it to the overlay/container as `gpvCleanupCallbacks`, invokes stored callbacks when replacing an old overlay, and adds `teardownOverlay()` / `closeOverlay()` which guard `overlay.isConnected` and run cleanup before removing the overlay; the close button and outside-click now call `closeOverlay()`.
- Like I'm 5: before the popup window goes away the code now tells every little chart to stop watching and clean up so they don't keep running in the background.

### Testing
- No automated tests were run for this change because it is a UI/DOM lifecycle fix and a version bump.
- The existing test suite (`npm test`) was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c44dcfa848326b342fef4ac549542)