### PR TITLE
feat(tooling): add changelog synthesizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,143 @@
+# Changelog
+
+Range: `v1.0.3..HEAD`
+
+### Features
+
+- clarify FSM assignment conflicts (#129) (`2ed31c3`)
+- allow forced local overwrite on conflict (#127) (`b65a14e`)
+- add FSM holdings interception and migrate sync payload to v2 namespaced schema (#122) (`0379820`)
+- add per-goal TWR window row in bucket detail (#119) (`4a64244`)
+- enable default auto-sync with buffered sync-on-change and docs reflow (#93) (`89edb19`)
+- clarify performance return metrics (#84) (`4357041`)
+- highlight high remaining target percent (#56) (`50cd785`)
+- add per-goal fixed toggles and remaining target percent (#53) (`21b2008`)
+- add goal-type performance charts, sequential fetching and 7-day cache (#33) (`ddb7fad`)
+- show diff in dollar amount with 5% threshold for red color (`8c6bb17`)
+- add target percentage feature for goal types per bucket (`1542e6f`)
+- Add GitHub Copilot agents and instructions (`f078844`)
+
+### Fixes
+
+- align demo E2E summary artifact paths (#128) (`c42ef71`)
+- address code audit findings (#126) (`c0e7efc`)
+- auto-expand performance panels and refresh rows (#123) (`90bf605`)
+- reduce false multi-device sync conflicts (#121) (`fc11177`)
+- render conflicts in sync settings overlay and ignore fixed-goal targets (#104) (`d9e22c8`)
+- apply remaining-target to missing goal diff and add allocation drift model (#94) (`5099eea`)
+- use Number.isFinite and adjust fallback returns for net flows (#63) (`a3094eb`)
+- sort bucket detail goals alphabetically (#62) (`54e8d5c`)
+- harden routing and allocation logic (#60) (`e859e88`)
+- include pending processing in ending balance (#59) (`1cf756e`)
+- move bucket metadata to _meta (#58) (`61e500e`)
+- correct growth % calculations and streamline goal rows (#57) (`7cd9156`)
+- refine bucket parsing and logging (#54) (`838c98b`)
+- teardown performance chart observers on overlay close (#45) (`4256edb`)
+- scope projected diff recalculation to goal table (#44) (`aa1f8b8`)
+- improve error handling and eliminate remaining code duplication (`370f707`)
+- properly handle clearing target percentage and add GM_deleteValue grant (`a93f28f`)
+- Restructure GitHub Copilot configuration to follow best practices (`b1a0a50`)
+
+### Documentation
+
+- allow autonomous execution for clear specs (#125) (`ed07f41`)
+- consolidate planning docs into skills (#124) (`d4d1e31`)
+- format skills list as table (#113) (`e777863`)
+- add explicit user journey for manual rebalance userscript flow (#101) (`cf9bc06`)
+- trim agents overview to avoid overlap (#91) (`f337d99`)
+- clarify template hygiene and iteration (#88) (`c3705a8`)
+- add alignment gates and Devil's Advocate agent (#85) (`4028960`)
+- clarify agent interaction model (#65) (`7bc96a4`)
+- align AGENTS with role guides (#50) (`a0acef3`)
+- clarify fund visualization gap (#43) (`77f5162`)
+- rename to Goal Portfolio Viewer and apply reviewer feedback (#42) (`59f80e4`)
+- refocus on core-satellite portfolio tracking (#34) (`d200342`)
+
+### Refactors
+
+- modal accessibility, sync helpers, worker utilities (#120) (`8dfcbba`)
+- simplify helpers and remove legacy auth (#111) (`74f8466`)
+- consolidate percent formatting and goal model helpers (#89) (`687f570`)
+- remove demo-only performance fallback and add E2E demo tooling (#86) (`dca47f6`)
+- simplify refresh gating (#52) (`47618c0`)
+- move target % to individual goal rows per user feedback (`1ef7e0f`)
+- extract helper functions to reduce code duplication (`41e372b`)
+- improve storage key handling, add user feedback for validation (`8befaf7`)
+
+### Tests
+
+- consolidate low-value unit checks (#110) (`5b3efd1`)
+- cover auth helpers (#106) (`04651ca`)
+- add storage kv coverage (#107) (`13e388c`)
+- expand auth and sync route coverage (#108) (`4a711d9`)
+- cover token refresh helpers (#109) (`59eac40`)
+- add worker unit tests and path-scoped CI (#100) (`72d987a`)
+- expand userscript coverage and document skills (#99) (`a2c26ff`)
+
+### Chores
+
+- skip draft pull request workflow jobs (#117) (`2750485`)
+- adopt pnpm workspaces and move userscript tooling into tampermonkey package (#105) (`b0b41e4`)
+- refresh skill set and update alignment (#98) (`239fdd3`)
+- render production wrangler config (`98dc3ef`)
+- align stats markup, move screenshots to docs, and bump version (#69) (`bbd298d`)
+- skip tests for draft pull requests (#64) (`0439bde`)
+
+### Security
+
+- gate stale cache fallback to demo mode only (#82) (`91cff43`)
+- add HTML escaping for data attributes to prevent XSS (`b7aee20`)
+
+### Other
+
+- Chore/unify sync kv binding (#118) (`4036b39`)
+- Fix preview KV selection and add spec execution gate (#116) (`748f936`)
+- Add cross-device sync with password-based auth, two-stage key derivation, hardened password storage, polished UI, critical security fixes, repository cleanup, code simplification, and code review response (#90) (`4e0b9e1`)
+- agent improvements (#87) (`82478b8`)
+- Update demo screenshots with automated capture tooling (#81) (`ebe23b9`)
+- Fix demo mock data structure, complete performance metrics, and correct demo data generation (#80) (`b6b87f5`)
+- Add memoization to sortGoalsByName() with 1-week cache expiration for O(n log n) → O(1) on repeated renders (#78) (`ef968f3`)
+- Update demo with time-series performance data, cache fallback, and working charts (#76) (`b97299a`)
+- cleanupv2 (#73) (`58fc8fa`)
+- clean up (#72) (`892369a`)
+- Code debt payoff (#71) (`4da979f`)
+- Updated testing and linting (#68) (`e68cff8`)
+- Add mock data generator and screenshots for Personal and Holiday buckets (#55) (`a9e9de8`)
+- Refactor UI view models and add unit tests (#49) (`b8c96bb`)
+- Rebrand from "Endowus Portfolio Viewer" to "Goal Portfolio Viewer" (#41) (`c30eb4e`)
+- Reference GitHub agent guidance in AGENTS.md (#32) (`4b78a13`)
+- Add test infrastructure and CI with zero code duplication (#30) (`e513a9b`)
+- Revise README for clarity and structure (#31) (`399b9db`)
+- Add capital allocation guidance (#27) (`5a37891`)
+- Refactor data flow for portfolio viewer logic (#26) (`87f5b7d`)
+- Align styles section with UI layer (#25) (`34dd6bb`)
+- Create assets folder and move endowus_view_enhancer_screenshot.png into it. (`35a3e9b`)
+- Update README.md with improved documentation and add screenshot placeholder (`5a9d016`)
+- Address feedback: neutral colors, allow negative values, revert version to 2.2.0 (`2c58e75`)
+- Add projected investment input feature for goal type diff calculation (`1d2ba88`)
+- Initial plan (`4dceee9`)
+- Rename 'Diff (%)' header to 'Diff' (`7ba9bea`)
+- Initial plan (`36a03ed`)
+- Update documentation to reflect bottom-right button location (`18f9932`)
+- Initial plan (`692d567`)
+- removed firefox addon and updated readme files (`d98a7a5`)
+- Fix TypeError when navigating between pages by validating array data (`a92e29f`)
+- Initial plan (`cf26545`)
+- updated the readme (`890847c`)
+- Make tampermonkey/README.md self-contained without external links (`47f4ac1`)
+- Address code review feedback: update date format and remove duplicate features (`0a5839b`)
+- Refactor documentation: user-focused README and consolidated technical docs (`ae04381`)
+- Initial plan (`9e75743`)
+- Add debouncing to MutationObserver for better performance (`6dc2b9e`)
+- Replace setInterval with MutationObserver for URL change detection (`364b9a8`)
+- Initial plan (`63f1ab6`)
+- Update goal type sorting and rename Passive Income to Income (`410c032`)
+- Add URL monitoring every 2 seconds for SPA navigation support (`047dedb`)
+- Add passive income support, optimize spacing, and enable click-outside to close (`19167fe`)
+- Implement storage, conditional button display, and improve UI readability (`612d804`)
+- Add quick installation guide for users (`226e059`)
+- Improve error handling and add JSDoc documentation (`897b820`)
+- Fix URL matching logic and add clarifying comments (`293215b`)
+- Add feature comparison documentation with UI screenshots (`4ab222b`)
+- Add Tampermonkey script with modern UI and API interception (`75a6e2b`)
+- Initial plan (`0fd0926`)

--- a/README.md
+++ b/README.md
@@ -152,11 +152,21 @@ Our project uses specialized AI agents for different aspects of development:
 ```bash
 # Development
 pnpm test              # Run tests
+pnpm test:changelog    # Run changelog CLI tests
+pnpm changelog         # Preview changelog markdown for latest-tag..HEAD
+pnpm changelog:write   # Regenerate CHANGELOG.md
 pnpm run lint          # Check code quality
 pnpm run test:watch    # Development mode
 ```
 
 `pnpm-lock.yaml` is committed to keep workspace installs reproducible across contributors and CI.
+
+### Release Notes and Changelog Maintenance
+
+- `pnpm changelog` prints markdown for commits between the latest reachable tag and `HEAD`.
+- `pnpm changelog:write` writes the same synthesized output to `CHANGELOG.md`.
+- Override stale or missing tags with explicit refs, for example `node scripts/generate-changelog.mjs --from v1.0.3.1 --to HEAD --write CHANGELOG.md`.
+- Conventional commit subjects produce the cleanest section grouping; non-conventional subjects are still included under `Other`.
 
 ### Documentation
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
     }
   },
   "scripts": {
+    "changelog": "node scripts/generate-changelog.mjs",
+    "changelog:write": "node scripts/generate-changelog.mjs --write CHANGELOG.md",
     "lint": "pnpm --filter ./tampermonkey lint",
     "test": "pnpm --filter ./tampermonkey test",
+    "test:changelog": "node --test scripts/__tests__/generate-changelog.test.mjs",
     "test:watch": "pnpm --filter ./tampermonkey test:watch",
     "test:coverage": "pnpm --filter ./tampermonkey test:coverage",
     "test:e2e": "pnpm --filter ./demo test:e2e"

--- a/scripts/__tests__/generate-changelog.test.mjs
+++ b/scripts/__tests__/generate-changelog.test.mjs
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    buildGitLogArgs,
+    formatRange,
+    generateChangelog,
+    parseGitLogOutput,
+    renderChangelog,
+    resolveRange
+} from '../generate-changelog.mjs';
+
+const record = (hash, subject, body = '') => `${hash}\x1f${subject}\x1f${body}\x1e`;
+
+test('resolveRange falls back to the latest reachable tag', async () => {
+    const calls = [];
+    const git = async args => {
+        calls.push(args);
+        return 'v2.0.0\n';
+    };
+
+    const range = await resolveRange({}, { cwd: '/repo', git });
+
+    assert.deepEqual(range, { from: 'v2.0.0', to: 'HEAD' });
+    assert.deepEqual(calls, [['describe', '--tags', '--abbrev=0', 'HEAD']]);
+});
+
+test('generateChangelog honors explicit --from and --to overrides', async () => {
+    const calls = [];
+    const git = async args => {
+        calls.push(args);
+
+        if (args[0] === 'describe') {
+            throw new Error('describe should not run when --from is explicit');
+        }
+
+        return record('abc1234', 'fix: patch release note output');
+    };
+
+    const changelog = await generateChangelog(
+        { from: 'v1.2.0', to: 'HEAD~1' },
+        { cwd: '/repo', git }
+    );
+
+    assert.equal(changelog.from, 'v1.2.0');
+    assert.equal(changelog.to, 'HEAD~1');
+    assert.match(changelog.markdown, /Range: `v1\.2\.0\.\.HEAD~1`/);
+    assert.deepEqual(calls, [buildGitLogArgs({ from: 'v1.2.0', to: 'HEAD~1' })]);
+});
+
+test('parseGitLogOutput groups conventional commits and keeps non-conventional subjects', () => {
+    const commits = parseGitLogOutput([
+        record('1111111', 'feat(ui): add release command'),
+        record('2222222', 'fix(security): harden changelog path writes'),
+        record('3333333', 'docs: explain release steps'),
+        record('4444444', 'Ship it without a prefix')
+    ].join(''));
+
+    assert.deepEqual(
+        commits.map(commit => ({ section: commit.section, text: commit.text })),
+        [
+            { section: 'feat', text: 'add release command' },
+            { section: 'security', text: 'harden changelog path writes' },
+            { section: 'docs', text: 'explain release steps' },
+            { section: 'other', text: 'Ship it without a prefix' }
+        ]
+    );
+});
+
+test('parseGitLogOutput skips merge commits and keeps revert commits readable', () => {
+    const commits = parseGitLogOutput([
+        record('1111111', 'Merge pull request #42 from example/topic'),
+        record('2222222', 'Revert "feat(ui): add release command"')
+    ].join(''));
+
+    assert.equal(commits.length, 1);
+    assert.equal(commits[0].section, 'feat');
+    assert.equal(commits[0].text, 'Revert: add release command');
+});
+
+test('renderChangelog shows a stable empty-range message', () => {
+    const markdown = renderChangelog({
+        from: 'v1.0.0',
+        to: 'HEAD',
+        commits: []
+    });
+
+    assert.equal(
+        markdown,
+        '# Changelog\n\nRange: `v1.0.0..HEAD`\n\n- No user-facing changes detected in this range.\n'
+    );
+});
+
+test('renderChangelog keeps section ordering deterministic', () => {
+    const commits = parseGitLogOutput([
+        record('4444444', 'docs: explain release steps'),
+        record('1111111', 'fix: patch release note output'),
+        record('2222222', 'feat: add changelog command'),
+        record('3333333', 'Ship it without a prefix')
+    ].join(''));
+
+    const markdown = renderChangelog({
+        from: null,
+        to: 'HEAD',
+        commits
+    });
+
+    assert.match(markdown, /### Features[\s\S]*### Fixes[\s\S]*### Documentation[\s\S]*### Other/);
+    assert.equal(markdown, renderChangelog({ from: null, to: 'HEAD', commits }));
+    assert.equal(formatRange(null, 'HEAD'), 'start..HEAD');
+});

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+
+import { execFile as execFileCallback } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+const execFile = promisify(execFileCallback);
+
+const FIELD_SEPARATOR = '\x1f';
+const RECORD_SEPARATOR = '\x1e';
+const DEFAULT_OUTPUT_PATH = 'CHANGELOG.md';
+const DEFAULT_TO_REF = 'HEAD';
+const SECTION_ORDER = [
+    'feat',
+    'fix',
+    'docs',
+    'refactor',
+    'perf',
+    'test',
+    'chore',
+    'security',
+    'other'
+];
+const SECTION_TITLES = {
+    feat: 'Features',
+    fix: 'Fixes',
+    docs: 'Documentation',
+    refactor: 'Refactors',
+    perf: 'Performance',
+    test: 'Tests',
+    chore: 'Chores',
+    security: 'Security',
+    other: 'Other'
+};
+const CONVENTIONAL_SUBJECT_PATTERN = /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?:\s*(?<description>.+)$/i;
+const REVERT_SUBJECT_PATTERN = /^Revert\s+"(?<subject>.+)"$/i;
+
+const USAGE = `Usage: node scripts/generate-changelog.mjs [options]
+
+Generate changelog markdown from git history.
+
+Options:
+  --from <ref>     Start ref (defaults to latest reachable tag)
+  --to <ref>       End ref (defaults to HEAD)
+  --write [path]   Write markdown to a file (defaults to CHANGELOG.md)
+  --help           Show this message
+`;
+
+export {
+    DEFAULT_OUTPUT_PATH,
+    DEFAULT_TO_REF,
+    SECTION_ORDER,
+    SECTION_TITLES
+};
+
+export function parseArgs(argv) {
+    const options = {
+        from: undefined,
+        to: DEFAULT_TO_REF,
+        writePath: null,
+        help: false
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+
+        if (argument === '--help' || argument === '-h') {
+            options.help = true;
+            continue;
+        }
+
+        if (argument === '--from') {
+            const value = argv[index + 1];
+            if (!value || value.startsWith('--')) {
+                throw new Error('Missing value for --from.');
+            }
+
+            options.from = value;
+            index += 1;
+            continue;
+        }
+
+        if (argument === '--to') {
+            const value = argv[index + 1];
+            if (!value || value.startsWith('--')) {
+                throw new Error('Missing value for --to.');
+            }
+
+            options.to = value;
+            index += 1;
+            continue;
+        }
+
+        if (argument === '--write') {
+            const value = argv[index + 1];
+            if (value && !value.startsWith('--')) {
+                options.writePath = value;
+                index += 1;
+            } else {
+                options.writePath = DEFAULT_OUTPUT_PATH;
+            }
+
+            continue;
+        }
+
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+
+    return options;
+}
+
+export async function runGit(args, { cwd = process.cwd(), execFileImpl = execFile } = {}) {
+    const { stdout } = await execFileImpl('git', args, {
+        cwd,
+        maxBuffer: 10 * 1024 * 1024
+    });
+
+    return stdout;
+}
+
+export async function getLatestReachableTag({ cwd = process.cwd(), to = DEFAULT_TO_REF, git = runGit } = {}) {
+    try {
+        const stdout = await git(['describe', '--tags', '--abbrev=0', to], { cwd });
+        const tag = stdout.trim();
+
+        return tag || null;
+    } catch (error) {
+        const stderr = String(error?.stderr || '');
+        const missingTag =
+            error?.code === 128 &&
+            (
+                stderr.includes('No names found') ||
+                stderr.includes('No tags can describe')
+            );
+
+        if (missingTag) {
+            return null;
+        }
+
+        throw error;
+    }
+}
+
+export async function resolveRange(options = {}, { cwd = process.cwd(), git = runGit } = {}) {
+    const to = options.to || DEFAULT_TO_REF;
+    const explicitFrom = options.from;
+
+    if (explicitFrom) {
+        return {
+            from: explicitFrom,
+            to
+        };
+    }
+
+    return {
+        from: await getLatestReachableTag({ cwd, to, git }),
+        to
+    };
+}
+
+export function buildGitLogArgs({ from, to = DEFAULT_TO_REF } = {}) {
+    const range = from ? `${from}..${to}` : to;
+
+    return [
+        'log',
+        '--no-merges',
+        `--format=%H${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%b${RECORD_SEPARATOR}`,
+        range
+    ];
+}
+
+export function parseConventionalSubject(subject) {
+    const revertedSubject = subject.match(REVERT_SUBJECT_PATTERN)?.groups?.subject ?? null;
+    const candidate = (revertedSubject || subject).trim();
+    const match = candidate.match(CONVENTIONAL_SUBJECT_PATTERN);
+
+    if (!match?.groups) {
+        return {
+            type: null,
+            scope: null,
+            description: subject.trim(),
+            revertedSubject
+        };
+    }
+
+    return {
+        type: match.groups.type.toLowerCase(),
+        scope: match.groups.scope ? match.groups.scope.toLowerCase() : null,
+        description: revertedSubject
+            ? `Revert: ${match.groups.description.trim()}`
+            : match.groups.description.trim(),
+        revertedSubject
+    };
+}
+
+export function classifySection(type, scope) {
+    if (!type) {
+        return 'other';
+    }
+
+    if (type === 'security' || scope === 'security') {
+        return 'security';
+    }
+
+    if (type === 'feat' || type === 'feature') {
+        return 'feat';
+    }
+
+    if (type === 'fix') {
+        return 'fix';
+    }
+
+    if (type === 'docs' || type === 'doc') {
+        return 'docs';
+    }
+
+    if (type === 'refactor') {
+        return 'refactor';
+    }
+
+    if (type === 'perf' || type === 'performance') {
+        return 'perf';
+    }
+
+    if (type === 'test' || type === 'tests') {
+        return 'test';
+    }
+
+    if (type === 'chore' || type === 'ci' || type === 'build') {
+        return 'chore';
+    }
+
+    return 'other';
+}
+
+export function normalizeCommit(record) {
+    if (!record.subject || record.subject.startsWith('Merge ')) {
+        return null;
+    }
+
+    const parsedSubject = parseConventionalSubject(record.subject);
+
+    return {
+        hash: record.hash,
+        subject: record.subject.trim(),
+        body: record.body.trim(),
+        section: classifySection(parsedSubject.type, parsedSubject.scope),
+        text: parsedSubject.description
+    };
+}
+
+export function parseGitLogOutput(stdout) {
+    return stdout
+        .split(RECORD_SEPARATOR)
+        .map(entry => entry.trim())
+        .filter(Boolean)
+        .map(entry => {
+            const [hash = '', subject = '', body = ''] = entry.split(FIELD_SEPARATOR);
+
+            return {
+                hash: hash.trim(),
+                subject: subject.trim(),
+                body
+            };
+        })
+        .map(normalizeCommit)
+        .filter(Boolean);
+}
+
+export async function readCommits(options = {}, { cwd = process.cwd(), git = runGit } = {}) {
+    const stdout = await git(buildGitLogArgs(options), { cwd });
+
+    return parseGitLogOutput(stdout);
+}
+
+export function groupCommits(commits) {
+    const grouped = Object.fromEntries(SECTION_ORDER.map(section => [section, []]));
+
+    for (const commit of commits) {
+        grouped[commit.section].push(commit);
+    }
+
+    return grouped;
+}
+
+export function shortHash(hash) {
+    return hash.slice(0, 7);
+}
+
+export function formatRange(from, to) {
+    return `${from || 'start'}..${to || DEFAULT_TO_REF}`;
+}
+
+export function renderChangelog({ from, to = DEFAULT_TO_REF, commits }) {
+    const lines = [
+        '# Changelog',
+        '',
+        `Range: \`${formatRange(from, to)}\``,
+        ''
+    ];
+
+    if (commits.length === 0) {
+        lines.push('- No user-facing changes detected in this range.');
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    const grouped = groupCommits(commits);
+
+    for (const section of SECTION_ORDER) {
+        if (grouped[section].length === 0) {
+            continue;
+        }
+
+        lines.push(`### ${SECTION_TITLES[section]}`, '');
+
+        for (const commit of grouped[section]) {
+            lines.push(`- ${commit.text} (\`${shortHash(commit.hash)}\`)`);
+        }
+
+        lines.push('');
+    }
+
+    while (lines.at(-1) === '') {
+        lines.pop();
+    }
+
+    return `${lines.join('\n')}\n`;
+}
+
+export async function generateChangelog(options = {}, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const git = dependencies.git || runGit;
+    const range = await resolveRange(options, { cwd, git });
+    const commits = await readCommits(range, { cwd, git });
+    const markdown = renderChangelog({
+        from: range.from,
+        to: range.to,
+        commits
+    });
+
+    return {
+        ...range,
+        commits,
+        markdown
+    };
+}
+
+export async function main(argv = process.argv.slice(2), dependencies = {}) {
+    const options = parseArgs(argv);
+
+    if (options.help) {
+        (dependencies.stdout || process.stdout).write(USAGE);
+        return;
+    }
+
+    const { markdown } = await generateChangelog(options, dependencies);
+
+    if (options.writePath) {
+        const targetPath = resolvePath(dependencies.cwd || process.cwd(), options.writePath);
+        await writeFile(targetPath, markdown, 'utf8');
+        (dependencies.stdout || process.stdout).write(`Wrote changelog to ${options.writePath}\n`);
+        return;
+    }
+
+    (dependencies.stdout || process.stdout).write(markdown);
+}
+
+const isDirectExecution =
+    process.argv[1] &&
+    pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isDirectExecution) {
+    main().catch(error => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- add `scripts/generate-changelog.mjs` as a dependency-free Node CLI for synthesizing markdown changelog output from git history
- add root scripts and built-in tests for range resolution, grouping, merge/revert handling, empty ranges, and deterministic rendering
- generate `CHANGELOG.md` and document maintainer usage in `README.md`

## Spec and assumptions
- Spec-Clarity Gate: pass
- Acceptance criteria source: `changelog-synth:/workspace/goal-portfolio-viewer`
- Open questions: none
- Assumption: the most useful default is `latest reachable tag..HEAD`; when tags are stale or missing, maintainers can override with `--from`/`--to`
- Limitation: non-conventional commit subjects are preserved under `Other`, so output quality still depends on commit hygiene

## Verification
- `pnpm lint`
- `pnpm test`
- `pnpm test:changelog`
- `pnpm changelog`
- `pnpm changelog:write` twice with identical output
- `node scripts/generate-changelog.mjs --from v1.0.3 --to HEAD --write /tmp/changelog-explicit.md`

## Notes
- Existing repo state on the original branch was preserved by doing the work in a separate worktree off `main`.
- `pnpm test` passes, with the existing Jest warning about a worker process not exiting gracefully after the suite completes.