### PR TITLE
docs(workflow): centralize workflow in `.github/copilot-instructions.md`, trim `AGENTS.md`, and add PR-template CI check

### DIFF
--- a/.github/agents/code-reviewer.md
+++ b/.github/agents/code-reviewer.md
@@ -4,6 +4,8 @@ description: Code Reviewer agent for thorough code reviews, security checks, and
 applies_to:
   - copilot-code-review
   - copilot-chat
+  - copilot-cli
+  - copilot-workspace
 ---
 
 # Code Reviewer Agent
@@ -17,6 +19,10 @@ You are a Code Reviewer for the Goal Portfolio Viewer. Your role is to ensure co
 2. **Security**: Identify vulnerabilities, especially for financial data
 3. **Architecture**: Ensure changes align with project architecture
 4. **Mentorship**: Provide constructive, educational feedback
+
+### Applicability
+- Use in Copilot Chat, CLI, Workspace, and Code Review contexts.
+- Engage whenever a review gate, release readiness, or security verification is needed.
 
 ## Review Checklist
 
@@ -62,6 +68,10 @@ You are a Code Reviewer for the Goal Portfolio Viewer. Your role is to ensure co
 - [ ] Breaking changes documented
 - [ ] README updated if needed
 - [ ] Version bumped appropriately
+
+### Release & Docs Stewardship (Merged Role)
+- Confirm versioning aligns with behavior changes.
+- Ensure user-facing docs reflect updates or new constraints.
 
 ## Review Labels
 

--- a/.github/agents/devils-advocate.md
+++ b/.github/agents/devils-advocate.md
@@ -3,6 +3,7 @@ name: devils-advocate
 description: Devil's Advocate agent for surfacing blind spots, assumptions, and hidden risks
 applies_to:
   - copilot-chat
+  - copilot-cli
   - copilot-workspace
   - copilot-code-review
 ---
@@ -16,6 +17,10 @@ You are the Devil's Advocate for the Goal Portfolio Viewer. Your role is to chal
 2. **Risk Surfacing**: Call out privacy, financial accuracy, UX, and regression risks.
 3. **Scope Challenges**: Ensure scope is crisp and acceptance criteria are unambiguous.
 4. **Mitigation**: Provide concrete mitigation options and minimal changes to reduce risk.
+
+## Applicability
+- Use in Copilot Chat, CLI, Workspace, and Code Review contexts.
+- Engage whenever risks, assumptions, or edge-case gaps need to be surfaced.
 
 ## Blocking vs. Non-Blocking
 

--- a/.github/agents/product-manager.md
+++ b/.github/agents/product-manager.md
@@ -3,6 +3,8 @@ name: product-manager
 description: Product Manager agent for feature prioritization, requirements definition, and user-focused decision making
 applies_to:
   - copilot-chat
+  - copilot-cli
+  - copilot-code-review
   - copilot-workspace
 ---
 
@@ -17,6 +19,10 @@ You are a Product Manager for the Goal Portfolio Viewer. Your role is to bridge 
 2. **Feature Prioritization**: Balance value vs. complexity
 3. **Requirements**: Define clear, testable acceptance criteria
 4. **Strategy**: Align features with privacy-first principles
+
+### Applicability
+- Use in Copilot Chat, CLI, Workspace, and Code Review contexts.
+- Engage whenever scope, acceptance criteria, or UX impact must be clarified.
 
 ### Decision Framework
 
@@ -101,6 +107,11 @@ You are a Product Manager for the Goal Portfolio Viewer. Your role is to bridge 
 - Intuitive UI (no documentation needed)
 - Clear visual hierarchy
 - Minimal configuration
+
+### 5. Accessibility & UX (Merged Role)
+- Ensure UI text is clear, scannable, and finance-friendly
+- Validate color usage for contrast and meaning (e.g., red/green)
+- Confirm keyboard and screen-reader paths are considered for modals
 
 ## Feature Evaluation
 

--- a/.github/agents/qa-engineer.md
+++ b/.github/agents/qa-engineer.md
@@ -3,7 +3,9 @@ name: qa-engineer
 description: QA Engineer agent for quality assurance, testing strategies, and bug identification
 applies_to:
   - copilot-chat
