### PR TITLE
fix(ci): align demo E2E summary artifact paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,13 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter ./demo exec playwright install --with-deps
 
-      - name: Run E2E demo tests
+      - name: Run E2E demo regression tests
         id: e2e
         env:
           E2E_SCREENSHOT_DIR: screenshots
           E2E_SUMMARY_PATH: screenshots/e2e-summary.json
-        run: pnpm --filter ./demo test:e2e
+          E2E_MODE: regression
+        run: pnpm --filter ./demo test:e2e:regression
 
       - name: Upload E2E screenshots
         if: always()
@@ -237,6 +238,17 @@ jobs:
         with:
           name: e2e-screenshots
           path: demo/screenshots
+          if-no-files-found: warn
+
+      - name: Upload E2E regression artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-regression
+          path: |
+            demo/regression/actual
+            demo/regression/diff
+            demo/screenshots/e2e-summary.json
           if-no-files-found: warn
 
       - name: Post E2E summary comment
@@ -254,6 +266,20 @@ jobs:
             }
             const flows = summary?.flowsTested ?? [];
             const screenshots = summary?.screenshots ?? [];
+            const diffs = summary?.diffs ?? [];
+            const assertions = summary?.assertions ?? {};
+            const failedDiffs = diffs.filter(diff => diff.status === 'failed');
+            const missingBaselines = diffs.filter(diff => diff.status === 'baseline-missing');
+            const assertionTotals = Object.values(assertions).reduce((acc, items) => {
+              const safeItems = Array.isArray(items) ? items : [];
+              safeItems.forEach(item => {
+                acc.total += 1;
+                if (item && item.passed === false) {
+                  acc.failed += 1;
+                }
+              });
+              return acc;
+            }, { total: 0, failed: 0 });
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               ...context.repo,
               run_id: context.runId
@@ -270,6 +296,14 @@ jobs:
               `- Status: **${status}**`,
               `- Flows tested: **${flows.length}**${flows.length ? ` (${flows.join(', ')})` : ''}`,
               `- Screenshots: ${screenshots.length ? screenshots.map(name => `\`${name}\``).join(', ') : 'None'}`,
+              `- Assertions: **${assertionTotals.total}** total, **${assertionTotals.failed}** failed`,
+              `- Visual diffs: **${diffs.length}** checked, **${failedDiffs.length}** failed${missingBaselines.length ? `, **${missingBaselines.length}** missing baseline` : ''}`,
+              failedDiffs.length
+                ? `- Failed diffs: ${failedDiffs.map(diff => `\`${diff.screenshot}\` (${(diff.mismatchRatio * 100).toFixed(2)}%)`).join(', ')}`
+                : null,
+              missingBaselines.length
+                ? `- Missing baselines: ${missingBaselines.map(diff => `\`${diff.screenshot}\``).join(', ')}`
+                : null,
               '',
               artifactUrl
                 ? `- Screenshots artifact: ${artifactUrl}`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
       - name: Run E2E demo tests
         id: e2e
         env:
-          E2E_SCREENSHOT_DIR: demo/screenshots
-          E2E_SUMMARY_PATH: demo/screenshots/e2e-summary.json
+          E2E_SCREENSHOT_DIR: screenshots
+          E2E_SUMMARY_PATH: screenshots/e2e-summary.json
         run: pnpm --filter ./demo test:e2e
 
       - name: Upload E2E screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ spec/
 demo/goal_portfolio_viewer.user.js
 demo/goal_portfolio_viewer_demo.user.js
 demo/screenshots/
+demo/regression/actual/
+demo/regression/diff/
 
 # Node.js
 node_modules/

--- a/demo/README.md
+++ b/demo/README.md
@@ -47,6 +47,8 @@ This directory contains tools and files for demonstrating the Goal Portfolio Vie
 
 - **`index.html`** - Full-featured demo page with info panel
 - **`demo.html`** - Alternative demo page (kept for reference)
+- **`fsm/index.html`** - FSM E2E demo page (served at `/fsmone/holdings/investments`)
+  - Loads FSM mock holdings and seeds portfolio/assignment targets for FSM flows
 
 ### Generated Files (gitignored)
 - **`goal_portfolio_viewer_demo.user.js`** - Modified userscript with demo mode patch
@@ -81,7 +83,7 @@ This creates `mock-data.json` with randomized investment amounts and returns.
 The E2E smoke test uses Playwright to validate the demo flow and capture screenshots.
 
 ```bash
