### PR TITLE
feat(tooling): add doc drift detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       userscript: ${{ steps.filter.outputs.userscript }}
       workers: ${{ steps.filter.outputs.workers }}
+      docdrift: ${{ steps.filter.outputs.docdrift }}
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - name: Checkout code
@@ -40,6 +41,23 @@ jobs:
               - 'workers/**'
               - 'pnpm-workspace.yaml'
               - 'pnpm-lock.yaml'
+            docdrift:
+              - '*.md'
+              - '.github/**/*.md'
+              - '.github/workflows/ci.yml'
+              - 'demo/**/*.md'
+              - 'demo/package.json'
+              - 'docs/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'scripts/check-doc-drift.mjs'
+              - 'scripts/__tests__/check-doc-drift.test.mjs'
+              - 'tampermonkey/**/*.md'
+              - 'tampermonkey/goal_portfolio_viewer.user.js'
+              - 'tampermonkey/package.json'
+              - 'workers/**/*.md'
+              - 'workers/package.json'
             e2e:
               - 'demo/**'
               - 'tampermonkey/**'
@@ -72,6 +90,34 @@ jobs:
 
       - name: Run ESLint
         run: pnpm --filter ./tampermonkey lint
+
+  doc-drift:
+    name: Documentation Drift
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.changes.outputs.docdrift == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run doc drift tests
+        run: pnpm run test:docs
+
+      - name: Run doc drift detector
+        run: pnpm run doc:drift
 
   test:
     name: Test on Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - 'pnpm-lock.yaml'
             docdrift:
               - '*.md'
+              - '.agents/**/*.md'
               - '.github/**/*.md'
               - '.github/workflows/ci.yml'
               - 'demo/**/*.md'

--- a/README.md
+++ b/README.md
@@ -153,13 +153,17 @@ Our project uses specialized AI agents for different aspects of development:
 # Development
 pnpm test              # Run tests
 pnpm test:changelog    # Run changelog CLI tests
+pnpm test:docs         # Run doc drift detector tests
 pnpm changelog         # Preview changelog markdown for latest-tag..HEAD
 pnpm changelog:write   # Regenerate CHANGELOG.md
+pnpm doc:drift         # Validate markdown links, documented scripts, and version touchpoints
 pnpm run lint          # Check code quality
 pnpm run test:watch    # Development mode
 ```
 
 `pnpm-lock.yaml` is committed to keep workspace installs reproducible across contributors and CI.
+
+Run `pnpm run doc:drift` whenever you touch documentation, package scripts, CI manifests, or userscript version metadata so docs and release touchpoints stay aligned with the repo.
 
 ### Release Notes and Changelog Maintenance
 
@@ -178,6 +182,7 @@ pnpm run test:watch    # Development mode
 
 - ✅ All tests must pass
 - ✅ ESLint checks clean
+- ✅ Doc drift checks clean when docs/tooling/version touchpoints change
 - ✅ Financial calculations manually verified
 - ✅ Documentation updated for behavior changes
 - ✅ Version bumped appropriately

--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -493,6 +493,8 @@ When shipping a release, update every version touchpoint to keep them aligned:
 
 If any of these are missed, Tampermonkey auto-updates or release notes can drift from the actual code.
 
+Before merging documentation, manifest, or userscript metadata changes, run `pnpm run doc:drift` to verify relative markdown links, documented package scripts, and version touchpoints still match the repository state.
+
 **Key Sections to Modify:**
 
 ```javascript

--- a/TESTING.md
+++ b/TESTING.md
@@ -58,7 +58,11 @@ pnpm run test:watch
 # Run tests with coverage report
 pnpm run test:coverage
 
