### PR TITLE
feat(fsm): show scoped allocation and drift in FSM table

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -338,6 +338,8 @@ The UI consists of:
 
 The modal overlay traps keyboard focus while open, supports `Esc` to close, restores focus to the triggering button, and applies dialog ARIA attributes to improve accessibility.
 
+On FSM holdings routes, the table includes per-row `Current %` and `Drift %` columns. Both values are computed against the currently selected scope/filter dataset so percentages match what is visible in the table at any time.
+
 ### Sync Conflict Review
 
 For FSM sync conflicts, the assignment step renders instrument-aware rows rather than opaque assignment IDs. The UI:

--- a/demo/e2e-tests.js
+++ b/demo/e2e-tests.js
@@ -459,7 +459,10 @@ async function captureFsmFlow(page, summary, outputDir) {
     }
 
     const tableHeaders = await page.$$eval('.gpv-table thead th', nodes => nodes.map(node => node.textContent || '').map(text => text.trim()));
-    const hasTableHeaders = tableHeaders.includes('Ticker') && tableHeaders.includes('Portfolio');
+    const hasTableHeaders = tableHeaders.includes('Ticker')
+        && tableHeaders.includes('Current %')
+        && tableHeaders.includes('Drift %')
+        && tableHeaders.includes('Portfolio');
     recordAssertion(summary, 'fsm-overlay', 'table-headers', hasTableHeaders, 'FSM table headers present.');
     if (!hasTableHeaders) {
         summary.status = 'failed';

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   "pnpm": {
     "overrides": {
       "ajv": "^6.14.0",
-      "minimatch": "^10.2.2",
-      "test-exclude": "^7.0.1"
+      "brace-expansion": "^5.0.5",
+      "flatted": "^3.4.2",
+      "minimatch": "^10.2.3",
+      "picomatch": "^2.3.2",
+      "test-exclude": "^7.0.1",
+      "undici": "^7.24.0"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,12 @@ settings:
 
 overrides:
   ajv: ^6.14.0
-  minimatch: ^10.2.2
+  brace-expansion: ^5.0.5
+  flatted: ^3.4.2
+  minimatch: ^10.2.3
+  picomatch: ^2.3.2
   test-exclude: ^7.0.1
+  undici: ^7.24.0
 
 importers:
 
@@ -37,8 +41,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.2.1)
       jsdom:
-        specifier: ^22.1.0
-        version: 22.1.0
+        specifier: ^24.1.3
+        version: 24.1.3
 
   workers:
     devDependencies:
@@ -50,6 +54,9 @@ importers:
         version: 4.63.0
 
 packages:
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -266,6 +273,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -743,10 +778,6 @@ packages:
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
-    engines: {node: '>= 10'}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -789,10 +820,6 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  abab@2.0.6:
-    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    deprecated: Use your platform's native atob() and btoa() methods instead
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -803,9 +830,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -883,9 +910,9 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  brace-expansion@5.0.2:
-    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
-    engines: {node: 20 || >=22}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -984,13 +1011,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cssstyle@3.0.0:
-    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
-    engines: {node: '>=14'}
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
-  data-urls@4.0.0:
-    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
-    engines: {node: '>=14'}
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1034,11 +1061,6 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  domexception@4.0.0:
-    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
-    engines: {node: '>=12'}
-    deprecated: Use your platform's native DOMException instead
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1194,8 +1216,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -1285,20 +1307,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  html-encoding-sniffer@3.0.0:
-    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
-    engines: {node: '>=12'}
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1536,11 +1558,11 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@22.1.0:
-    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
-    engines: {node: '>=16'}
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      canvas: ^2.5.0
+      canvas: ^2.11.2
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -1641,8 +1663,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  minimatch@10.2.2:
-    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minipass@7.1.2:
@@ -1745,8 +1767,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   pirates@4.0.7:
@@ -1835,8 +1857,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rrweb-cssom@0.6.0:
-    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1960,9 +1985,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
-  tr46@4.1.1:
-    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
-    engines: {node: '>=14'}
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1982,8 +2007,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2009,9 +2034,9 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -2020,18 +2045,18 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  whatwg-encoding@2.0.0:
-    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
-    engines: {node: '>=12'}
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
-  whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
-  whatwg-url@12.0.1:
-    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
-    engines: {node: '>=14'}
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2096,9 +2121,9 @@ packages:
       utf-8-validate:
         optional: true
 
-  xml-name-validator@4.0.0:
-    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
-    engines: {node: '>=12'}
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -2129,6 +2154,14 @@ packages:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2348,6 +2381,26 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
@@ -2442,7 +2495,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.2
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2463,7 +2516,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 10.2.2
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -2818,8 +2871,6 @@ snapshots:
 
   '@speed-highlight/core@1.2.14': {}
 
-  '@tootallnate/once@2.0.0': {}
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -2871,19 +2922,13 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  abab@2.0.6: {}
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
+  agent-base@7.1.4: {}
 
   ajv@6.14.0:
     dependencies:
@@ -2911,7 +2956,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -2982,7 +3027,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  brace-expansion@5.0.2:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.3
 
@@ -3087,15 +3132,15 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cssstyle@3.0.0:
+  cssstyle@4.6.0:
     dependencies:
-      rrweb-cssom: 0.6.0
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
-  data-urls@4.0.0:
+  data-urls@5.0.0:
     dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 12.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.3:
     dependencies:
@@ -3116,10 +3161,6 @@ snapshots:
   detect-newline@3.1.0: {}
 
   diff-sequences@29.6.3: {}
-
-  domexception@4.0.0:
-    dependencies:
-      webidl-conversions: 7.0.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3237,7 +3278,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 10.2.2
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -3315,10 +3356,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -3377,7 +3418,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 10.2.2
+      minimatch: 10.2.5
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -3387,7 +3428,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 10.2.2
+      minimatch: 10.2.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -3409,23 +3450,22 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  html-encoding-sniffer@3.0.0:
+  html-encoding-sniffer@4.0.0:
     dependencies:
-      whatwg-encoding: 2.0.0
+      whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@7.0.2:
     dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@7.0.6:
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -3795,7 +3835,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   jest-validate@29.7.0:
     dependencies:
@@ -3847,31 +3887,29 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@22.1.0:
+  jsdom@24.1.3:
     dependencies:
-      abab: 2.0.6
-      cssstyle: 3.0.0
-      data-urls: 4.0.0
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
       decimal.js: 10.6.0
-      domexception: 4.0.0
       form-data: 4.0.5
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
-      rrweb-cssom: 0.6.0
+      rrweb-cssom: 0.7.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 4.1.4
-      w3c-xmlserializer: 4.0.0
+      w3c-xmlserializer: 5.0.0
       webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 12.0.1
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
       ws: 8.19.0
-      xml-name-validator: 4.0.0
+      xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3937,7 +3975,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -3951,7 +3989,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.18.2
+      undici: 7.25.0
       workerd: 1.20260205.0
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -3959,9 +3997,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  minimatch@10.2.2:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.2
+      brace-expansion: 5.0.5
 
   minipass@7.1.2: {}
 
@@ -4052,7 +4090,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   pirates@4.0.7: {}
 
@@ -4121,7 +4159,9 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rrweb-cssom@0.6.0: {}
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -4240,7 +4280,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 10.2.2
+      minimatch: 10.2.5
 
   tmpl@1.0.5: {}
 
@@ -4255,7 +4295,7 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
-  tr46@4.1.1:
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
@@ -4272,7 +4312,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.18.2: {}
+  undici@7.25.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -4301,9 +4341,9 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  w3c-xmlserializer@4.0.0:
+  w3c-xmlserializer@5.0.0:
     dependencies:
-      xml-name-validator: 4.0.0
+      xml-name-validator: 5.0.0
 
   walker@1.0.8:
     dependencies:
@@ -4311,15 +4351,15 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  whatwg-encoding@2.0.0:
+  whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
-  whatwg-mimetype@3.0.0: {}
+  whatwg-mimetype@4.0.0: {}
 
-  whatwg-url@12.0.1:
+  whatwg-url@14.2.0:
     dependencies:
-      tr46: 4.1.1
+      tr46: 5.1.1
       webidl-conversions: 7.0.0
 
   which@2.0.2:
@@ -4375,7 +4415,7 @@ snapshots:
 
   ws@8.19.0: {}
 
-  xml-name-validator@4.0.0: {}
+  xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -301,6 +301,10 @@ Contributions are welcome! To contribute:
 
 ## Changelog
 
+### Version 2.14.2
+- Added FSM table columns for scoped current allocation percentage and per-holding drift percentage
+- Updated FSM table and E2E checks to verify the new allocation/drift columns
+
 ### Version 2.14.1
 - Improved FSM sync conflict assignment readability with instrument names and richer assignment context
 

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -485,6 +485,11 @@ describe('initialization and URL monitoring', () => {
         expect(overlay.textContent).not.toContain('Endowus Only Goal');
         expect(overlay.querySelector('.gpv-select')).toBeTruthy();
         expect(overlay.textContent).toContain('Product Type');
+        expect(overlay.textContent).toContain('Current %');
+        expect(overlay.textContent).toContain('Drift %');
+        const firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
+        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('-');
     });
 
     test('showOverlay on FSM route alerts when FSM holdings are unavailable', () => {
@@ -789,6 +794,73 @@ describe('initialization and URL monitoring', () => {
         overlay = document.querySelector('#gpv-overlay');
         expect(overlay.textContent).toContain('Enter target between 0 and 100');
         expect(storage.has('fsm_target_pct_AAA')).toBe(false);
+    });
+
+    test('FSM row allocation and drift use selected scope totals', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 },
+            { code: 'BBB', subcode: 'BOND', name: 'Fund B', productType: 'UNIT_TRUST', currentValueLcy: 800 }
+        ]));
+        storage.set('fsm_target_pct_AAA', 60);
+        storage.set('fsm_portfolios', JSON.stringify([
+            { id: 'core', name: 'Core', archived: false }
+        ]));
+        storage.set('fsm_assignment_by_code', JSON.stringify({ AAA: 'core', BBB: 'unassigned' }));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        let firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
+        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
+        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('0.00%');
+
+        const scopeToolbar = Array.from(overlay.querySelectorAll('.gpv-fsm-toolbar')).find(toolbar =>
+            toolbar.querySelector('input.gpv-target-input')
+        );
+        const scopeSelect = scopeToolbar.querySelector('select.gpv-select');
+        scopeSelect.value = 'core';
+        scopeSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+        overlay = document.querySelector('#gpv-overlay');
+        firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
+        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
+        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('66.67%');
     });
 
 });

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -847,7 +847,8 @@ describe('initialization and URL monitoring', () => {
         let firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
-        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('0.00%');
+        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('0.00% (SGD\u00A00.00)');
+        expect(firstRow.querySelector('td[data-col="drift"]').className).toContain('gpv-drift--green');
 
         const scopeToolbar = Array.from(overlay.querySelectorAll('.gpv-fsm-toolbar')).find(toolbar =>
             toolbar.querySelector('input.gpv-target-input')
@@ -860,7 +861,15 @@ describe('initialization and URL monitoring', () => {
         firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
-        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('66.67%');
+        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('+66.67% (+SGD\u00A0480.00)');
+        expect(firstRow.querySelector('td[data-col="drift"]').className).toContain('gpv-drift--red');
+
+        const driftSummaryCard = Array.from(overlay.querySelectorAll('.gpv-summary-card')).find(card =>
+            card.textContent.includes('Drift:')
+        );
+        expect(driftSummaryCard).toBeTruthy();
+        expect(driftSummaryCard.textContent).toContain('66.67%');
+        expect(driftSummaryCard.className).toContain('gpv-drift--red');
     });
 
 });

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -486,10 +486,10 @@ describe('initialization and URL monitoring', () => {
         expect(overlay.querySelector('.gpv-select')).toBeTruthy();
         expect(overlay.textContent).toContain('Product Type');
         expect(overlay.textContent).toContain('Current %');
-        expect(overlay.textContent).toContain('Drift %');
+        expect(overlay.textContent).not.toContain('Drift %');
         const firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
-        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('-');
+        expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
     });
 
     test('showOverlay on FSM route alerts when FSM holdings are unavailable', () => {
@@ -847,8 +847,7 @@ describe('initialization and URL monitoring', () => {
         let firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
-        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('0.00% (SGD\u00A00.00)');
-        expect(firstRow.querySelector('td[data-col="drift"]').className).toContain('gpv-drift--green');
+        expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
 
         const scopeToolbar = Array.from(overlay.querySelectorAll('.gpv-fsm-toolbar')).find(toolbar =>
             toolbar.querySelector('input.gpv-target-input')

--- a/tampermonkey/__tests__/uiModels.test.js
+++ b/tampermonkey/__tests__/uiModels.test.js
@@ -52,12 +52,16 @@ describe('format helpers', () => {
         const diffInfo = calculateGoalDiff(1200, 60, 2500);
         expect(diffInfo.diffClass).toBe('negative');
         expect(diffInfo.diffAmount).toBe(-300);
+        expect(diffInfo.driftPercent).toBeCloseTo(-0.2, 5);
+        expect(diffInfo.driftAmount).toBe(-300);
     });
 
     test('should handle invalid goal diff inputs', () => {
         expect(calculateGoalDiff(100, null, 200)).toEqual({
             diffAmount: null,
-            diffClass: ''
+            diffClass: '',
+            driftPercent: null,
+            driftAmount: null
         });
     });
 
@@ -143,6 +147,7 @@ describe('view model builders', () => {
         expect(retirement.goalTypes[0].goalType).toBe('GENERAL_WEALTH_ACCUMULATION');
         expect(retirement.goalTypes[1].returnClass).toBe('negative');
         expect(retirement.goalTypes[0].allocationDriftDisplay).toBe('20.00%');
+        expect(retirement.goalTypes[0].allocationDriftClass).toBe('gpv-drift--green');
     });
 
     test('should build bucket detail view model with projections', () => {
@@ -168,11 +173,14 @@ describe('view model builders', () => {
         expect(goalTypeModel.remainingTargetDisplay).toBe('12.00%');
         expect(goalTypeModel.remainingTargetIsHigh).toBe(true);
         expect(goalTypeModel.allocationDriftDisplay).toBe('20.00%');
+        expect(goalTypeModel.allocationDriftClass).toBe('gpv-drift--green');
         const firstGoal = goalTypeModel.goals[0];
         expect(firstGoal.percentOfType).toBe(60);
         expect(firstGoal.diffDisplay).toMatch(/0\.00/);
         expect(firstGoal.targetDisplay).toBe('48.00');
         expect(firstGoal.isFixed).toBe(true);
+        expect(firstGoal.driftDisplay).toBe('0.00% (SGD\u00A00.00)');
+        expect(firstGoal.driftClass).toBe('gpv-drift--green');
     });
 
     test('should map per-goal window returns with fallback', () => {
@@ -331,6 +339,7 @@ describe('view model builders', () => {
         expect(missingGoal.targetDisplay).toBe('');
         expect(missingGoal.diffDisplay).toBe('-');
         expect(goalTypeModel.allocationDriftDisplay).toBe('-');
+        expect(goalTypeModel.allocationDriftClass).toBe('');
         expect(goalTypeModel.allocationDriftAvailable).toBe(false);
     });
 
@@ -379,6 +388,7 @@ describe('buildAllocationDriftModel', () => {
         const model = buildAllocationDriftModel(goalModels, 2500);
         expect(model.allocationDriftPercent).toBeCloseTo(0.4, 5);
         expect(model.allocationDriftDisplay).toBe('40.00%');
+        expect(model.allocationDriftClass).toBe('gpv-drift--yellow');
         expect(model.allocationDriftAvailable).toBe(true);
     });
 
@@ -390,6 +400,7 @@ describe('buildAllocationDriftModel', () => {
         const model = buildAllocationDriftModel(goalModels, 1000);
         expect(model.allocationDriftPercent).toBeCloseTo(2, 5);
         expect(model.allocationDriftDisplay).toBe('200.00%');
+        expect(model.allocationDriftClass).toBe('gpv-drift--red');
     });
 
     test('should skip non-positive target amounts', () => {
@@ -399,6 +410,7 @@ describe('buildAllocationDriftModel', () => {
         const model = buildAllocationDriftModel(goalModels, 1000);
         expect(model.allocationDriftPercent).toBe(0);
         expect(model.allocationDriftDisplay).toBe('0.00%');
+        expect(model.allocationDriftClass).toBe('gpv-drift--green');
         expect(model.allocationDriftAvailable).toBe(true);
     });
 
@@ -406,11 +418,13 @@ describe('buildAllocationDriftModel', () => {
         expect(buildAllocationDriftModel([], 1000)).toEqual({
             allocationDriftPercent: null,
             allocationDriftDisplay: '-',
+            allocationDriftClass: '',
             allocationDriftAvailable: false
         });
         expect(buildAllocationDriftModel([{ endingBalanceAmount: 100, targetPercent: 50 }], 0)).toEqual({
             allocationDriftPercent: null,
             allocationDriftDisplay: '-',
+            allocationDriftClass: '',
             allocationDriftAvailable: false
         });
     });

--- a/tampermonkey/__tests__/utils.test.js
+++ b/tampermonkey/__tests__/utils.test.js
@@ -473,25 +473,36 @@ describe('formatGrowthPercentFromEndingBalance', () => {
 
 describe('calculateGoalDiff', () => {
     test('should return null diff when target is missing', () => {
-        expect(calculateGoalDiff(1000, null, 2000)).toEqual({ diffAmount: null, diffClass: '' });
+        expect(calculateGoalDiff(1000, null, 2000)).toEqual({
+            diffAmount: null,
+            diffClass: '',
+            driftPercent: null,
+            driftAmount: null
+        });
     });
 
     test('should calculate diff and class when within threshold', () => {
         const result = calculateGoalDiff(1000, 50, 2000);
         expect(result.diffAmount).toBe(0);
         expect(result.diffClass).toBe('positive');
+        expect(result.driftPercent).toBe(0);
+        expect(result.driftAmount).toBe(0);
     });
 
     test('should mark diff as negative when over threshold', () => {
         const result = calculateGoalDiff(1000, 80, 2000);
         expect(result.diffAmount).toBe(-600);
         expect(result.diffClass).toBe('negative');
+        expect(result.driftPercent).toBeCloseTo(-0.375, 5);
+        expect(result.driftAmount).toBe(-600);
     });
 
     test('should mark diff as positive when at threshold', () => {
         const result = calculateGoalDiff(1000, 95, 1000);
         expect(result.diffAmount).toBe(50);
         expect(result.diffClass).toBe('positive');
+        expect(result.driftPercent).toBeCloseTo(0.0526315789, 5);
+        expect(result.driftAmount).toBe(50);
     });
 
     test('should handle zero or negative current amounts', () => {
@@ -505,7 +516,12 @@ describe('calculateGoalDiff', () => {
     });
 
     test('should return null diff for invalid totals', () => {
-        expect(calculateGoalDiff(1000, 10, 0)).toEqual({ diffAmount: null, diffClass: '' });
+        expect(calculateGoalDiff(1000, 10, 0)).toEqual({
+            diffAmount: null,
+            diffClass: '',
+            driftPercent: null,
+            driftAmount: null
+        });
     });
 });
 
@@ -1778,4 +1794,3 @@ describe('buildMergedInvestmentData', () => {
         expect(result.Retirement.GENERAL_WEALTH_ACCUMULATION.goals).toHaveLength(2); // Both goals present
     });
 });
-

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -5263,6 +5263,22 @@ let GoalTargetStore;
         return span;
     }
 
+    function applySelectContentWidth(selectElement, options = {}) {
+        if (!selectElement || typeof selectElement.options === 'undefined') {
+            return;
+        }
+        const minCh = Number.isFinite(options.minCh) ? options.minCh : 12;
+        const maxCh = Number.isFinite(options.maxCh) ? options.maxCh : 28;
+        const paddingCh = Number.isFinite(options.paddingCh) ? options.paddingCh : 4;
+        const longestOptionLength = Array.from(selectElement.options).reduce((maxLength, option) => {
+            const text = utils.normalizeString(option?.text, '');
+            return Math.max(maxLength, text.length);
+        }, 0);
+        const widthCh = Math.min(maxCh, Math.max(minCh, longestOptionLength + paddingCh));
+        selectElement.style.width = `${widthCh}ch`;
+        selectElement.style.maxWidth = `${maxCh}ch`;
+    }
+
     const FOCUSABLE_SELECTOR = [
         'a[href]',
         'button',
@@ -9243,6 +9259,10 @@ syncUi.update = function updateSyncUI() {
                     gap: 6px;
                 }
 
+                .gpv-fsm-table-portfolio-select {
+                    min-width: 0;
+                }
+
                 /* Sync Indicator */
                 .gpv-sync-indicator {
                     position: fixed;
@@ -9949,13 +9969,14 @@ syncUi.update = function updateSyncUI() {
                 tbody.appendChild(tr);
                 return;
             }
-            const select = createElement('select', 'gpv-select');
+            const select = createElement('select', 'gpv-select gpv-fsm-table-portfolio-select');
             select.innerHTML = [
                 { id: FSM_UNASSIGNED_PORTFOLIO_ID, label: 'Unassigned' },
                 ...activePortfolios.map(item => ({ id: item.id, label: item.name }))
             ].map(option => `
                 <option value="${escapeHtml(option.id)}">${escapeHtml(option.label)}</option>
             `).join('');
+            applySelectContentWidth(select, { minCh: 12, maxCh: 26, paddingCh: 4 });
             select.value = row.portfolioId;
             select.onchange = () => {
                 if (typeof onPortfolioChange === 'function') {

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -325,6 +325,45 @@
         return `${sign}${percentValue.toFixed(2)}%`;
     }
 
+    function formatSignedMoney(value) {
+        const numericValue = toFiniteNumber(value, null);
+        if (numericValue === null) {
+            return '-';
+        }
+        const money = formatMoney(numericValue);
+        if (money === '-') {
+            return '-';
+        }
+        return numericValue > 0 ? `+${money}` : money;
+    }
+
+    function getDriftSeverityClass(driftRatio) {
+        const numericDrift = toFiniteNumber(driftRatio, null);
+        if (numericDrift === null) {
+            return '';
+        }
+        const magnitude = Math.abs(numericDrift);
+        if (magnitude <= 0.25) {
+            return 'gpv-drift--green';
+        }
+        if (magnitude <= 0.5) {
+            return 'gpv-drift--yellow';
+        }
+        return 'gpv-drift--red';
+    }
+
+    function formatDriftDisplay(driftPercent, driftAmount) {
+        const percentDisplay = formatPercent(driftPercent, {
+            multiplier: 100,
+            showSign: true
+        });
+        const amountDisplay = formatSignedMoney(driftAmount);
+        if (percentDisplay === '-' || amountDisplay === '-') {
+            return '-';
+        }
+        return `${percentDisplay} (${amountDisplay})`;
+    }
+
     function getFiniteNumbers(values) {
         const numbers = values.map(value => toFiniteNumber(value, null));
         return numbers.some(value => value === null) ? null : numbers;
@@ -423,23 +462,29 @@
 
     function calculateGoalDiff(currentAmount, targetPercent, adjustedTypeTotal) {
         if (targetPercent === null || targetPercent === undefined) {
-            return { diffAmount: null, diffClass: '' };
+            return { diffAmount: null, diffClass: '', driftPercent: null, driftAmount: null };
         }
         const numericValues = getFiniteNumbers([currentAmount, targetPercent, adjustedTypeTotal]);
         if (!numericValues) {
-            return { diffAmount: null, diffClass: '' };
+            return { diffAmount: null, diffClass: '', driftPercent: null, driftAmount: null };
         }
         const [numericCurrent, numericTarget, numericTotal] = numericValues;
         if (numericTotal <= 0) {
-            return { diffAmount: null, diffClass: '' };
+            return { diffAmount: null, diffClass: '', driftPercent: null, driftAmount: null };
         }
         const targetAmount = (numericTarget / 100) * numericTotal;
+        if (!Number.isFinite(targetAmount) || targetAmount <= 0) {
+            return { diffAmount: null, diffClass: '', driftPercent: null, driftAmount: null };
+        }
         const diffAmount = numericCurrent - targetAmount;
+        const driftPercent = diffAmount / targetAmount;
         const threshold = numericCurrent * 0.05;
         const diffClass = Math.abs(diffAmount) > threshold ? 'negative' : 'positive';
         return {
             diffAmount,
-            diffClass
+            diffClass,
+            driftPercent: Number.isFinite(driftPercent) ? driftPercent : null,
+            driftAmount: Number.isFinite(diffAmount) ? diffAmount : null
         };
     }
 
@@ -449,6 +494,7 @@
             return {
                 allocationDriftPercent: null,
                 allocationDriftDisplay: '-',
+                allocationDriftClass: '',
                 allocationDriftAvailable: false
             };
         }
@@ -457,6 +503,7 @@
             return {
                 allocationDriftPercent: null,
                 allocationDriftDisplay: '-',
+                allocationDriftClass: '',
                 allocationDriftAvailable: false
             };
         }
@@ -468,6 +515,7 @@
             return {
                 allocationDriftPercent: null,
                 allocationDriftDisplay: '-',
+                allocationDriftClass: '',
                 allocationDriftAvailable: false
             };
         }
@@ -478,6 +526,7 @@
             return {
                 allocationDriftPercent: null,
                 allocationDriftDisplay: '-',
+                allocationDriftClass: '',
                 allocationDriftAvailable: false
             };
         }
@@ -503,6 +552,7 @@
         return {
             allocationDriftPercent: driftSum,
             allocationDriftDisplay: formatPercent(driftSum, { multiplier: 100, showSign: false }),
+            allocationDriftClass: getDriftSeverityClass(driftSum),
             allocationDriftAvailable: true
         };
     }
@@ -652,6 +702,8 @@
             targetPercent,
             diffAmount: diffInfo.diffAmount,
             diffClass: diffInfo.diffClass,
+            driftPercent: diffInfo.driftPercent,
+            driftAmount: diffInfo.driftAmount,
             returnValue,
             returnPercent
         };
@@ -694,7 +746,9 @@
                 return {
                     ...goal,
                     diffAmount: diffInfo.diffAmount,
-                    diffClass: diffInfo.diffClass
+                    diffClass: diffInfo.diffClass,
+                    driftPercent: diffInfo.driftPercent,
+                    driftAmount: diffInfo.driftAmount
                 };
             });
         }
@@ -704,6 +758,7 @@
             remainingTargetPercent: adjustedRemainingTargetPercent,
             allocationDriftPercent: allocationDriftModel.allocationDriftPercent,
             allocationDriftDisplay: allocationDriftModel.allocationDriftDisplay,
+            allocationDriftClass: allocationDriftModel.allocationDriftClass,
             allocationDriftAvailable: allocationDriftModel.allocationDriftAvailable
         };
     }
@@ -856,6 +911,7 @@
                                 ),
                                 returnClass: getReturnClass(typeReturn),
                                 allocationDriftDisplay: allocationModel.allocationDriftDisplay,
+                                allocationDriftClass: allocationModel.allocationDriftClass,
                                 allocationDriftAvailable: allocationModel.allocationDriftAvailable
                             };
                         })
@@ -948,6 +1004,7 @@ function buildBucketDetailGoalTypeModel({ goalType, group, projectedAmount, allo
         remainingTargetDisplay: formatPercent(allocationModel.remainingTargetPercent),
         remainingTargetIsHigh: isRemainingTargetAboveThreshold(allocationModel.remainingTargetPercent),
         allocationDriftDisplay: allocationModel.allocationDriftDisplay,
+        allocationDriftClass: allocationModel.allocationDriftClass,
         allocationDriftAvailable: allocationModel.allocationDriftAvailable,
         goalModelsById: allocationModel.goalModelsById,
         goals: allocationModel.goalModels.map(goal => buildBucketDetailGoalRow(goal))
@@ -963,6 +1020,8 @@ function buildBucketDetailGoalRow(goal) {
         percentOfTypeDisplay: formatPercent(goal.percentOfType),
         targetDisplay: goal.targetPercent !== null ? goal.targetPercent.toFixed(2) : '',
         diffDisplay: goal.diffAmount === null ? '-' : formatMoney(goal.diffAmount),
+        driftDisplay: formatDriftDisplay(goal.driftPercent, goal.driftAmount),
+        driftClass: getDriftSeverityClass(goal.driftPercent),
         returnDisplay: formatMoney(goal.returnValue),
         returnPercentDisplay: formatPercent(goal.returnPercent, { multiplier: 100, showSign: false }),
         returnClass: getReturnClass(goal.returnValue),
@@ -5611,6 +5670,7 @@ let GoalTargetStore;
         headerRow.appendChild(targetHeader);
 
         headerRow.appendChild(createElement('th', 'gpv-column-diff', 'Diff'));
+        headerRow.appendChild(createElement('th', 'gpv-column-drift', 'Drift'));
         headerRow.appendChild(createElement('th', 'gpv-column-return', 'Cumulative Return'));
         headerRow.appendChild(createElement('th', 'gpv-column-return-percent', 'Return %'));
 
@@ -5656,6 +5716,10 @@ let GoalTargetStore;
                 ? `${CLASS_NAMES.diffCell} gpv-column-diff ${goalModel.diffClass}`
                 : `${CLASS_NAMES.diffCell} gpv-column-diff`;
             tr.appendChild(createElement('td', diffClassName, goalModel.diffDisplay));
+            const driftClassName = goalModel.driftClass
+                ? `gpv-column-drift ${goalModel.driftClass}`
+                : 'gpv-column-drift';
+            tr.appendChild(createElement('td', driftClassName, goalModel.driftDisplay));
             const returnClassName = goalModel.returnClass
                 ? `${goalModel.returnClass} gpv-column-return`
                 : 'gpv-column-return';
@@ -5811,7 +5875,8 @@ let GoalTargetStore;
                     typeRow,
                     'gpv-goal-type-stat',
                     'Allocation Drift:',
-                    goalTypeModel.allocationDriftDisplay
+                    goalTypeModel.allocationDriftDisplay,
+                    { valueClass: goalTypeModel.allocationDriftClass || null }
                 );
                 bucketCard.appendChild(typeRow);
             });
@@ -5885,7 +5950,13 @@ let GoalTargetStore;
             appendLabeledValue(typeSummary, null, 'Balance:', goalTypeModel.endingBalanceDisplay);
             appendLabeledValue(typeSummary, null, 'Return:', goalTypeModel.returnDisplay);
             appendLabeledValue(typeSummary, null, 'Growth:', typeGrowth);
-            appendLabeledValue(typeSummary, null, 'Allocation Drift:', goalTypeModel.allocationDriftDisplay);
+            appendLabeledValue(
+                typeSummary,
+                null,
+                'Allocation Drift:',
+                goalTypeModel.allocationDriftDisplay,
+                { valueClass: goalTypeModel.allocationDriftClass || null }
+            );
             typeHeader.appendChild(typeTitle);
             typeHeader.appendChild(typeSummary);
 
@@ -6021,6 +6092,7 @@ let GoalTargetStore;
         rows.forEach(row => {
             const targetInput = row.querySelector(`.${CLASS_NAMES.targetInput}`);
             const diffCell = row.querySelector(`.${CLASS_NAMES.diffCell}`);
+            const driftCell = row.querySelector('.gpv-column-drift');
             if (!targetInput) {
                 return;
             }
@@ -6039,6 +6111,11 @@ let GoalTargetStore;
                 diffCell.className = goalModel.diffClass
                     ? `${CLASS_NAMES.diffCell} ${goalModel.diffClass}`
                     : CLASS_NAMES.diffCell;
+            }
+            if (driftCell) {
+                driftCell.textContent = formatDriftDisplay(goalModel.driftPercent, goalModel.driftAmount);
+                const driftClass = getDriftSeverityClass(goalModel.driftPercent);
+                driftCell.className = driftClass ? `gpv-column-drift ${driftClass}` : 'gpv-column-drift';
             }
         });
     }
