### PR TITLE
fix(data): move bucket metadata to _meta

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -193,7 +193,11 @@ function buildMergedInvestmentData(performanceData, investibleData, summaryData)
         };
 
         if (!bucketMap[goalBucket]) {
-            bucketMap[goalBucket] = { total: 0 };
+            bucketMap[goalBucket] = {
+                _meta: {
+                    endingBalanceTotal: 0
+                }
+            };
         }
 
         if (!bucketMap[goalBucket][goalObj.goalType]) {
@@ -208,7 +212,7 @@ function buildMergedInvestmentData(performanceData, investibleData, summaryData)
 
         if (typeof goalObj.endingBalanceAmount === 'number') {
             bucketMap[goalBucket][goalObj.goalType].endingBalanceAmount += goalObj.endingBalanceAmount;
-            bucketMap[goalBucket].endingBalanceTotal += goalObj.endingBalanceAmount;
+            bucketMap[goalBucket]._meta.endingBalanceTotal += goalObj.endingBalanceAmount;
         }
 
         if (typeof goalObj.totalCumulativeReturn === 'number') {

--- a/__tests__/fixtures/uiFixtures.js
+++ b/__tests__/fixtures/uiFixtures.js
@@ -1,7 +1,9 @@
 function createBucketMapFixture() {
     return {
         Education: {
-            endingBalanceTotal: 0,
+            _meta: {
+                endingBalanceTotal: 0
+            },
             GENERAL_WEALTH_ACCUMULATION: {
                 endingBalanceAmount: 0,
                 totalCumulativeReturn: 0,
@@ -9,7 +11,9 @@ function createBucketMapFixture() {
             }
         },
         Retirement: {
-            endingBalanceTotal: 3000,
+            _meta: {
+                endingBalanceTotal: 3000
+            },
             GENERAL_WEALTH_ACCUMULATION: {
                 endingBalanceAmount: 2000,
                 totalCumulativeReturn: 200,

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -705,7 +705,7 @@ describe('buildMergedInvestmentData', () => {
         const result = buildMergedInvestmentData(performanceData, investibleData, summaryData);
 
         expect(result).toHaveProperty('Retirement');
-        expect(result.Retirement.endingBalanceTotal).toBe(1000);
+        expect(result.Retirement._meta.endingBalanceTotal).toBe(1000);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.endingBalanceAmount).toBe(1000);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.totalCumulativeReturn).toBe(100);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.goals).toHaveLength(1);
@@ -770,7 +770,7 @@ describe('buildMergedInvestmentData', () => {
 
         const result = buildMergedInvestmentData(performanceData, investibleData, summaryData);
 
-        expect(result.Retirement.endingBalanceTotal).toBe(3000);
+        expect(result.Retirement._meta.endingBalanceTotal).toBe(3000);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.endingBalanceAmount).toBe(3000);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.totalCumulativeReturn).toBe(300);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.goals).toHaveLength(2);
@@ -794,7 +794,7 @@ describe('buildMergedInvestmentData', () => {
 
         const result = buildMergedInvestmentData(performanceData, investibleData, summaryData);
 
-        expect(result.Emergency.endingBalanceTotal).toBe(1500);
+        expect(result.Emergency._meta.endingBalanceTotal).toBe(1500);
         expect(result.Emergency.CASH_MANAGEMENT.endingBalanceAmount).toBe(1500);
         expect(result.Emergency.CASH_MANAGEMENT.totalCumulativeReturn).toBe(75);
         expect(result.Emergency.CASH_MANAGEMENT.goals[0].endingBalanceAmount).toBe(1500);
@@ -896,7 +896,7 @@ describe('buildMergedInvestmentData', () => {
 
         const result = buildMergedInvestmentData(performanceData, investibleData, summaryData);
 
-        expect(result.Retirement.endingBalanceTotal).toBe(1000); // Only goal1 counted
+        expect(result.Retirement._meta.endingBalanceTotal).toBe(1000); // Only goal1 counted
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.endingBalanceAmount).toBe(1000);
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.goals).toHaveLength(2); // Both goals present
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "View and organize your investment portfolio by buckets with a modern interface",
   "main": "tampermonkey/goal_portfolio_viewer.user.js",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Prevent bucket-level metadata (like `endingBalanceTotal`) from being enumerated and rendered as a goal type in the UI by separating it from goal-type keys. 
- Avoid collisions when adding future bucket metadata fields by keeping metadata under a dedicated container. 
- Keep aggregation semantics (totals and per-goal-type sums) unchanged while making the bucket map shape explicit. 

### Description
- Move bucket-level `endingBalanceTotal` into a `_meta` object in the bucket map produced by `buildMergedInvestmentData`. 
- Update view-model builders (`buildSummaryViewModel`, `buildBucketDetailViewModel`) and `collectGoalIds` to ignore `_meta` when enumerating goal types and to read totals from `_meta`. 
- Update tests and fixtures in `__tests__` and the `TECHNICAL_DESIGN.md` snippet to reflect the new bucket shape, and bump versions to `2.6.4` in `package.json` and the userscript header. 

### Testing
- Ran `npm test` (Jest) which executed all suites. 
- Test results: `2` test suites passed and `117` tests passed. 
- All modified tests were updated to assert on `._meta.endingBalanceTotal` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696498e77a248326a25ba2e31525af65)