### PR TITLE
fix(ui): sort bucket detail goals alphabetically

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -382,7 +382,7 @@ renderBucketView(contentDiv, bucketViewModel, bucketMap, projectedInvestments, c
 The `bucketViewModel` contains:
 - bucket totals and growth display strings
 - per-goal-type sections (with projected investment inputs)
-- per-goal rows (fixed toggles, targets, remaining target %, diffs, return classes), with remaining target alerts for values above 2%
+- per-goal rows sorted alphabetically by goal name (fixed toggles, targets, remaining target %, diffs, return classes), with remaining target alerts for values above 2%
 
 ---
 

--- a/__tests__/fixtures/uiFixtures.js
+++ b/__tests__/fixtures/uiFixtures.js
@@ -19,17 +19,17 @@ function createBucketMapFixture() {
                 totalCumulativeReturn: 200,
                 goals: [
                     {
-                        goalId: 'g1',
-                        goalName: 'Retirement - Core',
-                        endingBalanceAmount: 1200,
-                        totalCumulativeReturn: 120,
-                        simpleRateOfReturnPercent: 0.1
-                    },
-                    {
                         goalId: 'g2',
                         goalName: 'Retirement - Growth',
                         endingBalanceAmount: 800,
                         totalCumulativeReturn: 80,
+                        simpleRateOfReturnPercent: 0.1
+                    },
+                    {
+                        goalId: 'g1',
+                        goalName: 'Retirement - Core',
+                        endingBalanceAmount: 1200,
+                        totalCumulativeReturn: 120,
                         simpleRateOfReturnPercent: 0.1
                     }
                 ]

--- a/__tests__/uiModels.test.js
+++ b/__tests__/uiModels.test.js
@@ -138,6 +138,10 @@ describe('view model builders', () => {
         const viewModel = buildBucketDetailViewModel('Retirement', bucketMap, projected, targets, fixed);
         expect(viewModel.bucketName).toBe('Retirement');
         const goalTypeModel = viewModel.goalTypes[0];
+        expect(goalTypeModel.goals.map(goal => goal.goalName)).toEqual([
+            'Retirement - Core',
+            'Retirement - Growth'
+        ]);
         expect(goalTypeModel.projectedAmount).toBe(500);
         expect(goalTypeModel.adjustedTotal).toBe(2500);
         expect(goalTypeModel.remainingTargetDisplay).toBe('12.00%');

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -259,6 +259,15 @@ describe('isRemainingTargetAboveThreshold', () => {
 });
 
 describe('buildGoalTypeAllocationModel', () => {
+    test('should sort goals alphabetically by name', () => {
+        const goals = [
+            { goalId: 'g2', goalName: 'Beta Goal', endingBalanceAmount: 50, totalCumulativeReturn: 0 },
+            { goalId: 'g1', goalName: 'alpha goal', endingBalanceAmount: 50, totalCumulativeReturn: 0 }
+        ];
+        const model = buildGoalTypeAllocationModel(goals, 100, 100, {}, {});
+        expect(model.goalModels.map(goal => goal.goalName)).toEqual(['alpha goal', 'Beta Goal']);
+    });
+
     test('should calculate goal allocation with fixed targets', () => {
         const goals = [
             { goalId: 'g1', goalName: 'Goal 1', endingBalanceAmount: 100, totalCumulativeReturn: 0 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "View and organize your investment portfolio by buckets with a modern interface",
   "main": "tampermonkey/goal_portfolio_viewer.user.js",
   "scripts": {

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -246,6 +246,9 @@ Contributions are welcome! To contribute:
 
 ## Changelog
 
+### Version 2.6.7
+- Sort goals alphabetically within each goal type in the bucket detail view
+
 ### Version 2.6.3
 - Corrected growth percentage calculations to use cumulative return over total invested
 - Clarified growth percentage definition in documentation

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.6.6
+// @version      2.6.7
 // @description  View and organize your investment portfolio by buckets with a modern interface. Groups goals by bucket names and displays comprehensive portfolio analytics. Currently supports Endowus (Singapore).
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*
@@ -233,8 +233,23 @@
         return numericRemaining > numericThreshold;
     }
 
-    function buildGoalTypeAllocationModel(goals, totalTypeAmount, adjustedTotal, goalTargets, goalFixed) {
+    function sortGoalsByName(goals) {
         const safeGoals = Array.isArray(goals) ? goals : [];
+        return safeGoals.slice().sort((left, right) => {
+            const leftName = String(left?.goalName || '');
+            const rightName = String(right?.goalName || '');
+            const nameCompare = leftName.localeCompare(rightName, 'en', { sensitivity: 'base' });
+            if (nameCompare !== 0) {
+                return nameCompare;
+            }
+            const leftId = String(left?.goalId || '');
+            const rightId = String(right?.goalId || '');
+            return leftId.localeCompare(rightId, 'en', { sensitivity: 'base' });
+        });
+    }
+
+    function buildGoalTypeAllocationModel(goals, totalTypeAmount, adjustedTotal, goalTargets, goalFixed) {
+        const safeGoals = sortGoalsByName(goals);
         const safeTargets = goalTargets || {};
         const safeFixed = goalFixed || {};
         const goalModels = safeGoals.map(goal => {


### PR DESCRIPTION
### Motivation
- Ensure deterministic and user-friendly ordering of goals in the bucket detail view so rows render consistently across refreshes and tests.
- Avoid UI-level sorting duplication by performing ordering at the view-model/allocation layer consumed by renderers.

### Description
- Added `sortGoalsByName` helper and integrated it into `buildGoalTypeAllocationModel` to sort goals case-insensitively with `goalId` as a tiebreaker.
- Updated fixtures and unit tests to assert the alphabetical ordering and adapted inputs to cover unsorted sources.
- Bumped userscript/package version to `2.6.7` and documented the behavior change in `TECHNICAL_DESIGN.md` and `tampermonkey/README.md`.

### Testing
- Ran the test suite with `npm test` which executed Jest and all tests passed.
- Result: `2` test suites passed, `137` tests passed, `0` snapshots failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696631afdcd88326bc4e9304ecf55374)