@@ -7977,6 +8054,33 @@ syncUi.update = function updateSyncUI() {
                 color: #4b5563;
                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             }
+
+            .gpv-goal-type-stat .gpv-drift--green,
+            .gpv-type-summary .gpv-drift--green,
+            .gpv-column-drift.gpv-drift--green,
+            .gpv-summary-card.gpv-drift--green,
+            .gpv-table .gpv-drift--green {
+                color: #059669;
+                font-weight: 700;
+            }
+
+            .gpv-goal-type-stat .gpv-drift--yellow,
+            .gpv-type-summary .gpv-drift--yellow,
+            .gpv-column-drift.gpv-drift--yellow,
+            .gpv-summary-card.gpv-drift--yellow,
+            .gpv-table .gpv-drift--yellow {
+                color: #b45309;
+                font-weight: 700;
+            }
+
+            .gpv-goal-type-stat .gpv-drift--red,
+            .gpv-type-summary .gpv-drift--red,
+            .gpv-column-drift.gpv-drift--red,
+            .gpv-summary-card.gpv-drift--red,
+            .gpv-table .gpv-drift--red {
+                color: #dc2626;
+                font-weight: 700;
+            }
             
             /* Detail View Styles */
             
@@ -8138,6 +8242,7 @@ syncUi.update = function updateSyncUI() {
             .gpv-mode-performance .gpv-column-fixed,
             .gpv-mode-performance .gpv-column-target,
             .gpv-mode-performance .gpv-column-diff,
+            .gpv-mode-performance .gpv-column-drift,
             .gpv-mode-performance .gpv-projection-panel,
             .gpv-mode-performance .gpv-section-toggle--projection {
                 display: none;
@@ -9435,13 +9540,14 @@ syncUi.update = function updateSyncUI() {
         const targetPercentTotal = activeRows.reduce((sum, row) => sum + (Number(row.targetPercent) || 0), 0);
         const totalDrift = activeRows.reduce((sum, row) => {
             const rowDrift = calculateFsmRowDrift(total, row);
-            return sum + (Number.isFinite(rowDrift) ? rowDrift : 0);
+            return sum + (Number.isFinite(rowDrift?.driftPercent) ? Math.abs(rowDrift.driftPercent) : 0);
         }, 0);
         return {
             total,
             actualWeightDisplay: formatPercent(1, { multiplier: 100, showSign: false }),
             targetWeightDisplay: formatPercent(targetPercentTotal / 100, { multiplier: 100, showSign: false }),
             driftDisplay: formatPercent(totalDrift, { multiplier: 100, showSign: false }),
+            driftClass: getDriftSeverityClass(totalDrift),
             suggestionDisplay: formatMoney(0)
         };
     }
@@ -9509,14 +9615,23 @@ syncUi.update = function updateSyncUI() {
             return null;
         }
         const currentValue = toFiniteNumber(row?.currentValueLcy, 0);
-        const drift = Math.abs(targetAmount - currentValue) / targetAmount;
-        return Number.isFinite(drift) ? drift : null;
+        const driftAmount = currentValue - targetAmount;
+        const driftPercent = driftAmount / targetAmount;
+        if (!Number.isFinite(driftPercent) || !Number.isFinite(driftAmount)) {
+            return null;
+        }
+        return {
+            driftPercent,
+            driftAmount
+        };
     }
 
     function buildFsmDisplayRows(rows, total) {
         return (Array.isArray(rows) ? rows : []).map(row => {
             const currentAllocationPercent = calculateFsmCurrentAllocation(total, row);
-            const driftPercent = calculateFsmRowDrift(total, row);
+            const driftModel = calculateFsmRowDrift(total, row);
+            const driftPercent = driftModel?.driftPercent ?? null;
+            const driftAmount = driftModel?.driftAmount ?? null;
             return {
                 ...row,
                 currentAllocationPercent,
@@ -9525,10 +9640,9 @@ syncUi.update = function updateSyncUI() {
                     showSign: false
                 }),
                 driftPercent,
-                driftDisplay: formatPercent(driftPercent, {
-                    multiplier: 100,
-                    showSign: false
-                })
+                driftAmount,
+                driftDisplay: formatDriftDisplay(driftPercent, driftAmount),
+                driftClass: getDriftSeverityClass(driftPercent)
             };
         });
     }