+  - copilot-cli
   - copilot-code-review
+  - copilot-workspace
 ---
 
 # QA Engineer Agent
@@ -18,6 +20,10 @@ You are a QA Engineer for the Goal Portfolio Viewer. Your role is to ensure qual
 3. **Bug Discovery**: Identify and report defects clearly
 4. **Quality Advocacy**: Champion user experience quality
 5. **Test Hooks & Guards**: Ensure test-only globals are documented and conditional exports are guarded in tests
+
+### Applicability
+- Use in Copilot Chat, CLI, Workspace, and Code Review contexts.
+- Engage whenever test planning, verification, or edge-case analysis is required.
 
 ## Testing Priorities
 
@@ -38,6 +44,11 @@ You are a QA Engineer for the Goal Portfolio Viewer. Your role is to ensure qual
 - **UI Polish**: Animations smooth, colors correct, responsive
 - **Accessibility**: Keyboard navigation, screen reader friendly
 - **Documentation**: README accurate, examples work
+
+### Accessibility & UX Verification (Merged Role)
+- Verify focus management for modals (open/close).
+- Spot-check color contrast and semantic meaning.
+- Confirm critical UI flows are navigable without a mouse.
 
 ## Test Plans
 

--- a/.github/agents/staff-engineer.md
+++ b/.github/agents/staff-engineer.md
@@ -3,6 +3,7 @@ name: staff-engineer
 description: Staff Engineer agent for technical architecture, code quality, and engineering excellence
 applies_to:
   - copilot-chat
+  - copilot-cli
   - copilot-code-review
   - copilot-workspace
 ---
@@ -18,6 +19,10 @@ You are a Staff Engineer for the Goal Portfolio Viewer. Your role is to provide 
 2. **Implementation**: Own coding changes (Staff Engineer is the implementer)
 3. **Code Quality**: Establish and maintain high standards
 4. **Security**: Ensure safe handling of financial data
+
+### Applicability
+- Use in Copilot Chat, CLI, Workspace, and Code Review contexts.
+- Engage whenever architecture, implementation, or security trade-offs are required.
 
 ## Technical Standards
 
@@ -128,6 +133,11 @@ function log(message, data) {
   }
 }
 ```
+
+### Security & Privacy Stewardship (Merged Role)
+- Threat-model changes involving data interception or storage.
+- Validate no data egress is introduced in any new flow.
+- Ensure XSS protections are preserved in any rendering changes.
 
 ## API Interception Best Practices
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,8 @@ applies_to:
 
 # Goal Portfolio Viewer - Development Guide
 
+> **Filename standard**: This guidance follows GitHub's recommended `copilot-instructions.md` filename.
+
 ## Project Overview
 
 **Type**: Browser Extension (Tampermonkey Userscript)  
@@ -28,7 +30,7 @@ applies_to:
 - **Privacy-First**: ALL processing happens client-side. Never send data externally.
 - **Financial Data**: Handles sensitive investment information requiring accuracy and security
 - **Single-File**: Entire application in one `.user.js` file for easy distribution
-- **No Dependencies**: Pure vanilla JS - no build process, no external libraries
+- **No Dependencies (Userscript Only)**: Pure vanilla JS for the userscript - no build process, no external libraries
 
 ---
 
@@ -53,12 +55,22 @@ Use this compact workflow for all changes. Keep detailed role guidance in `.gith
 | Performance | Jest + lint + perf check and reasoning about impact |
 | Documentation-only | Lint not required unless code changes; no tests required unless logic changed |
 
+### Trigger Rules for Merged Responsibilities
+- **Security/Privacy**: Required for API interception changes, storage changes, or data handling logic.
+- **UX/Accessibility**: Required for UI/visual changes and any new user interactions.
+- **Release/Docs**: Required for behavior changes, version bumps, and user-facing updates.
+
 ### Role Guides (Single Source of Detail)
 - **Product**: `.github/agents/product-manager.md` (requirements framing)
 - **Architecture/Risks**: `.github/agents/staff-engineer.md`
 - **QA/Test Depth**: `.github/agents/qa-engineer.md`
 - **Review Gates**: `.github/agents/code-reviewer.md`
 - **Devil's Advocate**: `.github/agents/devils-advocate.md` (blind spots)
