### PR TITLE
feat(ui): flag high remaining target (>2%) in bucket detail view

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -367,7 +367,7 @@ renderBucketView(contentDiv, bucketViewModel, bucketMap, projectedInvestments, c
 The `bucketViewModel` contains:
 - bucket totals and growth display strings
 - per-goal-type sections (with projected investment inputs)
-- per-goal rows (fixed toggles, targets, remaining target %, diffs, return classes)
+- per-goal rows (fixed toggles, targets, remaining target %, diffs, return classes), with remaining target alerts for values above 2%
 
 ---
 

--- a/__tests__/uiModels.test.js
+++ b/__tests__/uiModels.test.js
@@ -8,6 +8,7 @@ const {
     calculateGoalDiff,
     calculateFixedTargetPercent,
     calculateRemainingTargetPercent,
+    isRemainingTargetAboveThreshold,
     getProjectedInvestmentValue,
     buildDiffCellData,
     buildSummaryViewModel,
@@ -64,6 +65,12 @@ describe('format helpers', () => {
         expect(calculateRemainingTargetPercent([60, 25])).toBe(15);
         expect(calculateRemainingTargetPercent([100, 10])).toBe(-10);
     });
+
+    test('should detect high remaining target percentage', () => {
+        expect(isRemainingTargetAboveThreshold(2)).toBe(false);
+        expect(isRemainingTargetAboveThreshold(2.01)).toBe(true);
+        expect(isRemainingTargetAboveThreshold('invalid')).toBe(false);
+    });
 });
 
 describe('projected and goal helpers', () => {
@@ -104,6 +111,7 @@ describe('view model builders', () => {
         expect(goalTypeModel.projectedAmount).toBe(500);
         expect(goalTypeModel.adjustedTotal).toBe(2500);
         expect(goalTypeModel.remainingTargetDisplay).toBe('12.00%');
+        expect(goalTypeModel.remainingTargetIsHigh).toBe(true);
         const firstGoal = goalTypeModel.goals[0];
         expect(firstGoal.percentOfType).toBe(60);
         expect(firstGoal.diffDisplay).toBe('$0.00');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goal-portfolio-viewer",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "View and organize your investment portfolio by buckets with a modern interface",
   "main": "tampermonkey/goal_portfolio_viewer.user.js",
   "scripts": {

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -105,7 +105,7 @@ The script will automatically group all goals starting with the same bucket name
 - View individual goal performance metrics
 - Compare goals within the same bucket
 - Use per-goal fixed toggles to lock a goal's amount and auto-sync its target %
-- Track remaining unassigned target % for each goal type
+- Track remaining unassigned target % for each goal type, with visual flagging when it exceeds 2%
 
 ### Data Displayed
 
@@ -243,6 +243,9 @@ Contributions are welcome! To contribute:
 5. Submit a pull request
 
 ## Changelog
+
+### Version 2.6.2
+- Highlight remaining target percentages above 2% in the bucket detail view
 
 ### Version 2.6.1
 - Derived bucket names using the `"Bucket Name - Goal Description"` separator to preserve multi-word bucket labels


### PR DESCRIPTION
### Motivation
- Make the "Remaining" percentage in the bucket detail page more visible when it is materially large so users can act on unallocated target % quickly.
- Use a small, well-documented threshold to avoid noise while flagging cases that are likely meaningful (default: >2%).
- Keep logic pure and testable so the same rule is used for initial render and live refresh updates.

### Description
- Add a constant `REMAINING_TARGET_ALERT_THRESHOLD` and a pure helper `isRemainingTargetAboveThreshold()` to detect when remaining percent exceeds the threshold.
- Wire a new view-model field `remainingTargetIsHigh` into `buildBucketDetailViewModel()` and toggle a `gpv-remaining-alert` CSS class in both initial render and `refreshGoalTypeSection()` updates.
- Add pill-style alert CSS (`.gpv-remaining-target.gpv-remaining-alert`) to make the label high-contrast against the table, and include the helper in the module exports for testing.
- Update documentation and bump versions to `2.6.2` (userscript header, `package.json`, `package-lock.json`, `tampermonkey/README.md`, and `TECHNICAL_DESIGN.md`).

### Testing
- Ran the test suite with `npm test`, which executed Jest and completed successfully.
- Test results: 2 test suites passed and 113 tests passed (all green), including new unit tests for `isRemainingTargetAboveThreshold` and the `remainingTargetIsHigh` flag in the detail view model.
- The change adds no network or runtime-side effects and preserves existing logic paths, as verified by the unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618fee55a88326ac5123e47dee59b1)