### PR TITLE
fix(repo): make root lint use corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "lint": "pnpm --filter ./tampermonkey lint",
+    "lint": "corepack pnpm --filter ./tampermonkey lint",
     "test": "pnpm --filter ./tampermonkey test",
     "test:watch": "pnpm --filter ./tampermonkey test:watch",
     "test:coverage": "pnpm --filter ./tampermonkey test:coverage",


### PR DESCRIPTION
## Summary
- fix the root `lint` script to invoke the repo's declared pnpm toolchain through `corepack`
- keep scope limited to the local lint entrypoint issue; no userscript or test files changed

## Notes
- Assumption: the repo currently has no failing CI-equivalent ESLint errors in the `tampermonkey` workspace, and the minimal valuable scope is repairing the local root lint entrypoint plus any style-only autofix output (none was needed).

## Verification
- `corepack pnpm --filter ./tampermonkey lint`
- `corepack pnpm --filter ./tampermonkey test`
- `corepack pnpm --filter ./tampermonkey check:sync-ui-classes`
- `corepack pnpm lint`