-pnpm run test:e2e
+pnpm --filter ./demo test:e2e:smoke
 ```
 
 Screenshots are saved to `demo/screenshots/` by default (override with `E2E_SCREENSHOT_DIR`):
@@ -91,12 +93,36 @@ Screenshots are saved to `demo/screenshots/` by default (override with `E2E_SCRE
 - `e2e-sync-unconfigured.png`
 - `e2e-sync-configured.png`
 - `e2e-sync-conflict.png`
+- `e2e-fsm-overlay.png`
+- `e2e-fsm-manager.png`
+- `e2e-fsm-conflict.png`
 
 If Playwright is missing system dependencies on Linux, run:
 
 ```bash
 npx playwright install --with-deps
 ```
+
+### Run E2E Regression Tests
+
+Regression mode captures screenshots, compares them with baselines, and adds data assertions.
+
+```bash
+pnpm --filter ./demo test:e2e:regression
+```
+
+Regression artifacts live under:
+- `demo/regression/baseline/`
+- `demo/regression/actual/`
+- `demo/regression/diff/`
+
+To update baselines:
+
+```bash
+pnpm --filter ./demo test:e2e:update-baseline
+```
+
+Baseline files are gitignored by default. Only update baselines intentionally.
 
 ### Take Screenshots
 

--- a/demo/e2e-tests.js
+++ b/demo/e2e-tests.js
@@ -1,17 +1,102 @@
 /**
- * E2E smoke tests for the demo dashboard.
+ * E2E smoke and regression tests for the demo dashboard.
  *
- * Usage: node demo/e2e-tests.js
+ * Usage:
+ *   node demo/e2e-tests.js
+ *
+ * Modes:
+ *   E2E_MODE=smoke (default)
+ *   E2E_MODE=regression
+ *   E2E_MODE=update-baseline
  */
 
 const fs = require('fs');
 const path = require('path');
+const pixelmatch = require('pixelmatch');
+const { PNG } = require('pngjs');
 const { startDemoServer } = require('./mock-server');