+
+### Role Extensions (Merged Responsibilities)
+- **Security/Privacy** → Staff Engineer + Code Reviewer
+- **UX/Accessibility** → Product Manager + QA Engineer
+- **Release/Docs** → Staff Engineer + Code Reviewer
 
 ### Agent Interaction Model (Required)
 1. **Product**: Frame the problem, user impact, and acceptance criteria.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,22 +16,28 @@
 
 ## Stage Gate Alignment
 **Product**
+- Status: ☐ Approved / ☐ Blocked
 - 
 
 **Staff Engineer**
+- Status: ☐ Approved / ☐ Blocked
 - 
 
 **Devil's Advocate**
+- Status: ☐ Approved / ☐ Blocked
 - 
 
 **QA**
+- Status: ☐ Approved / ☐ Blocked
 - 
 
 **Code Review**
+- Status: ☐ Approved / ☐ Blocked
 - 
 
 ## Risks & Tradeoffs
 - 
+_If not applicable, state "N/A" with a brief rationale._
 
 ## Verification Matrix
 | Acceptance Criterion | Test/Check | Evidence |
@@ -40,9 +46,11 @@
 
 ## Test Plan
 - 
+_If not applicable, state "N/A" with a brief rationale._
 
 ## Verification
 - Command(s) run and outcomes:
+_If not applicable, state "N/A" with a brief rationale._
 
 ## Security & Privacy Checklist
 - [ ] No external data egress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,66 @@ permissions:
   pull-requests: write
   
 jobs:
