### PR TITLE
chore(version): automate userscript version sync

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -394,11 +394,13 @@ The `bucketViewModel` contains:
 
 ### Version Bump Checklist
 
-When shipping a release, update every version touchpoint to keep them aligned:
+Use `npm version <patch|minor|major>` to keep version touchpoints aligned automatically. The `postversion` hook runs
+`scripts/sync-version.js`, which syncs `package.json` to the userscript `// @version` line, and npm updates
+`package-lock.json` in the same step.
 
-1. **Userscript metadata**: `tampermonkey/goal_portfolio_viewer.user.js` → `// @version`
-2. **Package metadata**: `package.json` → `"version"`
-3. **Changelog**: `tampermonkey/README.md` → add a new entry under `## Changelog`
+Then update:
+
+1. **Changelog**: `tampermonkey/README.md` → add a new entry under `## Changelog`
 
 If any of these are missed, Tampermonkey auto-updates or release notes can drift from the actual code.
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "View and organize your investment portfolio by buckets with a modern interface",
   "main": "tampermonkey/goal_portfolio_viewer.user.js",
   "scripts": {
+    "postversion": "node scripts/sync-version.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function readPackageVersion() {
+    const packagePath = path.resolve(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    if (!packageJson.version) {
+        throw new Error('package.json is missing a version field.');
+    }
+    return packageJson.version;
+}
+
+function updateUserscriptVersion(version) {
+    const userScriptPath = path.resolve(__dirname, '..', 'tampermonkey', 'goal_portfolio_viewer.user.js');
+    const contents = fs.readFileSync(userScriptPath, 'utf8');
+    const versionRegex = /^\/\/ @version\s+.+$/m;
+    if (!versionRegex.test(contents)) {
+        throw new Error('Unable to find // @version metadata in userscript.');
+    }
+    const updated = contents.replace(versionRegex, `// @version      ${version}`);
+    if (updated === contents) {
+        return false;
+    }
+    fs.writeFileSync(userScriptPath, updated);
+    return true;
+}
+
+function run() {
+    const version = readPackageVersion();
+    const changed = updateUserscriptVersion(version);
+    const message = changed
+        ? `Updated userscript version to ${version}.`
+        : `Userscript version already at ${version}.`;
+    console.log(message);
+}
+
+run();


### PR DESCRIPTION
### Motivation
- Prevent manual drift between the authoritative `package.json` version and the userscript `// @version` metadata by making the package version the single source of truth. 
- Ensure `package-lock.json` is updated as part of the same versioning step so lockfile and package metadata stay aligned. 
- Make releases simpler and less error-prone by integrating the sync into the standard `npm version` workflow. 
- Tradeoff: maintainers must use `npm version` (or run the script manually) because direct edits to the userscript `// @version` can be overwritten by the automation.

### Description
- Add `scripts/sync-version.js` which reads the version from `package.json` and replaces the `// @version` line in `tampermonkey/goal_portfolio_viewer.user.js`, and throws a clear error if the metadata line is missing. 
- Add a `postversion` npm lifecycle hook in `package.json` that runs `node scripts/sync-version.js` so the sync runs automatically after `npm version`. 
- Update `TECHNICAL_DESIGN.md` to document the new recommended release flow and note that `npm version` updates `package-lock.json` as part of the process. 
- Minor repository housekeeping: add the new `scripts/` file and wire it into the package scripts.

### Testing
- No automated tests were run for this change (versioning automation only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d155fdb008326932d0095bfaea452)