+
+const DEFAULT_PORT = 8765;
+const E2E_MODE = process.env.E2E_MODE || 'smoke';
+const MODE = ['smoke', 'regression', 'update-baseline'].includes(E2E_MODE)
+    ? E2E_MODE
+    : 'smoke';
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
+const DEFAULT_DIFF_THRESHOLD = Number.parseFloat(process.env.E2E_DIFF_THRESHOLD || '0.001');
+const REGRESSION_DIR = path.join(__dirname, 'regression');
+const REGRESSION_BASELINE_DIR = path.join(REGRESSION_DIR, 'baseline');
+const REGRESSION_ACTUAL_DIR = path.join(REGRESSION_DIR, 'actual');
+const REGRESSION_DIFF_DIR = path.join(REGRESSION_DIR, 'diff');
 
 function assertCondition(condition, message) {
     if (!condition) {
         throw new Error(message);
     }
+}
+
+function ensureDir(dir) {
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+}
+
+function readPng(filePath) {
+    const data = fs.readFileSync(filePath);
+    return PNG.sync.read(data);
+}
+
+function writePng(filePath, png) {
+    const buffer = PNG.sync.write(png);
+    fs.writeFileSync(filePath, buffer);
+}
+
+function comparePngs({ baselinePath, actualPath, diffPath }) {
+    const baseline = readPng(baselinePath);
+    const actual = readPng(actualPath);
+    const width = Math.max(baseline.width, actual.width);
+    const height = Math.max(baseline.height, actual.height);
+
+    const baselineCanvas = new PNG({ width, height });
+    const actualCanvas = new PNG({ width, height });
+    PNG.bitblt(baseline, baselineCanvas, 0, 0, baseline.width, baseline.height, 0, 0);
+    PNG.bitblt(actual, actualCanvas, 0, 0, actual.width, actual.height, 0, 0);
+
+    const diff = new PNG({ width, height });
+    const mismatch = pixelmatch(
+        baselineCanvas.data,
+        actualCanvas.data,
+        diff.data,
+        width,
+        height,
+        { threshold: 0.1 }
+    );
+    writePng(diffPath, diff);
+    return {
+        mismatchPixels: mismatch,
+        mismatchRatio: width * height === 0 ? 0 : mismatch / (width * height)
+    };
+}
+
+function normalizeName(name) {
+    return name.replace(/\s+/g, '-').replace(/[^a-z0-9-]/gi, '').toLowerCase();
+}
+
+function buildPaths(flowName) {
+    const normalizedFlow = normalizeName(flowName);
+    const relative = `${normalizedFlow}.png`;
+    return {
+        relative,
+        baseline: path.join(REGRESSION_BASELINE_DIR, relative),
+        actual: path.join(REGRESSION_ACTUAL_DIR, relative),
+        diff: path.join(REGRESSION_DIFF_DIR, relative)
+    };
+}
+
+function buildSummaryPaths(outputDir) {
+    const summaryPath = process.env.E2E_SUMMARY_PATH
+        ? path.resolve(process.env.E2E_SUMMARY_PATH)
+        : path.join(outputDir, 'e2e-summary.json');
+    return { summaryPath };
 }
 
 async function runE2ETests() {
@@ -23,34 +108,50 @@ async function runE2ETests() {
         throw error;
     }
 
-    const port = 8765;
-    const demoUrl = `http://localhost:${port}/dashboard/`;
+    const demoUrl = `http://localhost:${DEFAULT_PORT}/dashboard/`;
     const outputDir = process.env.E2E_SCREENSHOT_DIR
         ? path.resolve(process.env.E2E_SCREENSHOT_DIR)
         : path.join(__dirname, 'screenshots');
-    const summaryPath = process.env.E2E_SUMMARY_PATH
-        ? path.resolve(process.env.E2E_SUMMARY_PATH)
-        : path.join(outputDir, 'e2e-summary.json');
+    const { summaryPath } = buildSummaryPaths(outputDir);
+
     const summary = {
+        mode: MODE,
         status: 'passed',
         flowsTested: [],
-        screenshots: []
+        screenshots: [],
+        assertions: {},
+        diffs: []
     };
+
     let server;
     let browser;
 
-    if (!fs.existsSync(outputDir)) {
-        fs.mkdirSync(outputDir, { recursive: true });
+    ensureDir(outputDir);
+    if (MODE !== 'smoke') {
+        ensureDir(REGRESSION_DIR);
+        ensureDir(REGRESSION_BASELINE_DIR);
+        ensureDir(REGRESSION_ACTUAL_DIR);
+        ensureDir(REGRESSION_DIFF_DIR);
     }
 
     try {
-        server = await startDemoServer({ port });
+        server = await startDemoServer({ port: DEFAULT_PORT });
         browser = await playwright.chromium.launch({ headless: true });
         const context = await browser.newContext({
-            viewport: { width: 1280, height: 800 }
+            viewport: DEFAULT_VIEWPORT,
+            locale: 'en-SG',
+            timezoneId: 'Asia/Singapore'
         });
-        const page = await context.newPage();
+        await context.addInitScript({
+            content: `(() => {
+                const style = document.createElement('style');
+                style.setAttribute('data-e2e-disable-animations', 'true');
+                style.textContent = '*{animation-duration:0s!important;animation-delay:0s!important;transition-duration:0s!important;transition-delay:0s!important;scroll-behavior:auto!important;}';
+                document.documentElement.appendChild(style);
+            })();`
+        });
 
+        const page = await context.newPage();
         await page.goto(demoUrl, { waitUntil: 'networkidle' });
         await page.waitForFunction(() => window.__GPV_E2E_READY__ === true, null, { timeout: 20000 });
 
@@ -63,28 +164,19 @@ async function runE2ETests() {
         const summaryHeader = await page.$('.gpv-header');
         assertCondition(summaryHeader, 'Expected summary header to render.');
 
-        await page.screenshot({
-            path: path.join(outputDir, 'e2e-summary.png'),
-            fullPage: false
-        });
-        summary.flowsTested.push('summary');
-        summary.screenshots.push('e2e-summary.png');
+        await captureScreenshot(page, summary, outputDir, 'summary');
+        recordAssertion(summary, 'summary', 'summary-header', true, 'Summary header rendered.');
 
         const options = await page.$$eval('select.gpv-select option', opts =>
             opts.map(opt => opt.textContent)
         );
-        assertCondition(options.some(text => text.includes('House Purchase')), 'Expected House Purchase option.');
-        assertCondition(options.some(text => text.includes('Retirement')), 'Expected Retirement option.');
+        const hasHouse = options.some(text => text.includes('House Purchase'));
+        const hasRetirement = options.some(text => text.includes('Retirement'));
+        assertCondition(hasHouse, 'Expected House Purchase option.');
+        assertCondition(hasRetirement, 'Expected Retirement option.');
+        recordAssertion(summary, 'summary', 'bucket-options', hasHouse && hasRetirement, 'Found bucket options.');
 
-        await page.selectOption('select.gpv-select', 'House Purchase');
-        await page.waitForFunction(
-            () => {
-                const title = document.querySelector('.gpv-detail-title');
-                return title && title.textContent && title.textContent.includes('House Purchase');
-            },
-            null,
-            { timeout: 5000 }
-        );
+        await openBucket(page, 'House Purchase');
         await page.waitForSelector('.gpv-content .gpv-fixed-toggle-input', { state: 'attached', timeout: 5000 });
         const fixedRow = await page.$('.gpv-content .gpv-fixed-toggle-input');
         assertCondition(fixedRow, 'Expected fixed toggle input to render in House Purchase view.');
@@ -103,32 +195,16 @@ async function runE2ETests() {
             null,
             { timeout: 5000 }
         );
-        await page.screenshot({
-            path: path.join(outputDir, 'e2e-house-purchase.png'),
-            fullPage: false
-        });
-        summary.flowsTested.push('house-purchase');
-        summary.screenshots.push('e2e-house-purchase.png');
+    recordAssertion(summary, 'house-purchase', 'fixed-toggle', true, 'Fixed toggle enabled.');
+        await captureScreenshot(page, summary, outputDir, 'house-purchase');
 
-        await page.selectOption('select.gpv-select', 'Retirement');
-        await page.waitForFunction(
-            () => {
-                const title = document.querySelector('.gpv-detail-title');
-                return title && title.textContent && title.textContent.includes('Retirement');
-            },
-            null,
-            { timeout: 5000 }
-        );
-        await page.screenshot({
-            path: path.join(outputDir, 'e2e-retirement.png'),
-            fullPage: false
-        });
-        summary.flowsTested.push('retirement');
-        summary.screenshots.push('e2e-retirement.png');
+        await openBucket(page, 'Retirement');
+    recordAssertion(summary, 'retirement', 'detail-title', true, 'Retirement detail loaded.');
+        await captureScreenshot(page, summary, outputDir, 'retirement');
 
-        const syncScreens = await captureSyncScreens(page, outputDir);
-        summary.flowsTested.push(...syncScreens.flows);
-        summary.screenshots.push(...syncScreens.screenshots);
+        await captureSyncScreens(page, outputDir, summary);
+
+        await captureFsmFlow(page, summary, outputDir);
     } catch (error) {
         summary.status = 'failed';
         summary.error = error instanceof Error ? error.message : String(error);
@@ -159,8 +235,80 @@ module.exports = {
     runE2ETests
 };
 
-async function captureSyncScreens(page, outputDir) {
-    const results = { flows: [], screenshots: [] };
+async function openBucket(page, bucketName) {
+    await page.selectOption('select.gpv-select', bucketName);
+    await page.waitForFunction(
+        name => {
+            const title = document.querySelector('.gpv-detail-title');
+            return title && title.textContent && title.textContent.includes(name);
+        },
+        bucketName,
+        { timeout: 5000 }
+    );
+}
+
+async function captureScreenshot(page, summary, outputDir, flowName) {
+    const normalizedFlowName = normalizeName(flowName);
+    const screenshotName = `e2e-${normalizedFlowName}.png`;
+    const screenshotPath = path.join(outputDir, screenshotName);
+    await page.screenshot({ path: screenshotPath, fullPage: false });
+
+    if (!summary.flowsTested.includes(flowName)) {
+        summary.flowsTested.push(flowName);
+    }
+    summary.screenshots.push(screenshotName);
+
+    if (MODE === 'smoke') {
+        return;
+    }
+
+    const paths = buildPaths(flowName);
+    fs.copyFileSync(screenshotPath, paths.actual);
+
+    if (MODE === 'update-baseline') {
+        ensureDir(REGRESSION_BASELINE_DIR);
+        fs.copyFileSync(paths.actual, paths.baseline);
+        summary.diffs.push({ flow: flowName, screenshot: paths.relative, status: 'baseline-updated' });
+        return;
+    }
+
+    if (!fs.existsSync(paths.baseline)) {
+        summary.diffs.push({ flow: flowName, screenshot: paths.relative, status: 'baseline-missing' });
+        summary.status = 'failed';
+        return;
+    }
+
+    const diffResult = comparePngs({
+        baselinePath: paths.baseline,
+        actualPath: paths.actual,
+        diffPath: paths.diff
+    });
+
+    const pass = diffResult.mismatchRatio <= DEFAULT_DIFF_THRESHOLD;
+    summary.diffs.push({
+        flow: flowName,
+        screenshot: paths.relative,
+        status: pass ? 'passed' : 'failed',
+        mismatchPixels: diffResult.mismatchPixels,
+        mismatchRatio: diffResult.mismatchRatio,
+        threshold: DEFAULT_DIFF_THRESHOLD
+    });
+    if (!pass) {
+        summary.status = 'failed';
+    }
+}
+
+function recordAssertion(summary, flowName, assertionName, passed, message) {
+    if (!summary.assertions[flowName]) {
+        summary.assertions[flowName] = [];
+    }
+    summary.assertions[flowName].push({ name: assertionName, passed, message });
+    if (!passed) {
+        summary.status = 'failed';
+    }
+}
+
+async function captureSyncScreens(page, outputDir, summary) {
     const syncButtonSelector = '.gpv-header-buttons .gpv-sync-btn';
 
     await page.click(syncButtonSelector);
@@ -175,10 +323,8 @@ async function captureSyncScreens(page, outputDir) {
         return required.every(token => root.querySelector(`.${token}`));
     }, null, { timeout: 5000 });
 
-    const unconfiguredPath = path.join(outputDir, 'e2e-sync-unconfigured.png');
-    await page.screenshot({ path: unconfiguredPath, fullPage: false });
-    results.flows.push('sync-unconfigured');
-    results.screenshots.push('e2e-sync-unconfigured.png');
+    recordAssertion(summary, 'sync-unconfigured', 'sync-settings', true, 'Sync settings rendered.');
+    await captureScreenshot(page, summary, outputDir, 'sync-unconfigured');
 
     await page.evaluate(() => {
         const status = document.querySelector('.gpv-sync-status-bar');
@@ -197,10 +343,8 @@ async function captureSyncScreens(page, outputDir) {
         }
     });
 
-    const configuredPath = path.join(outputDir, 'e2e-sync-configured.png');
-    await page.screenshot({ path: configuredPath, fullPage: false });
-    results.flows.push('sync-configured');
-    results.screenshots.push('e2e-sync-configured.png');
+    recordAssertion(summary, 'sync-configured', 'sync-actions', true, 'Sync actions rendered.');
+    await captureScreenshot(page, summary, outputDir, 'sync-configured');
 
     await page.evaluate(() => {
         const overlay = document.getElementById('gpv-overlay');
@@ -210,12 +354,30 @@ async function captureSyncScreens(page, outputDir) {
     });
 
     const conflict = {
-        local: { goalTargets: { goal_1: 10 }, goalFixed: {} },
-        remote: { goalTargets: { goal_1: 20 }, goalFixed: {} },
+        local: {
+            goalTargets: { goal_1: 10 },
+            goalFixed: {},
+            platforms: {
+                fsm: {
+                    portfolios: [{ id: 'demo-fsm-1', name: 'Core Portfolio' }],
+                    assignmentByCode: { ESG001: 'demo-fsm-1' }
+                }
+            }
+        },
+        remote: {
+            goalTargets: { goal_1: 20 },
+            goalFixed: {},
+            platforms: {
+                fsm: {
+                    portfolios: [{ id: 'demo-fsm-2', name: 'Growth Portfolio' }],
+                    assignmentByCode: { ESG001: 'demo-fsm-2' }
+                }
+            }
+        },
         localHash: 'local-hash',
         remoteHash: 'remote-hash',
-        localTimestamp: Date.now() - 5000,
-        remoteTimestamp: Date.now()
+        localTimestamp: 1700000000000,
+        remoteTimestamp: 1700000005000
     };
 
     await page.evaluate(conflictPayload => {
@@ -245,10 +407,103 @@ async function captureSyncScreens(page, outputDir) {
         return required.every(token => dialog.querySelector(`.${token}`));
     }, null, { timeout: 5000 });
 
-    const conflictPath = path.join(outputDir, 'e2e-sync-conflict.png');
-    await page.screenshot({ path: conflictPath, fullPage: false });
-    results.flows.push('sync-conflict');
-    results.screenshots.push('e2e-sync-conflict.png');
+    recordAssertion(summary, 'sync-conflict', 'conflict-dialog', true, 'Conflict dialog rendered.');
+    await captureScreenshot(page, summary, outputDir, 'sync-conflict');
+}
 
-    return results;
+async function captureFsmFlow(page, summary, outputDir) {
+    const fsmUrl = `http://localhost:${DEFAULT_PORT}/fsmone/holdings/investments`;
+    await page.goto(fsmUrl, { waitUntil: 'networkidle' });
+    await page.waitForFunction(() => window.__GPV_E2E_READY__ === true, null, { timeout: 20000 });
+    await page.click('.gpv-trigger-btn');
+    await page.waitForSelector('.gpv-overlay', { timeout: 5000 });
+
+    await page.waitForSelector('.gpv-fsm-toolbar', { timeout: 5000 });
+    recordAssertion(summary, 'fsm-overlay', 'toolbar', true, 'FSM toolbar rendered.');
+    await captureScreenshot(page, summary, outputDir, 'fsm-overlay');
+
+    const managerToggle = await page.$('.gpv-fsm-toolbar button');
+    if (managerToggle) {
+        await managerToggle.click();
+        await page.waitForSelector('.gpv-fsm-manager', { timeout: 5000 });
+        recordAssertion(summary, 'fsm-manager', 'manager-panel', true, 'FSM manager panel rendered.');
+        await captureScreenshot(page, summary, outputDir, 'fsm-manager');
+        await managerToggle.click();
+    }
+
+    const summaryCards = await page.$$eval('.gpv-summary-row .gpv-summary-card', nodes => nodes.length);
+    recordAssertion(summary, 'fsm-overlay', 'summary-cards', summaryCards >= 4, 'FSM summary cards present.');
+    if (summaryCards < 4) {
+        summary.status = 'failed';
+    }
+
+    const tableHeaders = await page.$$eval('.gpv-table thead th', nodes => nodes.map(node => node.textContent || '').map(text => text.trim()));
+    const hasTableHeaders = tableHeaders.includes('Ticker') && tableHeaders.includes('Portfolio');
+    recordAssertion(summary, 'fsm-overlay', 'table-headers', hasTableHeaders, 'FSM table headers present.');
+    if (!hasTableHeaders) {
+        summary.status = 'failed';
+    }
+
+    const conflict = {
+        local: {
+            goalTargets: { goal_1: 10 },
+            goalFixed: {},
+            platforms: {
+                fsm: {
+                    portfolios: [{ id: 'demo-fsm-1', name: 'Core Portfolio' }],
+                    assignmentByCode: { ESG001: 'demo-fsm-1' }
+                }
+            }
+        },
+        remote: {
+            goalTargets: { goal_1: 20 },
+            goalFixed: {},
+            platforms: {
+                fsm: {
+                    portfolios: [{ id: 'demo-fsm-2', name: 'Growth Portfolio' }],
+                    assignmentByCode: { ESG001: 'demo-fsm-2' }
+                }
+            }
+        },
+        localHash: 'local-hash',
+        remoteHash: 'remote-hash',
+        localTimestamp: 1700000000000,
+        remoteTimestamp: 1700000005000
+    };
+
+    await page.evaluate(conflictPayload => {
+        const conflictHtml = window.__gpvSyncUi?.createConflictDialogHTML
+            ? window.__gpvSyncUi.createConflictDialogHTML(conflictPayload)
+            : null;
+        if (!conflictHtml) {
+            throw new Error('Conflict dialog renderer not available for FSM E2E.');
+        }
+        const overlay = document.getElementById('gpv-overlay');
+        if (overlay) {
+            overlay.remove();
+        }
+        const newOverlay = document.createElement('div');
+        newOverlay.id = 'gpv-overlay';
+        newOverlay.className = 'gpv-overlay gpv-conflict-overlay';
+        const container = document.createElement('div');
+        container.className = 'gpv-container gpv-conflict-modal';
+        container.innerHTML = conflictHtml;
+        newOverlay.appendChild(container);
+        document.body.appendChild(newOverlay);
+    }, conflict);
+
+    await page.waitForSelector('.gpv-conflict-dialog', { timeout: 5000 });
+    const fsmDiffCount = await page.$eval('.gpv-conflict-details', list => {
+        const item = Array.from(list.querySelectorAll('li')).find(li => li.textContent && li.textContent.includes('FSM differences'));
+        if (!item) {
+            return 0;
+        }
+        const match = item.textContent.match(/FSM differences:\s*(\d+)/);
+        return match ? Number(match[1]) : 0;
+    });
+    recordAssertion(summary, 'fsm-conflict', 'fsm-diff-count', fsmDiffCount > 0, 'FSM conflict diff rows present.');
+    if (fsmDiffCount <= 0) {
+        summary.status = 'failed';
+    }
+    await captureScreenshot(page, summary, outputDir, 'fsm-conflict');
 }

--- a/demo/fsm/index.html
+++ b/demo/fsm/index.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Goal Portfolio Viewer - E2E Dashboard</title>
+    <title>Goal Portfolio Viewer - FSM Demo</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             margin: 0;
             padding: 0;
-            background: #f3f4f6;
+            background: #f8fafc;
         }
 
         .demo-shell {
@@ -23,28 +23,28 @@
             background: #ffffff;
             padding: 32px;
             border-radius: 16px;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
-            max-width: 520px;
+            box-shadow: 0 10px 40px rgba(15, 23, 42, 0.12);
+            max-width: 540px;
             text-align: center;
         }
 
         .demo-card h1 {
             margin: 0 0 8px;
-            color: #111827;
+            color: #0f172a;
             font-size: 28px;
         }
 
         .demo-card p {
-            margin: 0;
-            color: #4b5563;
+            margin: 0 0 16px;
+            color: #475569;
         }
 
         .demo-status {
-            margin-top: 20px;
+            margin-top: 12px;
             padding: 12px 16px;
             border-radius: 8px;
-            background: #eef2ff;
-            color: #3730a3;
+            background: #e0f2fe;
+            color: #0369a1;
             font-weight: 600;
         }
     </style>
@@ -52,15 +52,11 @@
 <body>
     <div class="demo-shell">
         <div class="demo-card">
-            <h1>Goal Portfolio Viewer</h1>
-            <p>Mock Endowus dashboard for E2E tests.</p>
-            <div class="demo-status" id="demoStatus">Loading demo data…</div>
+            <h1>Goal Portfolio Viewer (FSM)</h1>
+            <p>Mock FSM holdings page for E2E regression tests.</p>
+            <div class="demo-status" id="demoStatus">Loading FSM demo data…</div>
         </div>
     </div>
-
-    <script>
-        window.__GPV_DEMO_MODE__ = true;
-    </script>
 
     <script>
         const mockStorage = {};
@@ -85,30 +81,6 @@
     </script>
 
     <script>
-        (function() {
-            const PERFORMANCE_ENDPOINT = 'https://bff.prod.silver.endowus.com/v1/performance';
-            const originalFetch = window.fetch.bind(window);
-
-            window.fetch = function(resource, options) {
-                const url = typeof resource === 'string' ? resource : resource?.url;
-                if (url && url.startsWith(PERFORMANCE_ENDPOINT)) {
-                    const originalUrl = new URL(url);
-                    const localUrl = new URL('/v1/performance', window.location.origin);
-                    originalUrl.searchParams.forEach((value, key) => {
-                        localUrl.searchParams.set(key, value);
-                    });
-                    if (resource instanceof Request) {
-                        resource = new Request(localUrl.toString(), resource);
-                    } else {
-                        resource = localUrl.toString();
-                    }
-                }
-                return originalFetch(resource, options);
-            };
-        })();
-    </script>
-
-    <script>
         function updateStatus(message, isError = false) {
             const status = document.getElementById('demoStatus');
             status.textContent = message;
@@ -116,8 +88,8 @@
                 status.style.background = '#fee2e2';
                 status.style.color = '#991b1b';
             } else {
-                status.style.background = '#ecfdf3';
-                status.style.color = '#065f46';
+                status.style.background = '#dcfce7';
+                status.style.color = '#166534';
             }
         }
 
@@ -128,6 +100,43 @@
                 script.onload = () => resolve();
                 script.onerror = () => reject(new Error('Failed to load userscript'));
                 document.head.appendChild(script);
+            });
+        }
+
+        async function bootstrapMockData() {
+            const response = await fetch('/fsmone/rest/holding/client/protected/find-holdings-with-pnl');
+            const payload = await response.json();
+            const rows = Array.isArray(payload?.data)
+                ? payload.data.flatMap(group => Array.isArray(group?.holdings) ? group.holdings : [])
+                : [];
+            if (rows.length > 0) {
+                GM_setValue('fsm_target_pct_ESG001', 35.5);
+                GM_setValue('fsm_fixed_ESG002', true);
+                GM_setValue('fsm_tag_ESG003', 'Core');
+                GM_setValue('fsm_tag_catalog', ['Core', 'Satellite']);
+                GM_setValue('fsm_portfolios', [
+                    { id: 'demo-fsm-core', name: 'Core Portfolio', archived: false },
+                    { id: 'demo-fsm-growth', name: 'Growth Portfolio', archived: false }
+                ]);
+                GM_setValue('fsm_assignment_by_code', {
+                    ESG001: 'demo-fsm-core',
+                    ESG002: 'demo-fsm-growth',
+                    ESG003: 'demo-fsm-core'
+                });
+            }
+            return payload;
+        }
+
+        function waitForButton() {
+            return new Promise(resolve => {
+                const check = () => {
+                    if (document.querySelector('.gpv-trigger-btn')) {
+                        resolve();
+                        return;
+                    }
+                    setTimeout(check, 100);
+                };
+                check();
             });
         }
 
@@ -144,36 +153,6 @@
             });
         }
 