-# Run layered coverage (userscript vs overall)
+# Run documentation drift detector tests
+pnpm run test:docs
+
+# Verify markdown links, documented commands, and version touchpoints
+pnpm run doc:drift
 ```
 
 ### Test Output
@@ -202,7 +206,7 @@ Draft pull requests are intentionally skipped by job conditions. When a draft PR
 1. Checkout code
 2. Setup Node.js (20.x)
 3. Install dependencies (`pnpm install`)
-4. Run affected jobs based on changed paths (lint, userscript tests, worker unit tests, e2e)
+4. Run affected jobs based on changed paths (lint, userscript tests, doc drift, worker unit tests, e2e)
 5. Post coverage/comments and upload artifacts for relevant jobs
 
 ### CI Requirements
@@ -211,6 +215,7 @@ Draft pull requests are intentionally skipped by job conditions. When a draft PR
 - No test failures allowed
 - Draft PRs should show CI jobs as skipped
 - Ready/non-draft PRs should run eligible jobs based on path filters
+- Documentation changes should trigger the doc drift job when relevant files change
 
 ### Viewing CI Results
 
@@ -296,7 +301,7 @@ Create initial automated test coverage for the Cloudflare Worker backend using *
      - `workers/src/**/*.js` (only if needed for test-friendly exports)
      - `workers/__tests__/` (new unit test files)
    - Changes:
-     - Add a dedicated `test:unit` script for workers.
+      - Use the dedicated `test:unit` script for workers.
      - Add unit tests for pure/mostly-pure behavior with mocked `env`, `Request`, and KV methods.
 
 2. **Unit test coverage for high-risk worker modules**
@@ -344,7 +349,9 @@ Create initial automated test coverage for the Cloudflare Worker backend using *
 - Local verification commands (during implementation):
   - `pnpm run test`
   - `pnpm run test:coverage`
-  - `pnpm --filter ./workers test:unit` (once added)
+  - `pnpm --filter ./workers test:unit`
+  - `pnpm run test:docs`
+  - `pnpm run doc:drift`
 - CI verification:
   - Open one PR that changes only `workers/src/**` and confirm only worker unit test path executes.
   - Open one PR that changes only `tampermonkey/**` and confirm worker unit test path is skipped.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   "scripts": {
     "changelog": "node scripts/generate-changelog.mjs",
     "changelog:write": "node scripts/generate-changelog.mjs --write CHANGELOG.md",
+    "doc:drift": "node scripts/check-doc-drift.mjs",
     "lint": "pnpm --filter ./tampermonkey lint",
     "test": "pnpm --filter ./tampermonkey test",
     "test:changelog": "node --test scripts/__tests__/generate-changelog.test.mjs",
+    "test:docs": "node --test scripts/__tests__/check-doc-drift.test.mjs",
     "test:watch": "pnpm --filter ./tampermonkey test:watch",
     "test:coverage": "pnpm --filter ./tampermonkey test:coverage",
     "test:e2e": "pnpm --filter ./demo test:e2e"

--- a/scripts/__tests__/check-doc-drift.test.mjs
+++ b/scripts/__tests__/check-doc-drift.test.mjs
@@ -8,6 +8,7 @@ import {
     checkDocDrift,
     extractDocumentedCommands,
     extractMarkdownTargets,
+    parseDocumentedCommands,
     parseDocumentedCommand
 } from '../check-doc-drift.mjs';
 
@@ -40,16 +41,20 @@ async function createWorkspaceFixture(overrides = {}) {
             '```bash',
             'pnpm test',
             'pnpm run lint',
+            'cd workers && pnpm install --frozen-lockfile',
             'pnpm --filter ./workers test:unit',
             '```',
             '',
             '`pnpm run doc:drift`',
+            '`cd tampermonkey && npm run lint`',
             '',
             '[External](https://example.com)',
             '[Section](#local-anchor)'
         ].join('\n'),
         'docs/guide.md': '# Guide\n',
         'docs/diagram.png': 'png',
+        '.agents/skills/example/SKILL.md': '# Example\n\n[Guide](references/guide.md)\n',
+        '.agents/skills/example/references/guide.md': '# Example Guide\n',
         'tampermonkey/package.json': JSON.stringify({
             name: 'tampermonkey',
             version: '1.0.0',
@@ -105,13 +110,16 @@ test('extract helpers keep command and target parsing deterministic', () => {
     assert.deepEqual(
         extractDocumentedCommands([
             '```bash',
+            'cd tampermonkey && npm run lint',
             'pnpm test # comment',
             '```',
-            'Use `pnpm run lint` after changes.'
+            'Use `pnpm run lint` and `cd workers && pnpm test:unit` after changes.'
         ].join('\n')),
         [
-            { command: 'pnpm test', line: 2 },
-            { command: 'pnpm run lint', line: 4 }
+            { command: 'cd tampermonkey && npm run lint', line: 2 },
+            { command: 'pnpm test', line: 3 },
+            { command: 'pnpm run lint', line: 5 },
+            { command: 'cd workers && pnpm test:unit', line: 5 }
         ]
     );
 
@@ -127,6 +135,11 @@ test('extract helpers keep command and target parsing deterministic', () => {
         parseDocumentedCommand('pnpm --filter ./workers test:unit', 'root'),
         { packageKey: 'workers', scriptName: 'test:unit' }
     );
+
+    assert.deepEqual(
+        parseDocumentedCommands('cd tampermonkey && npm run lint', 'root'),
+        [{ packageKey: 'tampermonkey', scriptName: 'lint' }]
+    );
 });
 
 test('checkDocDrift passes for valid links, commands, versions, and ignored paths', async () => {
@@ -134,6 +147,7 @@ test('checkDocDrift passes for valid links, commands, versions, and ignored path
     const result = await checkDocDrift({ rootDir });
 
     assert.equal(result.issues.length, 0);
+    assert.ok(result.files.includes('.agents/skills/example/SKILL.md'));
     assert.ok(result.files.includes('README.md'));
     assert.ok(result.files.includes('workers/README.md'));
     assert.ok(!result.files.some(file => file.startsWith('.review-audit-branch/')));
@@ -154,7 +168,7 @@ test('checkDocDrift reports broken markdown targets', async () => {
 
 test('checkDocDrift reports missing documented scripts in the resolved workspace', async () => {
     const rootDir = await createWorkspaceFixture({
-        'README.md': '# Workspace\n\n`pnpm run missing-script`\n'
+        'README.md': '# Workspace\n\n`cd tampermonkey && npm run missing-script`\n'
     });
     const result = await checkDocDrift({ rootDir });
 
@@ -162,7 +176,8 @@ test('checkDocDrift reports missing documented scripts in the resolved workspace
         result.issues.map(issue => issue.kind),
         ['missing-script']
     );
-    assert.match(result.issues[0].message, /missing script "missing-script" in package\.json/);
+    assert.equal(result.issues[0].file, 'README.md');
+    assert.match(result.issues[0].message, /missing script "missing-script" in tampermonkey\/package\.json/);
 });
 
 test('checkDocDrift reports version mismatches across release touchpoints', async () => {
@@ -204,4 +219,18 @@ test('ignored paths and external URLs do not produce findings', async () => {
     const result = await checkDocDrift({ rootDir });
 
     assert.equal(result.issues.length, 0);
+});
+
+test('checkDocDrift scans .agents markdown for broken relative links', async () => {
+    const rootDir = await createWorkspaceFixture({
+        '.agents/skills/example/SKILL.md': '# Example\n\n[Broken](references/missing.md)\n'
+    });
+    const result = await checkDocDrift({ rootDir });
+
+    assert.deepEqual(
+        result.issues.map(issue => issue.kind),
+        ['broken-link']
+    );
+    assert.equal(result.issues[0].file, '.agents/skills/example/SKILL.md');
+    assert.match(result.issues[0].message, /references\/missing\.md/);
 });

--- a/scripts/__tests__/check-doc-drift.test.mjs
+++ b/scripts/__tests__/check-doc-drift.test.mjs
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+    checkDocDrift,
+    extractDocumentedCommands,
+    extractMarkdownTargets,
+    parseDocumentedCommand
+} from '../check-doc-drift.mjs';
+
+async function createFixture(structure, rootDir) {
+    for (const [relativePath, content] of Object.entries(structure)) {
+        const absolutePath = path.join(rootDir, relativePath);
+        await mkdir(path.dirname(absolutePath), { recursive: true });
+        await writeFile(absolutePath, content);
+    }
+}
+
+async function createWorkspaceFixture(overrides = {}) {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), 'doc-drift-'));
+    const baseStructure = {
+        'package.json': JSON.stringify({
+            name: 'root',
+            version: '1.0.0',
+            scripts: {
+                'doc:drift': 'node scripts/check-doc-drift.mjs',
+                lint: 'eslint .',
+                test: 'node --test'
+            }
+        }, null, 2),
+        'README.md': [
+            '# Workspace',
+            '',
+            '[Guide](docs/guide.md)',
+            '![Diagram](docs/diagram.png)',
+            '',
+            '```bash',
+            'pnpm test',
+            'pnpm run lint',
+            'pnpm --filter ./workers test:unit',
+            '```',
+            '',
+            '`pnpm run doc:drift`',
+            '',
+            '[External](https://example.com)',
+            '[Section](#local-anchor)'
+        ].join('\n'),
+        'docs/guide.md': '# Guide\n',
+        'docs/diagram.png': 'png',
+        'tampermonkey/package.json': JSON.stringify({
+            name: 'tampermonkey',
+            version: '1.0.0',
+            scripts: {
+                lint: 'eslint .',
+                test: 'jest'
+            }
+        }, null, 2),
+        'tampermonkey/goal_portfolio_viewer.user.js': [
+            '// ==UserScript==',
+            '// @name Goal Portfolio Viewer',
+            '// @version      1.0.0',
+            '// ==/UserScript=='
+        ].join('\n'),
+        'workers/package.json': JSON.stringify({
+            name: 'workers',
+            version: '1.2.0',
+            scripts: {
+                dev: 'wrangler dev',
+                test: 'node --test',
+                'test:unit': 'node --test'
+            }
+        }, null, 2),
+        'workers/README.md': [
+            '# Workers',
+            '',
+            'Run `pnpm run dev` before deployment.',
+            '',
+            '```bash',
+            'pnpm test',
+            '```'
+        ].join('\n'),
+        'demo/package.json': JSON.stringify({
+            name: 'demo',
+            version: '1.0.0',
+            scripts: {
+                'test:e2e': 'node e2e-tests.js'
+            }
+        }, null, 2),
+        '.review-audit-branch/README.md': [
+            '# Ignored',
+            '',
+            '[Missing](docs/nope.md)',
+            '`pnpm run missing`'
+        ].join('\n')
+    };
+
+    await createFixture({ ...baseStructure, ...overrides }, rootDir);
+    return rootDir;
+}
+
+test('extract helpers keep command and target parsing deterministic', () => {
+    assert.deepEqual(
+        extractDocumentedCommands([
+            '```bash',
+            'pnpm test # comment',
+            '```',
+            'Use `pnpm run lint` after changes.'
+        ].join('\n')),
+        [
+            { command: 'pnpm test', line: 2 },
+            { command: 'pnpm run lint', line: 4 }
+        ]
+    );
+
+    assert.deepEqual(
+        extractMarkdownTargets('[Guide](docs/guide.md) and ![Diagram](docs/diagram.png#v2)'),
+        [
+            { line: 1, target: 'docs/guide.md' },
+            { line: 1, target: 'docs/diagram.png#v2' }
+        ]
+    );
+
+    assert.deepEqual(
+        parseDocumentedCommand('pnpm --filter ./workers test:unit', 'root'),
+        { packageKey: 'workers', scriptName: 'test:unit' }
+    );
+});
+
+test('checkDocDrift passes for valid links, commands, versions, and ignored paths', async () => {
+    const rootDir = await createWorkspaceFixture();
+    const result = await checkDocDrift({ rootDir });
+
+    assert.equal(result.issues.length, 0);
+    assert.ok(result.files.includes('README.md'));
+    assert.ok(result.files.includes('workers/README.md'));
+    assert.ok(!result.files.some(file => file.startsWith('.review-audit-branch/')));
+});
+
+test('checkDocDrift reports broken markdown targets', async () => {
+    const rootDir = await createWorkspaceFixture({
+        'README.md': '# Workspace\n\n[Broken](docs/missing.md)\n'
+    });
+    const result = await checkDocDrift({ rootDir });
+
+    assert.deepEqual(
+        result.issues.map(issue => issue.kind),
+        ['broken-link']
+    );
+    assert.match(result.issues[0].message, /Missing relative target "docs\/missing\.md"/);
+});
+
+test('checkDocDrift reports missing documented scripts in the resolved workspace', async () => {
+    const rootDir = await createWorkspaceFixture({
+        'README.md': '# Workspace\n\n`pnpm run missing-script`\n'
+    });
+    const result = await checkDocDrift({ rootDir });
+
+    assert.deepEqual(
+        result.issues.map(issue => issue.kind),
+        ['missing-script']
+    );
+    assert.match(result.issues[0].message, /missing script "missing-script" in package\.json/);
+});
+
+test('checkDocDrift reports version mismatches across release touchpoints', async () => {
+    const rootDir = await createWorkspaceFixture({
+        'tampermonkey/package.json': JSON.stringify({
+            name: 'tampermonkey',
+            version: '1.0.1',
+            scripts: {
+                lint: 'eslint .',
+                test: 'jest'
+            }
+        }, null, 2)
+    });
+    const result = await checkDocDrift({ rootDir });
+
+    assert.deepEqual(
+        result.issues.map(issue => issue.kind),
+        ['version-mismatch']
+    );
+    assert.equal(result.issues[0].file, 'tampermonkey/package.json');
+});
+
+test('ignored paths and external URLs do not produce findings', async () => {
+    const rootDir = await createWorkspaceFixture({
+        'README.md': [
+            '# Workspace',
+            '',
+            '[External](https://example.com)',
+            '[Mail](mailto:test@example.com)',
+            '[Anchor](#top)'
+        ].join('\n'),
+        '.review-audit-branch/README.md': [
+            '# Ignored',
+            '',
+            '[Broken](docs/nope.md)',
+            '`pnpm run missing-script`'
+        ].join('\n')
+    });
+    const result = await checkDocDrift({ rootDir });
+
+    assert.equal(result.issues.length, 0);
+});

--- a/scripts/check-doc-drift.mjs
+++ b/scripts/check-doc-drift.mjs
@@ -4,7 +4,7 @@ import { access, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const ROOT_MARKDOWN_DIRECTORIES = ['.github', 'demo', 'docs', 'tampermonkey', 'workers'];
+const ROOT_MARKDOWN_DIRECTORIES = ['.agents', '.github', 'demo', 'docs', 'tampermonkey', 'workers'];
 const IGNORED_DIRECTORIES = new Set([
     '.git',
     '.review-audit-branch',
@@ -17,6 +17,12 @@ const WORKSPACE_PACKAGE_PATHS = {
     demo: 'demo/package.json',
     tampermonkey: 'tampermonkey/package.json',
     workers: 'workers/package.json'
+};
+const WORKSPACE_DIRECTORIES = {
+    root: '',
+    demo: 'demo',
+    tampermonkey: 'tampermonkey',
+    workers: 'workers'
 };
 const NON_SCRIPT_PNPM_COMMANDS = new Set([
     'add',
@@ -186,6 +192,42 @@ function stripCommandComment(command) {
     return command.replace(/\s+#.*$/, '').trim();
 }
 
+function normalizeShellToken(token) {
+    if (
+        (token.startsWith('"') && token.endsWith('"')) ||
+        (token.startsWith('\'') && token.endsWith('\''))
+    ) {
+        return token.slice(1, -1);
+    }
+
+    return token;
+}
+
+function tokenizeShellCommand(command) {
+    return (command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).map(normalizeShellToken);
+}
+
+function splitShellChain(command) {
+    return stripCommandComment(command)
+        .split(/\s*(?:&&|;)\s*/)
+        .map(segment => segment.trim())
+        .filter(Boolean);
+}
+
+function resolveWorkspaceDirectory(directoryValue, currentPackageKey) {
+    if (!directoryValue) {
+        return currentPackageKey;
+    }
+
+    const currentDirectory = WORKSPACE_DIRECTORIES[currentPackageKey] || '.';
+    const normalizedPath = path.posix
+        .normalize(path.posix.join(currentDirectory, directoryValue))
+        .replace(/\/+$/, '')
+        .replace(/^\.\//, '');
+
+    return resolveWorkspaceFilter(normalizedPath) || currentPackageKey;
+}
+
 function parsePnpmCommand(tokens, defaultPackageKey) {
     let packageKey = defaultPackageKey;
     let index = 1;
@@ -257,58 +299,103 @@ function parseNpmCommand(tokens, defaultPackageKey) {
 }
 
 export function parseDocumentedCommand(command, defaultPackageKey) {
+    return parseDocumentedCommands(command, defaultPackageKey)[0] || null;
+}
+
+export function parseDocumentedCommands(command, defaultPackageKey) {
+    const parsedCommands = [];
+    let activePackageKey = defaultPackageKey;
+
+    for (const segment of splitShellChain(command)) {
+        const tokens = tokenizeShellCommand(segment);
+
+        if (tokens.length === 0) {
+            continue;
+        }
+
+        if (tokens[0] === 'cd') {
+            activePackageKey = resolveWorkspaceDirectory(tokens[1], activePackageKey);
+            continue;
+        }
+
+        if (tokens[0] === 'pnpm') {
+            const parsed = parsePnpmCommand(tokens, activePackageKey);
+
+            if (parsed) {
+                parsedCommands.push(parsed);
+            }
+
+            continue;
+        }
+
+        if (tokens[0] === 'npm') {
+            const parsed = parseNpmCommand(tokens, activePackageKey);
+
+            if (parsed) {
+                parsedCommands.push(parsed);
+            }
+        }
+    }
+
+    return parsedCommands;
+}
+
+function addDocumentedCommand(commands, seen, command, line) {
     const normalizedCommand = stripCommandComment(command);
 
     if (!normalizedCommand) {
-        return null;
+        return;
     }
 
-    const tokens = normalizedCommand.split(/\s+/);
+    const key = `${line}:${normalizedCommand}`;
 
-    if (tokens[0] === 'pnpm') {
-        return parsePnpmCommand(tokens, defaultPackageKey);
+    if (seen.has(key)) {
+        return;
     }
 
-    if (tokens[0] === 'npm') {
-        return parseNpmCommand(tokens, defaultPackageKey);
-    }
-
-    return null;
+    seen.add(key);
+    commands.push({ command: normalizedCommand, line });
 }
 
 export function extractDocumentedCommands(content) {
     const commands = [];
     const seen = new Set();
     const lines = content.split(/\r?\n/);
+    let activeFence = null;
 
     lines.forEach((line, lineIndex) => {
         const trimmed = line.trim();
 
-        if (/^(pnpm|npm)\b/.test(trimmed)) {
-            const command = stripCommandComment(trimmed);
-            const key = `${lineIndex + 1}:${command}`;
+        const fenceMatch = trimmed.match(/^(```+|~~~+)/);
 
-            if (!seen.has(key)) {
-                seen.add(key);
-                commands.push({ command, line: lineIndex + 1 });
+        if (fenceMatch) {
+            const fenceMarker = fenceMatch[1];
+
+            if (!activeFence) {
+                activeFence = fenceMarker;
+            } else if (trimmed.startsWith(activeFence)) {
+                activeFence = null;
             }
+
+            return;
+        }
+
+        if (activeFence && /\b(?:pnpm|npm)\b/.test(trimmed)) {
+            addDocumentedCommand(commands, seen, trimmed, lineIndex + 1);
+        }
+
+        if (/^(?:pnpm|npm|cd)\b/.test(trimmed) && /\b(?:pnpm|npm)\b/.test(trimmed)) {
+            addDocumentedCommand(commands, seen, trimmed, lineIndex + 1);
         }
 
         for (const match of line.matchAll(/`([^`\n]+)`/g)) {
-            const command = stripCommandComment(match[1].trim());
+            const command = match[1].trim();
 
-            if (!/^(pnpm|npm)\b/.test(command)) {
+            if (!/\b(?:pnpm|npm)\b/.test(command)) {
                 continue;
             }
 
-            const key = `${lineIndex + 1}:${command}`;
-
-            if (seen.has(key)) {
-                continue;
-            }
-
-            seen.add(key);
-            commands.push({ command, line: lineIndex + 1 });
+            addDocumentedCommand(commands, seen, command, lineIndex + 1);
         }
     });
 
@@ -440,34 +527,30 @@ function checkCommandsInDocument(docPath, content, packages) {
     const defaultPackageKey = inferPackageKey(docPath);
 
     for (const entry of extractDocumentedCommands(content)) {
-        const parsed = parseDocumentedCommand(entry.command, defaultPackageKey);
+        for (const parsed of parseDocumentedCommands(entry.command, defaultPackageKey)) {
+            const packageState = packages[parsed.packageKey];
 
-        if (!parsed) {
-            continue;
-        }
+            if (!packageState) {
+                issues.push({
+                    kind: 'missing-script',
+                    file: docPath,
+                    line: entry.line,
+                    message: `Command "${entry.command}" targets unknown workspace "${parsed.packageKey}".`
+                });
+                continue;
+            }
 
-        const packageState = packages[parsed.packageKey];
+            if (packageState.scripts[parsed.scriptName]) {
+                continue;
+            }
 
-        if (!packageState) {
             issues.push({
                 kind: 'missing-script',
                 file: docPath,
                 line: entry.line,
-                message: `Command "${entry.command}" targets unknown workspace "${parsed.packageKey}".`
+                message: `Command "${entry.command}" references missing script "${parsed.scriptName}" in ${packageState.path}.`
             });
-            continue;
         }
-
-        if (packageState.scripts[parsed.scriptName]) {
-            continue;
-        }
-
-        issues.push({
-            kind: 'missing-script',
-            file: docPath,
-            line: entry.line,
-            message: `Command "${entry.command}" references missing script "${parsed.scriptName}" in ${packageState.path}.`
-        });
     }
 
     return issues;

--- a/scripts/check-doc-drift.mjs
+++ b/scripts/check-doc-drift.mjs
@@ -1,0 +1,549 @@
+#!/usr/bin/env node
+
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT_MARKDOWN_DIRECTORIES = ['.github', 'demo', 'docs', 'tampermonkey', 'workers'];
+const IGNORED_DIRECTORIES = new Set([
+    '.git',
+    '.review-audit-branch',
+    'coverage',
+    'node_modules',
+    'spec'
+]);
+const WORKSPACE_PACKAGE_PATHS = {
+    root: 'package.json',
+    demo: 'demo/package.json',
+    tampermonkey: 'tampermonkey/package.json',
+    workers: 'workers/package.json'
+};
+const NON_SCRIPT_PNPM_COMMANDS = new Set([
+    'add',
+    'approve-builds',
+    'audit',
+    'bin',
+    'config',
+    'create',
+    'deploy',
+    'dlx',
+    'env',
+    'exec',
+    'fetch',
+    'help',
+    'i',
+    'import',
+    'info',
+    'init',
+    'install',
+    'link',
+    'list',
+    'ln',
+    'outdated',
+    'pack',
+    'patch',
+    'patch-commit',
+    'prune',
+    'publish',
+    'remove',
+    'root',
+    'setup',
+    'store',
+    'unlink',
+    'update',
+    'up',
+    'why'
+]);
+const NON_SCRIPT_NPM_COMMANDS = new Set([
+    'access',
+    'adduser',
+    'audit',
+    'bin',
+    'cache',
+    'ci',
+    'config',
+    'dedupe',
+    'dist-tag',
+    'doctor',
+    'exec',
+    'explain',
+    'help',
+    'help-search',
+    'init',
+    'install',
+    'link',
+    'login',
+    'logout',
+    'ls',
+    'outdated',
+    'owner',
+    'pack',
+    'ping',
+    'prefix',
+    'profile',
+    'prune',
+    'publish',
+    'query',
+    'rebuild',
+    'repo',
+    'root',
+    'search',
+    'shrinkwrap',
+    'team',
+    'uninstall',
+    'unpublish',
+    'version',
+    'view',
+    'whoami'
+]);
+
+function compareIssues(left, right) {
+    return (
+        left.file.localeCompare(right.file) ||
+        (left.line ?? 0) - (right.line ?? 0) ||
+        left.kind.localeCompare(right.kind) ||
+        left.message.localeCompare(right.message)
+    );
+}
+
+async function pathExists(targetPath) {
+    try {
+        await access(targetPath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function cleanLinkTarget(rawTarget) {
+    const trimmed = rawTarget.trim();
+    const withoutAngles =
+        trimmed.startsWith('<') && trimmed.endsWith('>')
+            ? trimmed.slice(1, -1).trim()
+            : trimmed;
+    const match = withoutAngles.match(/^(\S+)(?:\s+["'][^"']*["'])?$/);
+
+    return match ? match[1] : withoutAngles;
+}
+
+function isIgnoredLinkTarget(target) {
+    return (
+        !target ||
+        target.startsWith('#') ||
+        /^[a-z][a-z0-9+.-]*:/i.test(target)
+    );
+}
+
+function stripLinkDecorators(target) {
+    return target.replace(/[?#].*$/, '');
+}
+
+function inferPackageKey(docPath) {
+    if (docPath.startsWith('demo/')) {
+        return 'demo';
+    }
+
+    if (docPath.startsWith('tampermonkey/')) {
+        return 'tampermonkey';
+    }
+
+    if (docPath.startsWith('workers/')) {
+        return 'workers';
+    }
+
+    return 'root';
+}
+
+function resolveWorkspaceFilter(filterValue) {
+    if (!filterValue) {
+        return null;
+    }
+
+    const normalized = filterValue
+        .replace(/\/+$/, '')
+        .replace(/^\.\//, '');
+
+    if (!normalized || normalized === '.') {
+        return 'root';
+    }
+
+    if (normalized === 'demo') {
+        return 'demo';
+    }
+
+    if (normalized === 'tampermonkey') {
+        return 'tampermonkey';
+    }
+
+    if (normalized === 'workers') {
+        return 'workers';
+    }
+
+    return null;
+}
+
+function stripCommandComment(command) {
+    return command.replace(/\s+#.*$/, '').trim();
+}
+
+function parsePnpmCommand(tokens, defaultPackageKey) {
+    let packageKey = defaultPackageKey;
+    let index = 1;
+
+    while (index < tokens.length) {
+        const token = tokens[index];
+
+        if (token === '--filter' || token === '-F') {
+            packageKey = resolveWorkspaceFilter(tokens[index + 1]) || packageKey;
+            index += 2;
+            continue;
+        }
+
+        if (token.startsWith('--filter=')) {
+            packageKey = resolveWorkspaceFilter(token.slice('--filter='.length)) || packageKey;
+            index += 1;
+            continue;
+        }
+
+        if (token.startsWith('-')) {
+            index += 1;
+            continue;
+        }
+
+        break;
+    }
+
+    const subcommand = tokens[index];
+
+    if (!subcommand) {
+        return null;
+    }
+
+    if (subcommand === 'run') {
+        const scriptName = tokens[index + 1];
+
+        return scriptName ? { packageKey, scriptName } : null;
+    }
+
+    if (NON_SCRIPT_PNPM_COMMANDS.has(subcommand)) {
+        return null;
+    }
+
+    return { packageKey, scriptName: subcommand };
+}
+
+function parseNpmCommand(tokens, defaultPackageKey) {
+    const subcommand = tokens[1];
+
+    if (!subcommand) {
+        return null;
+    }
+
+    if (subcommand === 'run') {
+        const scriptName = tokens[2];
+
+        return scriptName ? { packageKey: defaultPackageKey, scriptName } : null;
+    }
+
+    if (['restart', 'start', 'stop', 'test'].includes(subcommand)) {
+        return { packageKey: defaultPackageKey, scriptName: subcommand };
+    }
+
+    if (NON_SCRIPT_NPM_COMMANDS.has(subcommand)) {
+        return null;
+    }
+
+    return null;
+}
+
+export function parseDocumentedCommand(command, defaultPackageKey) {
+    const normalizedCommand = stripCommandComment(command);
+
+    if (!normalizedCommand) {
+        return null;
+    }
+
+    const tokens = normalizedCommand.split(/\s+/);
+
+    if (tokens[0] === 'pnpm') {
+        return parsePnpmCommand(tokens, defaultPackageKey);
+    }
+
+    if (tokens[0] === 'npm') {
+        return parseNpmCommand(tokens, defaultPackageKey);
+    }
+
+    return null;
+}
+
+export function extractDocumentedCommands(content) {
+    const commands = [];
+    const seen = new Set();
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, lineIndex) => {
+        const trimmed = line.trim();
+
+        if (/^(pnpm|npm)\b/.test(trimmed)) {
+            const command = stripCommandComment(trimmed);
+            const key = `${lineIndex + 1}:${command}`;
+
+            if (!seen.has(key)) {
+                seen.add(key);
+                commands.push({ command, line: lineIndex + 1 });
+            }
+        }
+
+        for (const match of line.matchAll(/`([^`\n]+)`/g)) {
+            const command = stripCommandComment(match[1].trim());
+
+            if (!/^(pnpm|npm)\b/.test(command)) {
+                continue;
+            }
+
+            const key = `${lineIndex + 1}:${command}`;
+
+            if (seen.has(key)) {
+                continue;
+            }
+
+            seen.add(key);
+            commands.push({ command, line: lineIndex + 1 });
+        }
+    });
+
+    return commands;
+}
+
+export function extractMarkdownTargets(content) {
+    const targets = [];
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, lineIndex) => {
+        for (const match of line.matchAll(/!?\[[^\]]*]\(([^)]+)\)/g)) {
+            targets.push({
+                line: lineIndex + 1,
+                target: cleanLinkTarget(match[1])
+            });
+        }
+    });
+
+    return targets;
+}
+
+async function loadJson(filePath) {
+    return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function loadWorkspacePackages(rootDir) {
+    const entries = await Promise.all(
+        Object.entries(WORKSPACE_PACKAGE_PATHS).map(async ([packageKey, relativePath]) => {
+            const absolutePath = path.join(rootDir, relativePath);
+            const data = await loadJson(absolutePath);
+
+            return [
+                packageKey,
+                {
+                    path: relativePath,
+                    version: String(data.version || ''),
+                    scripts: data.scripts || {}
+                }
+            ];
+        })
+    );
+
+    return Object.fromEntries(entries);
+}
+
+async function listRootMarkdownFiles(rootDir) {
+    const entries = await readdir(rootDir, { withFileTypes: true });
+
+    return entries
+        .filter(entry => entry.isFile() && entry.name.endsWith('.md'))
+        .map(entry => entry.name)
+        .sort((left, right) => left.localeCompare(right));
+}
+
+async function walkMarkdownDirectory(rootDir, directory) {
+    const absoluteDirectory = path.join(rootDir, directory);
+    const entries = await readdir(absoluteDirectory, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+        if (entry.isDirectory()) {
+            if (IGNORED_DIRECTORIES.has(entry.name)) {
+                continue;
+            }
+
+            const nestedDirectory = path.posix.join(directory, entry.name);
+            files.push(...await walkMarkdownDirectory(rootDir, nestedDirectory));
+            continue;
+        }
+
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+            files.push(path.posix.join(directory, entry.name));
+        }
+    }
+
+    return files;
+}
+
+export async function listMarkdownFiles(rootDir) {
+    const files = await listRootMarkdownFiles(rootDir);
+
+    for (const directory of ROOT_MARKDOWN_DIRECTORIES) {
+        const absoluteDirectory = path.join(rootDir, directory);
+
+        if (!await pathExists(absoluteDirectory)) {
+            continue;
+        }
+
+        files.push(...await walkMarkdownDirectory(rootDir, directory));
+    }
+
+    return files.sort((left, right) => left.localeCompare(right));
+}
+
+async function checkRelativeLinks(rootDir, docPath, content) {
+    const issues = [];
+
+    for (const link of extractMarkdownTargets(content)) {
+        if (isIgnoredLinkTarget(link.target)) {
+            continue;
+        }
+
+        const strippedTarget = stripLinkDecorators(link.target);
+
+        if (!strippedTarget) {
+            continue;
+        }
+
+        const resolvedPath = path.resolve(rootDir, path.dirname(docPath), strippedTarget);
+
+        if (await pathExists(resolvedPath)) {
+            continue;
+        }
+
+        issues.push({
+            kind: 'broken-link',
+            file: docPath,
+            line: link.line,
+            message: `Missing relative target "${link.target}".`
+        });
+    }
+
+    return issues;
+}
+
+function checkCommandsInDocument(docPath, content, packages) {
+    const issues = [];
+    const defaultPackageKey = inferPackageKey(docPath);
+
+    for (const entry of extractDocumentedCommands(content)) {
+        const parsed = parseDocumentedCommand(entry.command, defaultPackageKey);
+
+        if (!parsed) {
+            continue;
+        }
+
+        const packageState = packages[parsed.packageKey];
+
+        if (!packageState) {
+            issues.push({
+                kind: 'missing-script',
+                file: docPath,
+                line: entry.line,
+                message: `Command "${entry.command}" targets unknown workspace "${parsed.packageKey}".`
+            });
+            continue;
+        }
+
+        if (packageState.scripts[parsed.scriptName]) {
+            continue;
+        }
+
+        issues.push({
+            kind: 'missing-script',
+            file: docPath,
+            line: entry.line,
+            message: `Command "${entry.command}" references missing script "${parsed.scriptName}" in ${packageState.path}.`
+        });
+    }
+
+    return issues;
+}
+
+async function checkVersionTouchpoints(rootDir, packages) {
+    const issues = [];
+    const rootVersion = packages.root.version;
+    const userscriptPath = 'tampermonkey/goal_portfolio_viewer.user.js';
+    const userscriptContent = await readFile(path.join(rootDir, userscriptPath), 'utf8');
+    const metadataVersion = userscriptContent.match(/^\s*\/\/\s*@version\s+([^\s]+)\s*$/m)?.[1] || '';
+
+    if (packages.tampermonkey.version !== rootVersion) {
+        issues.push({
+            kind: 'version-mismatch',
+            file: WORKSPACE_PACKAGE_PATHS.tampermonkey,
+            message: `Version "${packages.tampermonkey.version}" does not match root package version "${rootVersion}".`
+        });
+    }
+
+    if (metadataVersion !== rootVersion) {
+        issues.push({
+            kind: 'version-mismatch',
+            file: userscriptPath,
+            message: `Userscript metadata version "${metadataVersion}" does not match root package version "${rootVersion}".`
+        });
+    }
+
+    return issues;
+}
+
+export async function checkDocDrift({ rootDir = process.cwd() } = {}) {
+    const packages = await loadWorkspacePackages(rootDir);
+    const files = await listMarkdownFiles(rootDir);
+    const issues = [];
+
+    for (const docPath of files) {
+        const absolutePath = path.join(rootDir, docPath);
+        const content = await readFile(absolutePath, 'utf8');
+
+        issues.push(...await checkRelativeLinks(rootDir, docPath, content));
+        issues.push(...checkCommandsInDocument(docPath, content, packages));
+    }
+
+    issues.push(...await checkVersionTouchpoints(rootDir, packages));
+    issues.sort(compareIssues);
+
+    return {
+        files,
+        issues
+    };
+}
+
+export function formatIssues(issues) {
+    return issues.map(issue => {
+        const location = issue.line ? `${issue.file}:${issue.line}` : issue.file;
+        return `- [${issue.kind}] ${location} ${issue.message}`;
+    }).join('\n');
+}
+
+async function main() {
+    const result = await checkDocDrift({ rootDir: process.cwd() });
+
+    if (result.issues.length === 0) {
+        console.log(`No documentation drift detected across ${result.files.length} markdown files.`);
+        return;
+    }
+
+    console.error('Documentation drift detected:\n');
+    console.error(formatIssues(result.issues));
+    process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+    main().catch(error => {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- add a deterministic doc drift detector for markdown links, documented scripts, and version touchpoints
- add node-based regression tests plus root package scripts and a path-scoped CI job
- fix detector-proven doc drift in TESTING.md and document the new contributor workflow

## Verification
- node --test scripts/__tests__/check-doc-drift.test.mjs
- node scripts/check-doc-drift.mjs
- pnpm run test:docs
- pnpm run doc:drift
- pnpm lint
- pnpm test