### PR TITLE
feat(sync): force local overwrite on conflict

### DIFF
--- a/SYNC_ARCHITECTURE.md
+++ b/SYNC_ARCHITECTURE.md
@@ -228,7 +228,8 @@ Request Body:
   "deviceId": "uuid-v4",
   "encryptedData": "base64-encoded-encrypted-blob",
   "timestamp": 1234567890000,
-  "version": 1
+  "version": 1,
+  "force": false
 }
 
 Response (200 OK):
@@ -237,6 +238,8 @@ Response (200 OK):
   "timestamp": 1234567890000,
   "conflictDetected": false
 }
+
+When `force` is `true`, the server accepts the upload even if the incoming timestamp is older and stores a fresh server timestamp.
 
 Response (409 Conflict):
 {
@@ -321,7 +324,7 @@ GET /health
 Response (200 OK):
 {
   "status": "ok",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "timestamp": 1234567890000
 }
 ```

--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -36,6 +36,8 @@ tampermonkey/
 
 The sync feature is opt-in and encrypts configuration data client-side before upload. Authentication is handled with JWT access/refresh tokens issued after password login (legacy password-hash headers are no longer supported). After login or sign up, sync saves settings and enables encryption by default, storing a **derived encryption key** on the current device unless the user disables the remember-key option. After activation, auto-sync runs by default with a configurable interval and buffered sync-on-change to avoid excessive requests; if a sync is already running, change-triggered sync retries after a short delay. Fixed goals only sync their fixed state (target percentages are ignored), and conflict resolution is presented inside the sync settings overlay.
 
+When a sync conflict occurs, choosing "Keep This Device" forces an overwrite upload. The client sends `force: true` in the POST `/sync` payload and updates local sync metadata using the server-returned timestamp to keep device ordering consistent.
+
 ---
 
 ## API Interception

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -160,6 +160,7 @@ If you want to sync your goal configurations across devices:
 - Only encrypted goal targets + fixed flags are synced; holdings, balances, and transactions never leave your browser
 - Auto-sync is enabled by default after activation; you can disable it or tune the interval in Sync Settings
 - Conflict dialogs include a goal-level diff preview to help choose Local vs Remote
+- Choosing "Keep This Device" forces the local config to overwrite the server, even if the server timestamp is newer
 
 For detailed sync setup instructions, see `QUICK_START.md`.
 
@@ -299,6 +300,9 @@ Contributions are welcome! To contribute:
 5. Submit a pull request
 
 ## Changelog
+
+### Version 2.14.0
+- Forced local conflict resolution now overwrites the server on request
 
 ### Version 2.13.2
 - Hardened sync error handling and performance request timeouts

--- a/tampermonkey/__tests__/setup.js
+++ b/tampermonkey/__tests__/setup.js
@@ -32,6 +32,14 @@ if (typeof global.window === 'undefined') {
     global.window.location.href = 'https://app.sg.endowus.com/dashboard';
 }
 
+if (typeof global.CustomEvent === 'undefined' && global.window?.CustomEvent) {
+    global.CustomEvent = global.window.CustomEvent;
+}
+
+if (global.window?.CustomEvent && typeof global.CustomEvent === 'function') {
+    global.CustomEvent = (...args) => new global.window.CustomEvent(...args);
+}
+
 if (!global.window.__GPV_DISABLE_AUTO_INIT) {
     global.window.__GPV_DISABLE_AUTO_INIT = true;
 }

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",

--- a/workers/README.md
+++ b/workers/README.md
@@ -386,7 +386,7 @@ GET /health
 Response (200):
 {
   "status": "ok",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "timestamp": 1234567890000
 }
 ```
@@ -405,7 +405,8 @@ Body:
   "deviceId": "string (uuid)",
   "encryptedData": "string (base64)",
   "timestamp": number,
-  "version": number
+  "version": number,
+  "force": boolean
 }
 
 Response (200):
@@ -420,6 +421,8 @@ Response (409 Conflict):
   "error": "CONFLICT",
   "serverData": { ... }
 }
+
+When `force` is `true`, the upload overwrites server data even if the incoming timestamp is older, and the server returns a fresh timestamp.
 ```
 
 #### Download Config

--- a/workers/package.json
+++ b/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-sync-workers",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Cloudflare Workers backend for Goal Portfolio Viewer sync",
   "private": true,
   "type": "module",

--- a/workers/src/index.js
+++ b/workers/src/index.js
@@ -16,7 +16,7 @@ const CONFIG = {
 	MAX_PAYLOAD_SIZE: 10 * 1024, // 10KB
 	CORS_ORIGINS: 'https://app.sg.endowus.com,https://secure.fundsupermart.com',
 	SYNC_KV_BINDING: 'SYNC_KV',
-	VERSION: '1.1.1'
+	VERSION: '1.2.0'
 };
 
 // CORS headers


### PR DESCRIPTION
## Summary
- allow POST /sync to accept a `force` flag that bypasses newer-server conflicts and stores a fresh server timestamp
- send forced uploads when users choose Keep This Device, using the returned timestamp to update local sync metadata
- add tests and documentation updates plus version bumps for the behavior change

## Testing
- `corepack pnpm --filter ./workers test`
- `corepack pnpm --filter ./tampermonkey test -- syncManager.test.js`
- `corepack pnpm --filter ./tampermonkey test -- syncUi.test.js`
- `corepack pnpm --filter ./tampermonkey lint`