-        async function bootstrapMockData() {
-            const responses = await Promise.all([
-                fetch('/v1/goals/performance'),
-                fetch('/v2/goals/investible'),
-                fetch('/v1/goals')
-            ]);
-            const payloads = await Promise.all(responses.map(response => response.json()));
-            const investible = payloads[1];
-            const fixedGoalId = Array.isArray(investible)
-                ? investible.find(goal => goal && goal.goalName && goal.goalName.startsWith('House Purchase'))?.goalId
-                : null;
-            if (fixedGoalId) {
-                GM_setValue(`goal_fixed_${fixedGoalId}`, true);
-            }
-            return payloads;
-        }
-
-        function waitForButton() {
-            return new Promise(resolve => {
-                const check = () => {
-                    if (document.querySelector('.gpv-trigger-btn')) {
-                        resolve();
-                        return;
-                    }
-                    setTimeout(check, 100);
-                };
-                check();
-            });
-        }
-
         function signalReady() {
             window.__GPV_E2E_READY__ = true;
             window.dispatchEvent(new Event('gpv:e2e-ready'));
@@ -184,12 +163,12 @@
             .then(waitForButton)
             .then(waitForSyncUiExports)
             .then(() => {
-                updateStatus('Demo data loaded. Ready for E2E tests.');
+                updateStatus('FSM demo data loaded. Ready for E2E tests.');
                 signalReady();
             })
             .catch(error => {
-                console.error('[Demo] Failed to initialize E2E demo:', error);
-                updateStatus('Failed to initialize demo environment.', true);
+                console.error('[FSM Demo] Failed to initialize:', error);
+                updateStatus('Failed to initialize FSM demo environment.', true);
             });
     </script>
 </body>

--- a/demo/mock-data.json
+++ b/demo/mock-data.json
@@ -22410,5 +22410,35 @@
       "annualReturnRate": -0.04989359528320915,
       "cumulativeInvested": 7027.63
     }
