### PR TITLE
docs(workflow): add PR template and enforce template hygiene & agent iteration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,10 +37,11 @@ applies_to:
 Use this compact workflow for all changes. Keep detailed role guidance in `.github/agents/*.md` and avoid duplicating it here.
 
 ### Required Artifacts
-- **Change Brief**: Problem, goal, and acceptance criteria.
+- **Change Brief**: Problem, goal, and acceptance criteria (include change type and required steps).
 - **Risks & Tradeoffs**: Short note, especially for data accuracy, privacy, or API interception changes.
 - **Test Plan**: Jest coverage and any manual checks needed.
 - **Verification**: Commands run and outcomes.
+- **Verification Matrix**: Map each acceptance criterion to a test or manual check.
 
 ### Change Type → Required Steps
 
@@ -71,6 +72,13 @@ Only move to the next stage when all required agents are aligned.
 - **Alignment artifact**: 1-3 bullets per stage capturing agreement.
 - **Blocking rule**: Any blocking concern stops progression until resolved.
 - **Loopback rule**: If QA or Code Review fails, return to Stage 3 (Staff Engineer implementation), then re-run QA and Code Review.
+- **Iteration rule**: When any agent surfaces a blocking issue, re-enter the prior stage and iterate within the same agent group until the blocking issue is resolved and re-validated.
+
+### Workflow Templates
+Use the repository PR template to capture the required artifacts and gate alignment bullets in one place.
+**Template hygiene**
+- Do not commit per-change copies of the PR template or filled templates into the repo.
+- Keep the template file unchanged and provide filled content only in the PR description.
 
 #### Stage Gates
 1. **Product Gate**: Product owns scope; Staff Engineer and QA confirm acceptance criteria are testable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+## Change Brief
+**Problem**
+
+**Goal**
+
+**Acceptance Criteria**
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+**Change Type (select one)**
+- [ ] Pure logic (Jest + lint)
+- [ ] UI/visual (Jest if logic touched + lint + screenshot + smoke check)
+- [ ] Behavior change (Jest + lint + docs update + version bump)
+- [ ] Performance (Jest + lint + perf check)
+- [ ] Documentation-only (no tests unless logic changed)
+
+## Stage Gate Alignment
+**Product**
+- 
+
+**Staff Engineer**
+- 
+
+**Devil's Advocate**
+- 
+
+**QA**
+- 
+
+**Code Review**
+- 
+
+## Risks & Tradeoffs
+- 
+
+## Verification Matrix
+| Acceptance Criterion | Test/Check | Evidence |
+| --- | --- | --- |
+| Criterion 1 |  |  |
+
+## Test Plan
+- 
+
+## Verification
+- Command(s) run and outcomes:
+
+## Security & Privacy Checklist
+- [ ] No external data egress
+- [ ] No `eval()` or dynamic code execution
+- [ ] User input sanitized / XSS mitigations preserved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ See [Comprehensive Development Guide](.github/copilot-instructions.md) for detai
 - [ ] Version bumped if behavior changes
 - [ ] All tests passing
 - [ ] Security requirements met
+- [ ] Workflow artifacts captured (change brief, risks/tradeoffs, test plan, verification, stage-gate alignment)
 
 ## Quick Reference
 


### PR DESCRIPTION
### Motivation
- Standardize how change artifacts are captured so reviewers and QA have a single source of truth for scope, verification, and risk. 
- Prevent developers/agents from committing per-change filled templates into the repository to avoid clutter and leaked draft content. 
- Ensure blocking issues discovered by any agent trigger iteration inside the originating agent group before progressing stages.

### Description
- Add a repository PR template at `.github/pull_request_template.md` to capture `Change Brief`, `Stage Gate` alignment, `Verification Matrix`, `Test Plan`, and security checklist. 
- Update `.github/copilot-instructions.md` to require a `Verification Matrix`, expand `Change Brief` guidance, add a `Template hygiene` section that forbids committing per-change filled templates, and add an `Iteration rule` to the Stage Alignment Gates requiring in-group iteration when blocking issues are surfaced. 
- Update `AGENTS.md` Definition of Done to require that workflow artifacts (change brief, risks/tradeoffs, test plan, verification, stage-gate alignment) are captured for each change.

### Testing
- No automated tests were run because these are documentation-only changes; no logic was modified and Jest tests were not required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697750c855c8832692219e2aeddf66c7)