+  pr-template:
+    name: PR Template Check
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+    - name: Validate PR body
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const body = context.payload.pull_request?.body || '';
+          const requiredHeadings = [
+            '## Change Brief',
+            '## Stage Gate Alignment',
+            '## Risks & Tradeoffs',
+            '## Verification Matrix',
+            '## Test Plan',
+            '## Verification',
+            '## Security & Privacy Checklist'
+          ];
+
+          const missing = requiredHeadings.filter((heading) => !body.includes(heading));
+          if (missing.length) {
+            core.setFailed(`Missing required PR sections: ${missing.join(', ')}`);
+            return;
+          }
+
+          const placeholderMarkers = ['Criterion 1', 'Criterion 2'];
+          const hasPlaceholder = placeholderMarkers.some((marker) => body.includes(marker));
+          if (hasPlaceholder) {
+            core.setFailed('Replace placeholder acceptance criteria in the PR template.');
+            return;
+          }
+
+          const hasMeaningfulContent = (heading) => {
+            const regex = new RegExp(`${heading}[\\s\\S]*?(?=\\n## |$)`, 'm');
+            const match = body.match(regex);
+            if (!match) {
+              return false;
+            }
+            const content = match[0].replace(heading, '').trim();
+            if (!content) {
+              return false;
+            }
+            return content.split('\n').some((line) => {
+              const trimmed = line.trim();
+              if (!trimmed) return false;
+              if (trimmed === '-') return false;
+              if (/^- \[ \]/.test(trimmed)) return false;
+              if (/^- \[x\]/i.test(trimmed)) return true;
+              if (/^Status:\s*.+/i.test(trimmed)) return true;
+              if (/(^|\\s)(N\\/A|Not applicable)(\\s|$)/i.test(trimmed)) return true;
+              return true;
+            });
+          };
+
+          const empty = requiredHeadings.filter((heading) => !hasMeaningfulContent(heading));
+          if (empty.length) {
+            core.setFailed(`PR template sections must be filled in: ${empty.join(', ')}`);
+          }
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-> **Note:** This file provides a quick reference. For comprehensive guidance, see [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (single source of truth).
+> **Note:** This file provides a quick reference. For comprehensive guidance, see [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (single source of truth, GitHub standard filename).
 
 ## Quick Start
 
@@ -16,46 +16,16 @@ This repository uses a multi-agent workflow for development. Each agent has spec
 | **Code Reviewer** | Final review, quality gates | [`.github/agents/code-reviewer.md`](.github/agents/code-reviewer.md) |
 | **Devil's Advocate** | Risk surfacing, blind spots | [`.github/agents/devils-advocate.md`](.github/agents/devils-advocate.md) |
 
+### Merged Responsibilities (No New Roles)
+- **Security/Privacy** → Staff Engineer + Code Reviewer
+- **UX/Accessibility** → Product Manager + QA Engineer
+- **Release/Docs** → Staff Engineer + Code Reviewer
+
+### Trigger Rules
+For trigger rules and detailed enforcement, see [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
 ### Workflow Overview
-
-1. **Product Manager** frames the problem and acceptance criteria
-2. **Staff Engineer** designs solution and implements changes
-3. **Devil's Advocate** challenges assumptions and surfaces risks
-4. **QA Engineer** defines test plan and verifies quality
-5. **Code Reviewer** applies final quality gates before merge
-
-See [Comprehensive Development Guide](.github/copilot-instructions.md) for detailed workflow and orchestration.
-
-## Key Principles
-
-- **Single Source of Truth**: [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
-- **Privacy First**: No data egress, all processing client-side
-- **Testing Required**: Jest tests mandatory for all logic changes
-- **Financial Accuracy**: Critical - verify calculations
-- **Security**: No `eval`, sanitize all strings
-
-## Definition of Done
-
-- [ ] Behavior matches requirements and acceptance criteria
-- [ ] Jest tests added/updated for logic changes
-- [ ] Documentation updated if behavior changes
-- [ ] Version bumped if behavior changes
-- [ ] All tests passing
-- [ ] Security requirements met
-- [ ] Workflow artifacts captured (change brief, risks/tradeoffs, test plan, verification, stage-gate alignment)
-
-## Quick Reference
-
-```bash
-# Run tests
-npm test
-
-# Run linter
-npm run lint
-
-# Run tests with coverage
-npm run test:coverage
-```
+For workflow phases, key principles, definition of done, and testing commands, see the [Comprehensive Development Guide](.github/copilot-instructions.md).
 
 ## Further Reading
 


### PR DESCRIPTION
### Motivation
- Remove duplicated workflow, principles, and test-command details from `AGENTS.md` and make `.github/copilot-instructions.md` the single source of truth for workflow guidance. 
- Clarify scope-sensitive guidance such as the "No Dependencies" rule by making it explicit in `copilot-instructions.md` (Userscript-only). 
- Improve process hygiene by adding applicability details to agent guides and enforcing PR body requirements via CI to reduce drift and incomplete PRs.

### Description
- Trimmed `AGENTS.md` to be a short quick-reference and replaced the detailed workflow, key principles, DoD, and quick commands with links to `/.github/copilot-instructions.md` so details live in one place. 
- Expanded and clarified `/.github/copilot-instructions.md` by adding a filename note, changing `No Dependencies` to `No Dependencies (Userscript Only)`, adding trigger rules/role-extension notes, and making the workflow contract explicit. 
- Updated multiple agent definitions under `.github/agents/` (`product-manager.md`, `staff-engineer.md`, `qa-engineer.md`, `devils-advocate.md`, `code-reviewer.md`) to add `applies_to` contexts and brief `Applicability` / merged-responsibility sections so role guidance remains focused and non-duplicative. 
- Updated `/.github/pull_request_template.md` to add explicit `Status` lines and N/A guidance, and added a PR validation job in `/.github/workflows/ci.yml` that checks PR bodies for required headings, non-placeholder content, and basic meaningfulness.

### Testing
- No unit or Jest tests were required or run because these are documentation and CI workflow updates. 
- A new CI job `PR Template Check` was added to `/.github/workflows/ci.yml` to automatically validate PR bodies; this job is intended to fail CI when required sections or meaningful content are missing (the job was added but not executed locally in this change). 
- Lint and existing test jobs were not changed and remain configured to run under the existing CI matrix (`lint` and `test` jobs still present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb91f4a088326b7c4b84f680b9ec5)