+  },
+  "fsmHoldings": {
+    "data": [
+      {
+        "groupName": "FSM Demo Holdings",
+        "holdings": [
+          {
+            "code": "ESG001",
+            "subcode": "ESG1",
+            "name": "ESG Equity Fund",
+            "productType": "Unit Trust",
+            "currentValueLcy": 12450.25
+          },
+          {
+            "code": "ESG002",
+            "subcode": "ESG2",
+            "name": "Green Bond Fund",
+            "productType": "Unit Trust",
+            "currentValueLcy": 8032.1
+          },
+          {
+            "code": "ESG003",
+            "subcode": "ESG3",
+            "name": "Sustainable Growth",
+            "productType": "Unit Trust",
+            "currentValueLcy": 14220.78
+          }
+        ]
+      }
+    ]
   }
 }

--- a/demo/mock-server.js
+++ b/demo/mock-server.js
@@ -50,6 +50,10 @@ function resolveStaticFile(demoDir, repoRoot, requestPath) {
         return path.join(demoDir, 'dashboard', 'index.html');
     }
 
+    if (requestPath === '/fsmone/holdings/investments') {
+        return path.join(demoDir, 'fsm', 'index.html');
+    }
+
     if (requestPath === '/') {
         return path.join(demoDir, 'index.html');
     }