@@ -9659,11 +9773,14 @@ syncUi.update = function updateSyncUI() {
 
     function buildFsmSummaryRow(summary) {
         const summaryRow = createElement('div', 'gpv-summary-row');
+        const driftClassName = summary?.driftClass
+            ? `gpv-summary-card ${summary.driftClass}`
+            : 'gpv-summary-card';
         summaryRow.innerHTML = `
             <div class="gpv-summary-card"><strong>Total Value:</strong> ${escapeHtml(formatMoney(summary.total))}</div>
             <div class="gpv-summary-card"><strong>Actual:</strong> ${escapeHtml(summary.actualWeightDisplay)}</div>
             <div class="gpv-summary-card"><strong>Target:</strong> ${escapeHtml(summary.targetWeightDisplay)}</div>
-            <div class="gpv-summary-card"><strong>Drift:</strong> ${escapeHtml(summary.driftDisplay)}</div>
+            <div class="${escapeHtml(driftClassName)}"><strong>Drift:</strong> ${escapeHtml(summary.driftDisplay)}</div>
             <div class="gpv-summary-card"><strong>Suggestion:</strong> ${escapeHtml(summary.suggestionDisplay)}</div>
         `;
         return summaryRow;
@@ -9801,7 +9918,7 @@ syncUi.update = function updateSyncUI() {
                 <td data-col="value">${escapeHtml(formatMoney(row.currentValueLcy))}</td>
                 <td data-col="current">${escapeHtml(row.currentAllocationDisplay || '-')}</td>
                 <td data-col="target"></td>
-                <td data-col="drift">${escapeHtml(row.driftDisplay || '-')}</td>
+                <td data-col="drift" class="${escapeHtml(row.driftClass || '')}">${escapeHtml(row.driftDisplay || '-')}</td>
                 <td data-col="fixed"></td>
                 <td data-col="portfolio"></td>
             `;

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -9809,18 +9809,22 @@ syncUi.update = function updateSyncUI() {
         return manager;
     }
 
-    function buildFsmSummaryRow(summary) {
+    function buildFsmSummaryRow(summary, options = {}) {
+        const showDrift = options.showDrift !== false;
         const summaryRow = createElement('div', 'gpv-summary-row');
         const driftClassName = summary?.driftClass
             ? `gpv-summary-card ${summary.driftClass}`
             : 'gpv-summary-card';
+        const driftCardHtml = showDrift
+            ? `<div class="${escapeHtml(driftClassName)}"><strong>Drift:</strong> ${escapeHtml(summary.driftDisplay)}</div>`
+            : '';
         summaryRow.innerHTML = `
             <div class="gpv-summary-card"><strong>Total Value:</strong> ${escapeHtml(formatMoney(summary.total))}</div>
             <div class="gpv-summary-card"><strong>Target Assigned:</strong> ${escapeHtml(summary.targetAssignedDisplay)}</div>
             <div class="gpv-summary-card"><strong>Holdings:</strong> ${escapeHtml(String(summary.holdingsCount))}</div>
             <div class="gpv-summary-card"><strong>Unassigned:</strong> ${escapeHtml(String(summary.unassignedCount))}</div>
             <div class="gpv-summary-card"><strong>Fixed:</strong> ${escapeHtml(String(summary.fixedCount))}</div>
-            <div class="${escapeHtml(driftClassName)}"><strong>Drift:</strong> ${escapeHtml(summary.driftDisplay)}</div>
+            ${driftCardHtml}
         `;
         return summaryRow;
     }
@@ -9917,6 +9921,7 @@ syncUi.update = function updateSyncUI() {
         selectAllFiltered,
         activePortfolios,
         targetErrorsByCode,
+        showDrift,
         onSelectAllChange,
         onRowSelectChange,
         onTargetChange,
@@ -9937,7 +9942,7 @@ syncUi.update = function updateSyncUI() {
                     <th>Value (SGD)</th>
                     <th>Current %</th>
                     <th>Target %</th>
-                    <th>Drift %</th>
+                    ${showDrift ? '<th>Drift %</th>' : ''}
                     <th>Fixed</th>
                     <th>Portfolio</th>
                 </tr>
@@ -9966,7 +9971,7 @@ syncUi.update = function updateSyncUI() {
                 <td data-col="value">${escapeHtml(formatMoney(row.currentValueLcy))}</td>
                 <td data-col="current">${escapeHtml(row.currentAllocationDisplay || '-')}</td>
                 <td data-col="target"></td>
-                <td data-col="drift" class="${escapeHtml(row.driftClass || '')}">${escapeHtml(row.driftDisplay || '-')}</td>
+                ${showDrift ? `<td data-col="drift" class="${escapeHtml(row.driftClass || '')}">${escapeHtml(row.driftDisplay || '-')}</td>` : ''}
                 <td data-col="fixed"></td>
                 <td data-col="portfolio"></td>
             `;
@@ -10112,6 +10117,7 @@ syncUi.update = function updateSyncUI() {
 
             const selectedCodes = new Set(selectAllFiltered ? filteredRows.map(row => row.code).filter(Boolean) : []);
             const selectedCount = selectedCodes.size;
+            const showDrift = selectedScope !== FSM_ALL_PORTFOLIO_ID;
             const summary = buildFsmScopedSummary(filteredRows);
             const displayRows = buildFsmDisplayRows(filteredRows, summary.total);
             const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
@@ -10175,7 +10181,7 @@ syncUi.update = function updateSyncUI() {
                 contentDiv.appendChild(manager);
             }
 
-            contentDiv.appendChild(buildFsmSummaryRow(summary));
+            contentDiv.appendChild(buildFsmSummaryRow(summary, { showDrift }));
 
             const scopeOptions = [
                 { id: FSM_ALL_PORTFOLIO_ID, label: 'All' },
@@ -10228,6 +10234,7 @@ syncUi.update = function updateSyncUI() {
                 selectAllFiltered,
                 activePortfolios: activePortfolios(),
                 targetErrorsByCode,
+                showDrift,
                 onSelectAllChange: value => {
                     selectAllFiltered = value;
                     rerender();

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.1
+// @version      2.14.2
 // @description  View and organize your investment portfolio by buckets with a modern interface. Groups goals by bucket names and displays comprehensive portfolio analytics. Currently supports Endowus (Singapore). Now with optional cross-device sync!
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*
@@ -9433,7 +9433,10 @@ syncUi.update = function updateSyncUI() {
         const total = rows.reduce((sum, row) => sum + (Number(row.currentValueLcy) || 0), 0);
         const activeRows = rows.filter(row => row.fixed !== true);
         const targetPercentTotal = activeRows.reduce((sum, row) => sum + (Number(row.targetPercent) || 0), 0);
-        const totalDrift = activeRows.reduce((sum, row) => sum + calculateFsmRowDrift(total, row), 0);
+        const totalDrift = activeRows.reduce((sum, row) => {
+            const rowDrift = calculateFsmRowDrift(total, row);
+            return sum + (Number.isFinite(rowDrift) ? rowDrift : 0);
+        }, 0);
         return {
             total,
             actualWeightDisplay: formatPercent(1, { multiplier: 100, showSign: false }),
@@ -9441,6 +9444,18 @@ syncUi.update = function updateSyncUI() {
             driftDisplay: formatPercent(totalDrift, { multiplier: 100, showSign: false }),
             suggestionDisplay: formatMoney(0)
         };
+    }
+
+    function calculateFsmCurrentAllocation(total, row) {
+        const numericTotal = toFiniteNumber(total, null);
+        if (numericTotal === null || numericTotal <= 0) {
+            return null;
+        }
+        const currentValue = toFiniteNumber(row?.currentValueLcy, null);
+        if (currentValue === null) {
+            return null;
+        }
+        return currentValue / numericTotal;
     }
 
     function buildFsmHeader({ overlay, cleanupCallbacks }) {
@@ -9481,14 +9496,41 @@ syncUi.update = function updateSyncUI() {
     }
 
     function calculateFsmRowDrift(total, row) {
-        if (total <= 0 || !Number.isFinite(row.targetPercent)) {
-            return 0;
+        const numericTotal = toFiniteNumber(total, null);
+        if (numericTotal === null || numericTotal <= 0) {
+            return null;
         }
-        const targetAmount = (row.targetPercent / 100) * total;
+        const targetPercent = toFiniteNumber(row?.targetPercent, null);
+        if (targetPercent === null) {
+            return null;
+        }
+        const targetAmount = (targetPercent / 100) * numericTotal;
         if (!Number.isFinite(targetAmount) || targetAmount <= 0) {
-            return 0;
+            return null;
         }
-        return Math.abs(targetAmount - row.currentValueLcy) / targetAmount;
+        const currentValue = toFiniteNumber(row?.currentValueLcy, 0);
+        const drift = Math.abs(targetAmount - currentValue) / targetAmount;
+        return Number.isFinite(drift) ? drift : null;
+    }
+
+    function buildFsmDisplayRows(rows, total) {
+        return (Array.isArray(rows) ? rows : []).map(row => {
+            const currentAllocationPercent = calculateFsmCurrentAllocation(total, row);
+            const driftPercent = calculateFsmRowDrift(total, row);
+            return {
+                ...row,
+                currentAllocationPercent,
+                currentAllocationDisplay: formatPercent(currentAllocationPercent, {
+                    multiplier: 100,
+                    showSign: false
+                }),
+                driftPercent,
+                driftDisplay: formatPercent(driftPercent, {
+                    multiplier: 100,
+                    showSign: false
+                })
+            };
+        });
     }
 
     function buildFsmManagerSummary({
@@ -9728,7 +9770,9 @@ syncUi.update = function updateSyncUI() {
                     <th>Name</th>
                     <th>Product Type</th>
                     <th>Value (SGD)</th>
+                    <th>Current %</th>
                     <th>Target %</th>
+                    <th>Drift %</th>
                     <th>Fixed</th>
                     <th>Portfolio</th>
                 </tr>
@@ -9750,14 +9794,16 @@ syncUi.update = function updateSyncUI() {
             const tr = document.createElement('tr');
             const checked = selectedCodes.has(row.code);
             tr.innerHTML = `
-                <td><input type="checkbox" ${checked ? 'checked' : ''} aria-label="Select holding ${escapeHtml(row.displayTicker || row.code)}" /></td>
-                <td>${escapeHtml(row.displayTicker || '-')}</td>
-                <td>${escapeHtml(row.name)}</td>
-                <td>${escapeHtml(row.productType)}</td>
-                <td>${escapeHtml(formatMoney(row.currentValueLcy))}</td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td data-col="select"><input type="checkbox" ${checked ? 'checked' : ''} aria-label="Select holding ${escapeHtml(row.displayTicker || row.code)}" /></td>
+                <td data-col="ticker">${escapeHtml(row.displayTicker || '-')}</td>
+                <td data-col="name">${escapeHtml(row.name)}</td>
+                <td data-col="product-type">${escapeHtml(row.productType)}</td>
+                <td data-col="value">${escapeHtml(formatMoney(row.currentValueLcy))}</td>
+                <td data-col="current">${escapeHtml(row.currentAllocationDisplay || '-')}</td>
+                <td data-col="target"></td>
+                <td data-col="drift">${escapeHtml(row.driftDisplay || '-')}</td>
+                <td data-col="fixed"></td>
+                <td data-col="portfolio"></td>
             `;
             const checkbox = tr.querySelector('input[type="checkbox"]');
             checkbox.addEventListener('change', () => {
@@ -9766,7 +9812,11 @@ syncUi.update = function updateSyncUI() {
                 }
             });
 
-            const targetCell = tr.children[5];
+            const targetCell = tr.querySelector('td[data-col="target"]');
+            if (!targetCell) {
+                tbody.appendChild(tr);
+                return;
+            }
             const targetInput = createElement('input', 'gpv-target-input');
             targetInput.type = 'number';
             targetInput.min = '0';
@@ -9787,7 +9837,11 @@ syncUi.update = function updateSyncUI() {
                 targetCell.appendChild(err);
             }
 
-            const fixedCell = tr.children[6];
+            const fixedCell = tr.querySelector('td[data-col="fixed"]');
+            if (!fixedCell) {
+                tbody.appendChild(tr);
+                return;
+            }
             const fixedCheckbox = createElement('input');
             fixedCheckbox.type = 'checkbox';
             fixedCheckbox.checked = row.fixed === true;
@@ -9799,7 +9853,11 @@ syncUi.update = function updateSyncUI() {
             };
             fixedCell.appendChild(fixedCheckbox);
 
-            const selectCell = tr.children[7];
+            const selectCell = tr.querySelector('td[data-col="portfolio"]');
+            if (!selectCell) {
+                tbody.appendChild(tr);
+                return;
+            }
             const select = createElement('select', 'gpv-select');
             select.innerHTML = [
                 { id: FSM_UNASSIGNED_PORTFOLIO_ID, label: 'Unassigned' },
@@ -9883,6 +9941,7 @@ syncUi.update = function updateSyncUI() {
 
             const selectedCodes = new Set(selectAllFiltered ? filteredRows.map(row => row.code).filter(Boolean) : []);
             const summary = buildFsmScopedSummary(filteredRows);
+            const displayRows = buildFsmDisplayRows(filteredRows, summary.total);
             const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
 
             contentDiv.innerHTML = '';
@@ -9991,7 +10050,7 @@ syncUi.update = function updateSyncUI() {
             }));
 
             const table = buildFsmHoldingsTable({
-                filteredRows,
+                filteredRows: displayRows,
                 selectedCodes,
                 selectAllFiltered,
                 activePortfolios: activePortfolios(),

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -5669,7 +5669,6 @@ let GoalTargetStore;
         targetHeader.appendChild(remainingTarget);
         headerRow.appendChild(targetHeader);
 
-        headerRow.appendChild(createElement('th', 'gpv-column-diff', 'Diff'));
         headerRow.appendChild(createElement('th', 'gpv-column-drift', 'Drift'));
         headerRow.appendChild(createElement('th', 'gpv-column-return', 'Cumulative Return'));
         headerRow.appendChild(createElement('th', 'gpv-column-return-percent', 'Return %'));
@@ -5712,10 +5711,6 @@ let GoalTargetStore;
             targetCell.appendChild(targetInput);
             tr.appendChild(targetCell);
 
-            const diffClassName = goalModel.diffClass
-                ? `${CLASS_NAMES.diffCell} gpv-column-diff ${goalModel.diffClass}`
-                : `${CLASS_NAMES.diffCell} gpv-column-diff`;
-            tr.appendChild(createElement('td', diffClassName, goalModel.diffDisplay));
             const driftClassName = goalModel.driftClass
                 ? `gpv-column-drift ${goalModel.driftClass}`
                 : 'gpv-column-drift';
@@ -6091,7 +6086,6 @@ let GoalTargetStore;
         const forceTargetRefresh = options.forceTargetRefresh === true;
         rows.forEach(row => {
             const targetInput = row.querySelector(`.${CLASS_NAMES.targetInput}`);
-            const diffCell = row.querySelector(`.${CLASS_NAMES.diffCell}`);
             const driftCell = row.querySelector('.gpv-column-drift');
             if (!targetInput) {
                 return;
@@ -6105,12 +6099,6 @@ let GoalTargetStore;
             targetInput.disabled = goalModel.isFixed;
             if (goalModel.isFixed || forceTargetRefresh) {
                 targetInput.value = goalModel.targetPercent !== null ? goalModel.targetPercent.toFixed(2) : '';
-            }
-            if (diffCell) {
-                diffCell.textContent = goalModel.diffAmount === null ? '-' : formatMoney(goalModel.diffAmount);
-                diffCell.className = goalModel.diffClass
-                    ? `${CLASS_NAMES.diffCell} ${goalModel.diffClass}`
-                    : CLASS_NAMES.diffCell;
             }
             if (driftCell) {
                 driftCell.textContent = formatDriftDisplay(goalModel.driftPercent, goalModel.driftAmount);
@@ -6151,8 +6139,8 @@ let GoalTargetStore;
     function handleGoalTargetChange({
         input,
         goalId,
-        currentEndingBalance,
-        totalTypeEndingBalance,
+        _currentEndingBalance,
+        _totalTypeEndingBalance,
         bucket,
         goalType,
         typeSection,
@@ -6163,14 +6151,10 @@ let GoalTargetStore;
             return;
         }
         const value = input.value;
-        const row = input.closest('tr');
-        const diffCell = row.querySelector(`.${CLASS_NAMES.diffCell}`);
         
         if (value === '') {
             // Clear the target if input is empty
             GoalTargetStore.clearTarget(goalId);
-            diffCell.textContent = '-';
-            diffCell.className = CLASS_NAMES.diffCell;
             refreshGoalTypeSection({
                 typeSection,
                 bucket,
@@ -6205,15 +6189,6 @@ let GoalTargetStore;
             flashInputBorder(input, 'warning');
         }
         
-        // Get projected investment and calculate adjusted total
-        const projectedAmount = getProjectedInvestmentValue(projectedInvestmentsState, bucket, goalType);
-        const adjustedTypeTotal = totalTypeEndingBalance + projectedAmount;
-        
-        // Update difference display in dollar amount
-        const diffData = buildDiffCellData(currentEndingBalance, savedValue, adjustedTypeTotal);
-        diffCell.textContent = diffData.diffDisplay;
-        diffCell.className = diffData.diffClassName;
-
         refreshGoalTypeSection({
             typeSection,
             bucket,
@@ -8241,7 +8216,6 @@ syncUi.update = function updateSyncUI() {
 
             .gpv-mode-performance .gpv-column-fixed,
             .gpv-mode-performance .gpv-column-target,
-            .gpv-mode-performance .gpv-column-diff,
             .gpv-mode-performance .gpv-column-drift,
             .gpv-mode-performance .gpv-projection-panel,
             .gpv-mode-performance .gpv-section-toggle--projection {

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -9246,6 +9246,11 @@ syncUi.update = function updateSyncUI() {
                     font-size: 13px;
                 }
 
+                .gpv-fsm-filter-input {
+                    width: 220px;
+                    max-width: 100%;
+                }
+
                 .gpv-fsm-portfolio-list {
                     width: 100%;
                 }
@@ -9259,8 +9264,36 @@ syncUi.update = function updateSyncUI() {
                     gap: 6px;
                 }
 
+                .gpv-fsm-table-wrap {
+                    width: 100%;
+                    overflow-x: auto;
+                    -webkit-overflow-scrolling: touch;
+                }
+
                 .gpv-fsm-table-portfolio-select {
                     min-width: 0;
+                }
+
+                .gpv-table td[data-col="value"],
+                .gpv-table td[data-col="current"],
+                .gpv-table td[data-col="drift"] {
+                    text-align: right;
+                }
+
+                .gpv-fsm-table-wrap .gpv-table {
+                    min-width: 980px;
+                }
+
+                .gpv-fsm-table-wrap thead th {
+                    position: sticky;
+                    top: 0;
+                    z-index: 1;
+                }
+
+                .gpv-target-input:disabled {
+                    background: #f3f4f6;
+                    color: #6b7280;
+                    cursor: not-allowed;
                 }
 
                 /* Sync Indicator */
@@ -9357,6 +9390,14 @@ syncUi.update = function updateSyncUI() {
 
                     .gpv-sync-text {
                         display: none;
+                    }
+
+                    .gpv-fsm-toolbar {
+                        align-items: stretch;
+                    }
+
+                    .gpv-fsm-filter-input {
+                        width: 100%;
                     }
                 }
 
@@ -9532,17 +9573,20 @@ syncUi.update = function updateSyncUI() {
         const total = rows.reduce((sum, row) => sum + (Number(row.currentValueLcy) || 0), 0);
         const activeRows = rows.filter(row => row.fixed !== true);
         const targetPercentTotal = activeRows.reduce((sum, row) => sum + (Number(row.targetPercent) || 0), 0);
+        const fixedCount = rows.filter(row => row.fixed === true).length;
+        const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
         const totalDrift = activeRows.reduce((sum, row) => {
             const rowDrift = calculateFsmRowDrift(total, row);
             return sum + (Number.isFinite(rowDrift?.driftPercent) ? Math.abs(rowDrift.driftPercent) : 0);
         }, 0);
         return {
             total,
-            actualWeightDisplay: formatPercent(1, { multiplier: 100, showSign: false }),
-            targetWeightDisplay: formatPercent(targetPercentTotal / 100, { multiplier: 100, showSign: false }),
+            targetAssignedDisplay: formatPercent(targetPercentTotal / 100, { multiplier: 100, showSign: false }),
             driftDisplay: formatPercent(totalDrift, { multiplier: 100, showSign: false }),
             driftClass: getDriftSeverityClass(totalDrift),
-            suggestionDisplay: formatMoney(0)
+            holdingsCount: rows.length,
+            fixedCount,
+            unassignedCount
         };
     }
 
@@ -9722,8 +9766,8 @@ syncUi.update = function updateSyncUI() {
                 actionSelect.setAttribute('aria-label', `Actions for portfolio ${item.name}`);
                 actionSelect.innerHTML = `
                     <option value="">Actions</option>
-                    <option value="rename">Rename</option>
-                    <option value="archive">Archive</option>
+                    <option value="rename">Rename portfolio</option>
+                    <option value="archive">Archive portfolio</option>
                 `;
                 actionSelect.onchange = () => {
                     const action = actionSelect.value;
@@ -9772,10 +9816,11 @@ syncUi.update = function updateSyncUI() {
             : 'gpv-summary-card';
         summaryRow.innerHTML = `
             <div class="gpv-summary-card"><strong>Total Value:</strong> ${escapeHtml(formatMoney(summary.total))}</div>
-            <div class="gpv-summary-card"><strong>Actual:</strong> ${escapeHtml(summary.actualWeightDisplay)}</div>
-            <div class="gpv-summary-card"><strong>Target:</strong> ${escapeHtml(summary.targetWeightDisplay)}</div>
+            <div class="gpv-summary-card"><strong>Target Assigned:</strong> ${escapeHtml(summary.targetAssignedDisplay)}</div>
+            <div class="gpv-summary-card"><strong>Holdings:</strong> ${escapeHtml(String(summary.holdingsCount))}</div>
+            <div class="gpv-summary-card"><strong>Unassigned:</strong> ${escapeHtml(String(summary.unassignedCount))}</div>
+            <div class="gpv-summary-card"><strong>Fixed:</strong> ${escapeHtml(String(summary.fixedCount))}</div>
             <div class="${escapeHtml(driftClassName)}"><strong>Drift:</strong> ${escapeHtml(summary.driftDisplay)}</div>
-            <div class="gpv-summary-card"><strong>Suggestion:</strong> ${escapeHtml(summary.suggestionDisplay)}</div>
         `;
         return summaryRow;
     }
@@ -9787,7 +9832,7 @@ syncUi.update = function updateSyncUI() {
         onScopeChange,
         onFilterChange
     }) {
-        const toolbar = createElement('div', 'gpv-fsm-toolbar');
+        const toolbar = createElement('div', 'gpv-fsm-toolbar gpv-fsm-filter-toolbar');
         const scopeSelect = createElement('select', 'gpv-select');
         scopeSelect.innerHTML = scopeOptions.map(option => `
             <option value="${escapeHtml(option.id)}">${escapeHtml(option.label)}</option>
@@ -9800,8 +9845,9 @@ syncUi.update = function updateSyncUI() {
         };
         toolbar.appendChild(scopeSelect);
 
-        const searchInput = createElement('input', 'gpv-target-input');
+        const searchInput = createElement('input', 'gpv-target-input gpv-fsm-filter-input');
         searchInput.placeholder = 'Filter holdings';
+        searchInput.setAttribute('aria-label', 'Filter holdings by ticker, name, or product type');
         searchInput.value = filterTerm;
         searchInput.oninput = () => {
             if (typeof onFilterChange === 'function') {
@@ -9814,6 +9860,7 @@ syncUi.update = function updateSyncUI() {
 
     function buildFsmBulkRow({
         selectAllFiltered,
+        selectedCount,
         activePortfolios,
         bulkPortfolioId,
         filteredCount,
@@ -9835,6 +9882,9 @@ syncUi.update = function updateSyncUI() {
         selectAllLabel.prepend(selectAll);
         bulkRow.appendChild(selectAllLabel);
 
+        const selectedSummary = createElement('span', 'gpv-summary-card', `Selected: ${selectedCount} / ${filteredCount}`);
+        bulkRow.appendChild(selectedSummary);
+
         const bulkSelect = createElement('select', 'gpv-select');
         bulkSelect.innerHTML = [
             { id: FSM_UNASSIGNED_PORTFOLIO_ID, label: 'Unassigned' },
@@ -9851,6 +9901,7 @@ syncUi.update = function updateSyncUI() {
         bulkRow.appendChild(bulkSelect);
 
         const applyBulkBtn = createElement('button', 'gpv-sync-btn gpv-sync-btn-primary', `Apply to ${filteredCount} filtered holdings`);
+        applyBulkBtn.disabled = filteredCount === 0 || selectedCount === 0;
         applyBulkBtn.onclick = () => {
             if (typeof onApplyBulk === 'function') {
                 onApplyBulk();
@@ -9872,6 +9923,9 @@ syncUi.update = function updateSyncUI() {
         onFixedChange,
         onPortfolioChange
     }) {
+        if (!Array.isArray(filteredRows) || filteredRows.length === 0) {
+            return createElement('div', 'gpv-conflict-diff-empty', 'No holdings match this filter.');
+        }
         const table = createElement('table', 'gpv-table');
         table.innerHTML = `
             <thead>
@@ -9937,6 +9991,9 @@ syncUi.update = function updateSyncUI() {
             targetInput.setAttribute('aria-label', `Target percentage for ${row.displayTicker || row.code}`);
             targetInput.value = Number.isFinite(row.targetPercent) ? Number(row.targetPercent).toFixed(2) : '';
             targetInput.disabled = row.fixed === true;
+            if (row.fixed === true) {
+                targetInput.title = 'Fixed holdings do not use target %';
+            }
             targetInput.onchange = () => {
                 if (typeof onTargetChange === 'function') {
                     onTargetChange(row, targetInput.value.trim());
@@ -9986,7 +10043,9 @@ syncUi.update = function updateSyncUI() {
             selectCell.appendChild(select);
             tbody.appendChild(tr);
         });
-        return table;
+        const tableWrapper = createElement('div', 'gpv-fsm-table-wrap');
+        tableWrapper.appendChild(table);
+        return tableWrapper;
     }
 
     function renderFsmOverlay(fsmHoldings) {
@@ -10052,6 +10111,7 @@ syncUi.update = function updateSyncUI() {
             });
 
             const selectedCodes = new Set(selectAllFiltered ? filteredRows.map(row => row.code).filter(Boolean) : []);
+            const selectedCount = selectedCodes.size;
             const summary = buildFsmScopedSummary(filteredRows);
             const displayRows = buildFsmDisplayRows(filteredRows, summary.total);
             const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
@@ -10141,6 +10201,7 @@ syncUi.update = function updateSyncUI() {
 
             contentDiv.appendChild(buildFsmBulkRow({
                 selectAllFiltered,
+                selectedCount,
                 activePortfolios: activePortfolios(),
                 bulkPortfolioId,
                 filteredCount: filteredRows.length,

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -15,7 +15,7 @@
     "@eslint/js": "^9.39.2",
     "eslint": "^9.39.2",
     "jest": "^29.7.0",
-    "jsdom": "^22.1.0"
+    "jsdom": "^24.1.3"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
## Summary
- Add FSM holdings table columns for per-row `Current %` and `Drift %` so allocation and drift are visible directly in the table.
- Compute row allocation and drift against the currently selected FSM scope/filter, matching the visible dataset and user-selected context.
- Harden FSM table rendering by using explicit `data-col` selectors instead of brittle column indexes, and add/extend tests and docs for the new behavior.

## Why
- FSM users could not see current allocation percentages and row-level drift in the portfolio table, making it difficult to assess positioning and rebalance needs at a glance.

## Testing
- `corepack pnpm --filter ./tampermonkey lint`
- `corepack pnpm --filter ./tampermonkey test`
- `corepack pnpm --filter ./tampermonkey test -- --runInBand --detectOpenHandles`
- `corepack pnpm --filter ./demo test:e2e:smoke` *(fails in this environment due to missing system Playwright deps; browser install completed, but host libs are unavailable)*