@@ -98,6 +102,10 @@ function startDemoServer({
                 return sendText(res, 'Not found', 404);
             }
             return sendJson(res, series);
+        }
+
+        if (pathname === '/fsmone/rest/holding/client/protected/find-holdings-with-pnl') {
+            return sendJson(res, mockData.fsmHoldings || { data: [] });
         }
 
         const filePath = resolveStaticFile(demoDir, repoRoot, pathname);

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,9 +4,14 @@
   "description": "Goal Portfolio Viewer demo tooling",
   "private": true,
   "scripts": {
-    "test:e2e": "node e2e-tests.js"
+    "test:e2e": "node e2e-tests.js",
+    "test:e2e:smoke": "node e2e-tests.js",
+    "test:e2e:regression": "E2E_MODE=regression node e2e-tests.js",
+    "test:e2e:update-baseline": "E2E_MODE=update-baseline node e2e-tests.js"
   },
   "dependencies": {
-    "playwright": "^1.57.0"
+    "pixelmatch": "^5.3.0",
+    "playwright": "^1.57.0",
+    "pngjs": "^7.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,15 @@ importers:
 
   demo:
     dependencies:
+      pixelmatch:
+        specifier: ^5.3.0
+        version: 5.3.0
       playwright:
         specifier: ^1.57.0
         version: 1.58.1
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
 
   tampermonkey:
     devDependencies:
@@ -1747,6 +1753,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pixelmatch@5.3.0:
+    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
+    hasBin: true
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -1760,6 +1770,14 @@ packages:
     resolution: {integrity: sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4038,6 +4056,10 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pixelmatch@5.3.0:
+    dependencies:
+      pngjs: 6.0.0
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -4049,6 +4071,10 @@ snapshots:
       playwright-core: 1.58.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@6.0.0: {}
+
+  pngjs@7.0.0: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- fix E2E workflow env paths so `pnpm --filter ./demo test:e2e` writes screenshots and `e2e-summary.json` to the same `demo/screenshots` directory that later steps read
- prevent PR comments from defaulting to `Flows tested: 0` and `Screenshots: None` when tests actually produced artifacts

## Verification
- inspected `.github/workflows/ci.yml` diff to confirm only path env variables changed in the E2E job