### PR TITLE
feat(fsm): add profit cards and row-level profit display

### DIFF
--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -338,7 +338,11 @@ The UI consists of:
 
 The modal overlay traps keyboard focus while open, supports `Esc` to close, restores focus to the triggering button, and applies dialog ARIA attributes to improve accessibility.
 
-On FSM holdings routes, the table includes per-row `Current %` and `Drift %` columns. Both values are computed against the currently selected scope/filter dataset so percentages match what is visible in the table at any time.
+On FSM holdings routes, the overlay now opens in a portfolio overview instead of dropping directly into the full holdings table. The overview renders one card per active portfolio plus an explicit unassigned card, then drills into the existing instrument-level workspace only after the user picks a portfolio or requests all holdings.
+
+Within FSM detail mode, the scope/filter toolbar stays mounted while summary, bulk actions, and table content rerender. This keeps the `Filter holdings` input focused while users type, instead of recreating the input on every keystroke.
+
+The FSM table still includes per-row `Current %` and `Drift %` columns. Both values are computed against the currently selected scope/filter dataset so percentages match what is visible in the table at any time.
 
 ### Sync Conflict Review
 

--- a/TECHNICAL_DESIGN.md
+++ b/TECHNICAL_DESIGN.md
@@ -342,7 +342,9 @@ On FSM holdings routes, the overlay now opens in a portfolio overview instead of
 
 Within FSM detail mode, the scope/filter toolbar stays mounted while summary, bulk actions, and table content rerender. This keeps the `Filter holdings` input focused while users type, instead of recreating the input on every keystroke.
 
-The FSM table still includes per-row `Current %` and `Drift %` columns. Both values are computed against the currently selected scope/filter dataset so percentages match what is visible in the table at any time.
+The FSM overview summary and portfolio cards now show a `Profit` metric sourced from holdings-level `profitValueLcy`, with aggregate percent derived from total cost basis (`total value - total profit`) to avoid incorrect averaging. If any holding in scope is missing `profitValueLcy`, scope-level profit falls back to `-`.
+
+The FSM detail table includes per-row `Profit`, `Current %`, and `Drift %` columns. `Profit` is rendered as `value (percent)`; row percent prefers `profitPercentLcy` when available and derives from value/cost basis when missing. Current and drift values are computed against the currently selected scope/filter dataset so percentages match what is visible in the table at any time.
 
 ### Sync Conflict Review
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -301,6 +301,11 @@ Contributions are welcome! To contribute:
 
 ## Changelog
 
+### Version 2.14.3
+- FSM now opens to a portfolio overview first, with drill-in to individual holdings only after selecting a portfolio or unassigned holdings
+- Fixed the FSM holdings filter input losing focus while typing by keeping the detail toolbar mounted across updates
+- Normalized FSM toolbar and manager control heights for more consistent rows
+
 ### Version 2.14.2
 - Added FSM table columns for scoped current allocation percentage and per-holding drift percentage
 - Updated FSM table and E2E checks to verify the new allocation/drift columns

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -301,6 +301,10 @@ Contributions are welcome! To contribute:
 
 ## Changelog
 
+### Version 2.14.4
+- Replaced the FSM overview fixed card with a profit card derived from holdings `profitValueLcy` and cost-basis weighted profit percent
+- Added a per-row FSM `Profit` table column that shows combined value and percent (`value (percent)`) with safe fallback when fields are missing
+
 ### Version 2.14.3
 - FSM now opens to a portfolio overview first, with drill-in to individual holdings only after selecting a portfolio or unassigned holdings
 - Fixed the FSM holdings filter input losing focus while typing by keeping the detail toolbar mounted across updates

--- a/tampermonkey/__tests__/fsm-profit-models.test.js
+++ b/tampermonkey/__tests__/fsm-profit-models.test.js
@@ -48,7 +48,7 @@ describe('FSM profit models', () => {
         showOverlay();
 
         const overlay = document.querySelector('#gpv-overlay');
-        expect(overlay.textContent).toContain('Profit: +SGD\u00A0160.00 (+8.70%)');
+        expect(overlay.textContent).toContain('Profit: +8.70% (+SGD 160.00)');
     });
 
     test('buildFsmDisplayRows uses provided percent and derives missing percent', () => {
@@ -94,14 +94,28 @@ describe('FSM profit models', () => {
             return acc;
         }, {});
 
-        expect(rowByTicker.AAPL.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
-        expect(rowByTicker.BOND.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A040.00 (+5.26%)');
+        expect(rowByTicker.AAPL.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+10.00% (+SGD 120.00)');
+        expect(rowByTicker.BOND.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+5.26% (+SGD 40.00)');
     });
 
     test('formatProfitDisplay normalizes 1 and supports ratio inputs', () => {
         const { formatProfitDisplay } = require('../goal_portfolio_viewer.user.js');
         expect(formatProfitDisplay(120, 0.01)).toBe('+SGD\u00A0120.00 (+1.00%)');
         expect(formatProfitDisplay(-25, -0.01)).toBe('-SGD\u00A025.00 (-1.00%)');
+    });
+
+    test('formatFsmProfitDisplay renders percent-first with standard spacing', () => {
+        const { formatFsmProfitDisplay } = require('../goal_portfolio_viewer.user.js');
+        expect(formatFsmProfitDisplay(120, 0.01)).toBe('+1.00% (+SGD 120.00)');
+        expect(formatFsmProfitDisplay(-3334.65, -0.076)).toBe('-7.60% (-SGD 3,334.65)');
+    });
+
+    test('getFsmProfitClass applies threshold boundaries', () => {
+        const { getFsmProfitClass } = require('../goal_portfolio_viewer.user.js');
+        expect(getFsmProfitClass(0.0501)).toBe('positive');
+        expect(getFsmProfitClass(0.05)).toBe('');
+        expect(getFsmProfitClass(-0.05)).toBe('');
+        expect(getFsmProfitClass(-0.0501)).toBe('negative');
     });
 
     test('detail row resolves 0.5 percent scale using derived value percent', () => {
@@ -133,7 +147,7 @@ describe('FSM profit models', () => {
 
         overlay = document.querySelector('#gpv-overlay');
         const firstRow = overlay.querySelector('table tbody tr');
-        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A05.00 (+0.50%)');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+0.50% (+SGD 5.00)');
     });
 
     test('detail row keeps ratio-form percent above 1 when it matches derived value', () => {
@@ -165,7 +179,7 @@ describe('FSM profit models', () => {
 
         overlay = document.querySelector('#gpv-overlay');
         const firstRow = overlay.querySelector('table tbody tr');
-        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0150.00 (+150.00%)');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+150.00% (+SGD 150.00)');
     });
 
     test('detail row avoids misreporting percent scale when only percent is provided', () => {
@@ -197,6 +211,61 @@ describe('FSM profit models', () => {
         overlay = document.querySelector('#gpv-overlay');
         const firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('-');
+    });
+
+    test('detail row applies FSM profit color classes', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'P1',
+                        subcode: 'POS',
+                        name: 'Positive Fund',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1060,
+                        profitValueLcy: 60
+                    },
+                    {
+                        code: 'N1',
+                        subcode: 'NEU',
+                        name: 'Neutral Fund',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1050,
+                        profitValueLcy: 50
+                    },
+                    {
+                        code: 'R1',
+                        subcode: 'RED',
+                        name: 'Negative Fund',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 940,
+                        profitValueLcy: -60
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const rows = Array.from(overlay.querySelectorAll('table tbody tr'));
+        const rowByTicker = rows.reduce((acc, row) => {
+            const ticker = row.querySelector('td[data-col="ticker"]').textContent.trim();
+            acc[ticker] = row;
+            return acc;
+        }, {});
+
+        expect(rowByTicker.POS.querySelector('td[data-col="profit"]').classList.contains('positive')).toBe(true);
+        expect(rowByTicker.NEU.querySelector('td[data-col="profit"]').className.trim()).toBe('');
+        expect(rowByTicker.RED.querySelector('td[data-col="profit"]').classList.contains('negative')).toBe(true);
     });
 
     test('detail row avoids ambiguous percent scale when only sub-1 percent is provided', () => {

--- a/tampermonkey/__tests__/fsm-profit-models.test.js
+++ b/tampermonkey/__tests__/fsm-profit-models.test.js
@@ -1,0 +1,232 @@
+const { setupDom, teardownDom } = require('./helpers/domSetup');
+
+describe('FSM profit models', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+        global.GM_setValue = jest.fn();
+        global.GM_getValue = jest.fn((_, fallback = null) => fallback);
+        global.GM_deleteValue = jest.fn();
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.history = window.history;
+    });
+
+    afterEach(() => {
+        teardownDom();
+    });
+
+    test('buildFsmScopedSummary aggregates profit from profitValueLcy', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'AAA',
+                        subcode: 'AAPL',
+                        name: 'Fund A',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1200,
+                        profitValueLcy: 120,
+                        profitPercentLcy: 10
+                    },
+                    {
+                        code: 'BBB',
+                        subcode: 'BOND',
+                        name: 'Fund B',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 800,
+                        profitValueLcy: 40,
+                        profitPercentLcy: 5
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        const overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).toContain('Profit: +SGD\u00A0160.00 (+8.70%)');
+    });
+
+    test('buildFsmDisplayRows uses provided percent and derives missing percent', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'AAA',
+                        subcode: 'AAPL',
+                        name: 'Fund A',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1200,
+                        profitValueLcy: 120,
+                        profitPercentLcy: 10
+                    },
+                    {
+                        code: 'BBB',
+                        subcode: 'BOND',
+                        name: 'Fund B',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 800,
+                        profitValueLcy: 40
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const rows = Array.from(overlay.querySelectorAll('table tbody tr'));
+        const rowByTicker = rows.reduce((acc, row) => {
+            const ticker = row.querySelector('td[data-col="ticker"]').textContent.trim();
+            acc[ticker] = row;
+            return acc;
+        }, {});
+
+        expect(rowByTicker.AAPL.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
+        expect(rowByTicker.BOND.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A040.00 (+5.26%)');
+    });
+
+    test('formatProfitDisplay normalizes 1 and supports ratio inputs', () => {
+        const { formatProfitDisplay } = require('../goal_portfolio_viewer.user.js');
+        expect(formatProfitDisplay(120, 0.01)).toBe('+SGD\u00A0120.00 (+1.00%)');
+        expect(formatProfitDisplay(-25, -0.01)).toBe('-SGD\u00A025.00 (-1.00%)');
+    });
+
+    test('detail row resolves 0.5 percent scale using derived value percent', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'AAA',
+                        subcode: 'AAPL',
+                        name: 'Fund A',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1000,
+                        profitValueLcy: 5,
+                        profitPercentLcy: 0.5
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A05.00 (+0.50%)');
+    });
+
+    test('detail row keeps ratio-form percent above 1 when it matches derived value', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'AAA',
+                        subcode: 'AAPL',
+                        name: 'Fund A',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 250,
+                        profitValueLcy: 150,
+                        profitPercentLcy: 1.5
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0150.00 (+150.00%)');
+    });
+
+    test('detail row avoids misreporting percent scale when only percent is provided', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'AAA',
+                        subcode: 'AAPL',
+                        name: 'Fund A',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1000,
+                        profitPercentLcy: 1.5
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('-');
+    });
+
+    test('detail row avoids ambiguous percent scale when only sub-1 percent is provided', () => {
+        const { init, showOverlay } = require('../goal_portfolio_viewer.user.js');
+
+        global.GM_getValue = jest.fn((key, fallback = null) => {
+            if (key === 'api_fsm_holdings') {
+                return JSON.stringify([
+                    {
+                        code: 'AAA',
+                        subcode: 'AAPL',
+                        name: 'Fund A',
+                        productType: 'UNIT_TRUST',
+                        currentValueLcy: 1000,
+                        profitPercentLcy: 0.5
+                    }
+                ]);
+            }
+            return fallback;
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('-');
+    });
+});

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -944,7 +944,7 @@ describe('initialization and URL monitoring', () => {
         overlay = document.querySelector('#gpv-overlay');
         let firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
-        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+10.00% (+SGD 120.00)');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
         expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('+66.67% (+SGD\u00A0480.00)');
 
@@ -958,7 +958,7 @@ describe('initialization and URL monitoring', () => {
         overlay = document.querySelector('#gpv-overlay');
         firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
-        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+10.00% (+SGD 120.00)');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
         expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
 
@@ -1027,11 +1027,11 @@ describe('initialization and URL monitoring', () => {
         exportsModule.showOverlay();
 
         let overlay = document.querySelector('#gpv-overlay');
-        expect(overlay.textContent).toContain('Profit: +SGD\u00A0160.00 (+8.70%)');
+        expect(overlay.textContent).toContain('Profit: +8.70% (+SGD 160.00)');
         const overviewCards = Array.from(overlay.querySelectorAll('.gpv-fsm-overview-card'));
         const unassignedCard = overviewCards.find(card => card.textContent.includes('Unassigned'));
         expect(unassignedCard.textContent).toContain('Profit');
-        expect(unassignedCard.textContent).toContain('+SGD\u00A0160.00 (+8.70%)');
+        expect(unassignedCard.textContent).toContain('+8.70% (+SGD 160.00)');
 
         const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
         viewAllBtn.click();
@@ -1041,7 +1041,7 @@ describe('initialization and URL monitoring', () => {
         const profitHeader = Array.from(overlay.querySelectorAll('th')).find(th => th.textContent.trim() === 'Profit');
         expect(profitHeader).toBeTruthy();
         const firstRow = overlay.querySelector('table tbody tr');
-        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+10.00% (+SGD 120.00)');
     });
 
     test('FSM profit display falls back when holdings are missing profit fields', () => {
@@ -1112,7 +1112,7 @@ describe('initialization and URL monitoring', () => {
             acc[ticker] = row;
             return acc;
         }, {});
-        expect(rowByTicker.AAPL.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+11.11%)');
+        expect(rowByTicker.AAPL.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+11.11% (+SGD 120.00)');
         expect(rowByTicker.BOND.querySelector('td[data-col="profit"]').textContent.trim()).toBe('-');
     });
 

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -492,7 +492,7 @@ describe('initialization and URL monitoring', () => {
         expect(detailOverlay.textContent).toContain('Fund A');
         expect(detailOverlay.textContent).toContain('AAPL');
         expect(detailOverlay.querySelector('.gpv-select')).toBeTruthy();
-        expect(detailOverlay.textContent).toContain('Product Type');
+        expect(detailOverlay.textContent).toContain('Type');
         expect(detailOverlay.textContent).toContain('Current %');
         expect(detailOverlay.textContent).not.toContain('Drift %');
         const firstRow = detailOverlay.querySelector('table tbody tr');

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -575,8 +575,24 @@ describe('initialization and URL monitoring', () => {
         global.XMLHttpRequest = FakeXHR;
 
         storage.set('api_fsm_holdings', JSON.stringify([
-            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 },
-            { code: 'BBB', subcode: 'BOND', name: 'Fund B', productType: 'UNIT_TRUST', currentValueLcy: 800 }
+            {
+                code: 'AAA',
+                subcode: 'AAPL',
+                name: 'Fund A',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 1200,
+                profitValueLcy: 120,
+                profitPercentLcy: 10
+            },
+            {
+                code: 'BBB',
+                subcode: 'BOND',
+                name: 'Fund B',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 800,
+                profitValueLcy: 40,
+                profitPercentLcy: 5
+            }
         ]));
 
         const exportsModule = require('../goal_portfolio_viewer.user.js');
@@ -667,8 +683,24 @@ describe('initialization and URL monitoring', () => {
         global.XMLHttpRequest = FakeXHR;
 
         storage.set('api_fsm_holdings', JSON.stringify([
-            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 },
-            { code: 'BBB', subcode: 'BOND', name: 'Fund B', productType: 'UNIT_TRUST', currentValueLcy: 800 }
+            {
+                code: 'AAA',
+                subcode: 'AAPL',
+                name: 'Fund A',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 1200,
+                profitValueLcy: 120,
+                profitPercentLcy: 10
+            },
+            {
+                code: 'BBB',
+                subcode: 'BOND',
+                name: 'Fund B',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 800,
+                profitValueLcy: 40,
+                profitPercentLcy: 5
+            }
         ]));
 
         const exportsModule = require('../goal_portfolio_viewer.user.js');
@@ -854,8 +886,24 @@ describe('initialization and URL monitoring', () => {
         global.XMLHttpRequest = FakeXHR;
 
         storage.set('api_fsm_holdings', JSON.stringify([
-            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 },
-            { code: 'BBB', subcode: 'BOND', name: 'Fund B', productType: 'UNIT_TRUST', currentValueLcy: 800 }
+            {
+                code: 'AAA',
+                subcode: 'AAPL',
+                name: 'Fund A',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 1200,
+                profitValueLcy: 120,
+                profitPercentLcy: 10
+            },
+            {
+                code: 'BBB',
+                subcode: 'BOND',
+                name: 'Fund B',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 800,
+                profitValueLcy: 40,
+                profitPercentLcy: 5
+            }
         ]));
         storage.set('fsm_target_pct_AAA', 60);
         storage.set('fsm_portfolios', JSON.stringify([
@@ -876,6 +924,7 @@ describe('initialization and URL monitoring', () => {
         overlay = document.querySelector('#gpv-overlay');
         let firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
         expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('+66.67% (+SGD\u00A0480.00)');
 
@@ -889,6 +938,7 @@ describe('initialization and URL monitoring', () => {
         overlay = document.querySelector('#gpv-overlay');
         firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
         expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
 
@@ -896,6 +946,154 @@ describe('initialization and URL monitoring', () => {
             card.textContent.includes('Drift:')
         );
         expect(driftSummaryCard).toBeFalsy();
+    });
+
+    test('FSM overview and detail display profit metrics', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            {
+                code: 'AAA',
+                subcode: 'AAPL',
+                name: 'Fund A',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 1200,
+                profitValueLcy: 120,
+                profitPercentLcy: 10
+            },
+            {
+                code: 'BBB',
+                subcode: 'BOND',
+                name: 'Fund B',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 800,
+                profitValueLcy: 40,
+                profitPercentLcy: 5
+            }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).toContain('Profit: +SGD\u00A0160.00 (+8.70%)');
+        const overviewCards = Array.from(overlay.querySelectorAll('.gpv-fsm-overview-card'));
+        const unassignedCard = overviewCards.find(card => card.textContent.includes('Unassigned'));
+        expect(unassignedCard.textContent).toContain('Profit');
+        expect(unassignedCard.textContent).toContain('+SGD\u00A0160.00 (+8.70%)');
+
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).toContain('Fixed:');
+        const profitHeader = Array.from(overlay.querySelectorAll('th')).find(th => th.textContent.trim() === 'Profit');
+        expect(profitHeader).toBeTruthy();
+        const firstRow = overlay.querySelector('table tbody tr');
+        expect(firstRow.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+10.00%)');
+    });
+
+    test('FSM profit display falls back when holdings are missing profit fields', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            {
+                code: 'AAA',
+                subcode: 'AAPL',
+                name: 'Fund A',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 1200,
+                profitValueLcy: 120
+            },
+            {
+                code: 'BBB',
+                subcode: 'BOND',
+                name: 'Fund B',
+                productType: 'UNIT_TRUST',
+                currentValueLcy: 800
+            }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).toContain('Profit: -');
+
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const rows = Array.from(overlay.querySelectorAll('table tbody tr'));
+        const rowByTicker = rows.reduce((acc, row) => {
+            const ticker = row.querySelector('td[data-col="ticker"]').textContent.trim();
+            acc[ticker] = row;
+            return acc;
+        }, {});
+        expect(rowByTicker.AAPL.querySelector('td[data-col="profit"]').textContent.trim()).toBe('+SGD\u00A0120.00 (+11.11%)');
+        expect(rowByTicker.BOND.querySelector('td[data-col="profit"]').textContent.trim()).toBe('-');
     });
 
     test('FSM detail filter input keeps focus while typing', () => {

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -722,12 +722,32 @@ describe('initialization and URL monitoring', () => {
         viewAllBtn.click();
 
         overlay = document.querySelector('#gpv-overlay');
+        let applyBulkBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Apply to'));
+        expect(applyBulkBtn.textContent).toContain('Apply to 0 selected holdings');
+        expect(applyBulkBtn.getAttribute('aria-label')).toContain('Apply portfolio assignment to 0 selected holdings');
+        expect(applyBulkBtn.disabled).toBe(true);
+
+        overlay = document.querySelector('#gpv-overlay');
+        const firstRowCheckbox = overlay.querySelector('table tbody tr td[data-col="select"] input[type="checkbox"]');
+        firstRowCheckbox.checked = true;
+        firstRowCheckbox.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+        overlay = document.querySelector('#gpv-overlay');
+        applyBulkBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Apply to'));
+        expect(applyBulkBtn.textContent).toContain('Apply to 1 selected holding');
+        expect(applyBulkBtn.getAttribute('aria-label')).toContain('Apply portfolio assignment to 1 selected holding');
+        expect(applyBulkBtn.disabled).toBe(false);
+
+        overlay = document.querySelector('#gpv-overlay');
         const selectAll = overlay.querySelector('input[aria-label="Select all filtered holdings"]');
         selectAll.checked = true;
         selectAll.dispatchEvent(new window.Event('change', { bubbles: true }));
 
         overlay = document.querySelector('#gpv-overlay');
-        const applyBulkBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Apply to'));
+        applyBulkBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Apply to'));
+        expect(applyBulkBtn.textContent).toContain('Apply to 2 selected holdings');
+        expect(applyBulkBtn.getAttribute('aria-label')).toContain('Apply portfolio assignment to 2 selected holdings');
+        expect(applyBulkBtn.disabled).toBe(false);
         const bulkRow = applyBulkBtn.parentElement;
         const bulkSelect = bulkRow.querySelector('select.gpv-select');
         bulkSelect.value = 'core';

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -208,7 +208,7 @@ describe('initialization and URL monitoring', () => {
         expect(document.querySelector('#gpv-overlay')).toBeNull();
     });
 
-    test('showOverlay renders FSM workspace with product type and bulk assignment controls', () => {
+    test('showOverlay renders FSM portfolio overview on FSM route', () => {
         teardownDom();
         setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
 
@@ -231,13 +231,14 @@ describe('initialization and URL monitoring', () => {
 
         const overlay = document.querySelector('#gpv-overlay');
         expect(overlay).toBeTruthy();
-        expect(overlay.textContent).toContain('Product Type');
-        expect(overlay.textContent).toContain('AAPL');
+        expect(overlay.textContent).toContain('Start from a portfolio overview');
+        expect(overlay.querySelector('.gpv-fsm-overview-grid')).toBeTruthy();
+        expect(overlay.querySelector('table')).toBeNull();
+        expect(overlay.querySelector('.gpv-fsm-overview-card')).toBeTruthy();
         expect(overlay.textContent).toContain('Manage portfolios');
         expect(overlay.textContent).not.toContain('New portfolio');
-        expect(overlay.textContent).toContain('Target %');
-        expect(overlay.textContent).toContain('Apply to 1 filtered holdings');
-        expect(overlay.querySelector('input[aria-label="Select all holdings"]')).toBeTruthy();
+        expect(overlay.textContent).toContain('Unassigned');
+        expect(overlay.textContent).toContain('View all holdings');
 
         const manageBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Manage portfolios'));
         manageBtn.click();
@@ -480,14 +481,21 @@ describe('initialization and URL monitoring', () => {
         const overlay = document.querySelector('#gpv-overlay');
         expect(overlay).toBeTruthy();
         expect(overlay.textContent).toContain('Portfolio Viewer (FSM)');
-        expect(overlay.textContent).toContain('Fund A');
-        expect(overlay.textContent).toContain('AAPL');
         expect(overlay.textContent).not.toContain('Endowus Only Goal');
-        expect(overlay.querySelector('.gpv-select')).toBeTruthy();
-        expect(overlay.textContent).toContain('Product Type');
-        expect(overlay.textContent).toContain('Current %');
-        expect(overlay.textContent).not.toContain('Drift %');
-        const firstRow = overlay.querySelector('table tbody tr');
+        expect(overlay.querySelector('.gpv-fsm-overview-grid')).toBeTruthy();
+        expect(overlay.querySelector('table')).toBeNull();
+
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        const detailOverlay = document.querySelector('#gpv-overlay');
+        expect(detailOverlay.textContent).toContain('Fund A');
+        expect(detailOverlay.textContent).toContain('AAPL');
+        expect(detailOverlay.querySelector('.gpv-select')).toBeTruthy();
+        expect(detailOverlay.textContent).toContain('Product Type');
+        expect(detailOverlay.textContent).toContain('Current %');
+        expect(detailOverlay.textContent).not.toContain('Drift %');
+        const firstRow = detailOverlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
         expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
     });
@@ -601,6 +609,10 @@ describe('initialization and URL monitoring', () => {
         expect(corePortfolio.name).toBe('Core Growth');
 
         overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
         const rowSelect = overlay.querySelector('table tbody select.gpv-select');
         rowSelect.value = 'core';
         rowSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
@@ -674,6 +686,10 @@ describe('initialization and URL monitoring', () => {
         createBtn.click();
 
         overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
         const selectAll = overlay.querySelector('input[aria-label="Select all filtered holdings"]');
         selectAll.checked = true;
         selectAll.dispatchEvent(new window.Event('change', { bubbles: true }));
@@ -734,6 +750,10 @@ describe('initialization and URL monitoring', () => {
         exportsModule.showOverlay();
 
         let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
         const fixedCheckbox = overlay.querySelector('input[aria-label^="Fixed allocation"]');
         fixedCheckbox.checked = true;
         fixedCheckbox.dispatchEvent(new window.Event('change', { bubbles: true }));
@@ -787,6 +807,10 @@ describe('initialization and URL monitoring', () => {
         exportsModule.showOverlay();
 
         let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
         const targetInput = overlay.querySelector('table tbody tr input.gpv-target-input');
         targetInput.value = '150';
         targetInput.dispatchEvent(new window.Event('change', { bubbles: true }));
@@ -844,31 +868,264 @@ describe('initialization and URL monitoring', () => {
         exportsModule.showOverlay();
 
         let overlay = document.querySelector('#gpv-overlay');
+        const coreCard = Array.from(overlay.querySelectorAll('.gpv-fsm-overview-card')).find(card =>
+            card.textContent.includes('Core')
+        );
+        coreCard.click();
+
+        overlay = document.querySelector('#gpv-overlay');
         let firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
-        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
-        expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
+        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
+        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('+66.67% (+SGD\u00A0480.00)');
 
         const scopeToolbar = Array.from(overlay.querySelectorAll('.gpv-fsm-toolbar')).find(toolbar =>
-            toolbar.querySelector('input.gpv-target-input')
+            toolbar.querySelector('input.gpv-target-input.gpv-fsm-filter-input')
         );
         const scopeSelect = scopeToolbar.querySelector('select.gpv-select');
-        scopeSelect.value = 'core';
+        scopeSelect.value = 'all';
         scopeSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
 
         overlay = document.querySelector('#gpv-overlay');
         firstRow = overlay.querySelector('table tbody tr');
         expect(firstRow.querySelector('td[data-col="ticker"]').textContent.trim()).toBe('AAPL');
-        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('100.00%');
-        expect(firstRow.querySelector('td[data-col="drift"]').textContent.trim()).toBe('+66.67% (+SGD\u00A0480.00)');
-        expect(firstRow.querySelector('td[data-col="drift"]').className).toContain('gpv-drift--red');
+        expect(firstRow.querySelector('td[data-col="current"]').textContent.trim()).toBe('60.00%');
+        expect(firstRow.querySelector('td[data-col="drift"]')).toBeNull();
 
         const driftSummaryCard = Array.from(overlay.querySelectorAll('.gpv-summary-card')).find(card =>
             card.textContent.includes('Drift:')
         );
-        expect(driftSummaryCard).toBeTruthy();
-        expect(driftSummaryCard.textContent).toContain('66.67%');
-        expect(driftSummaryCard.className).toContain('gpv-drift--red');
+        expect(driftSummaryCard).toBeFalsy();
+    });
+
+    test('FSM detail filter input keeps focus while typing', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 },
+            { code: 'BBB', subcode: 'BOND', name: 'Fund B', productType: 'BOND', currentValueLcy: 800 }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const filterInput = overlay.querySelector('input.gpv-fsm-filter-input');
+        filterInput.focus();
+        filterInput.value = 'BO';
+        filterInput.setSelectionRange(2, 2);
+        filterInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+        const updatedOverlay = document.querySelector('#gpv-overlay');
+        const updatedInput = updatedOverlay.querySelector('input.gpv-fsm-filter-input');
+        expect(updatedInput).toBe(filterInput);
+        expect(updatedInput.value).toBe('BO');
+        expect(document.activeElement).toBe(updatedInput);
+        expect(updatedInput.selectionStart).toBe(2);
+        expect(updatedOverlay.textContent).toContain('BOND');
+        expect(updatedOverlay.textContent).not.toContain('AAPL');
+    });
+
+    test('FSM detail view can return to portfolio overview', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.querySelector('table')).toBeTruthy();
+        const backBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Back to portfolios'));
+        backBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.querySelector('.gpv-fsm-overview-grid')).toBeTruthy();
+        expect(overlay.querySelector('table')).toBeNull();
+    });
+
+    test('FSM overview keeps hidden detail toolbar out of tab order and restores visible focus', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const viewAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        viewAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const filterInput = overlay.querySelector('input.gpv-fsm-filter-input');
+        expect(filterInput.disabled).toBe(false);
+        filterInput.focus();
+
+        const backBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('Back to portfolios'));
+        backBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const hiddenFilterInput = overlay.querySelector('input.gpv-fsm-filter-input');
+        const firstOverviewCard = overlay.querySelector('.gpv-fsm-overview-card');
+        expect(hiddenFilterInput.disabled).toBe(true);
+        expect(document.activeElement).toBe(firstOverviewCard);
+    });
+
+    test('FSM keyboard navigation moves focus into detail mode', () => {
+        teardownDom();
+        setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_fsm_holdings', JSON.stringify([
+            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1200 }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const openAllBtn = Array.from(overlay.querySelectorAll('button')).find(btn => btn.textContent.includes('View all holdings'));
+        openAllBtn.focus();
+        openAllBtn.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        openAllBtn.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const filterInput = overlay.querySelector('input.gpv-fsm-filter-input');
+        expect(document.activeElement).toBe(filterInput);
     });
 
 });

--- a/tampermonkey/__tests__/interception.test.js
+++ b/tampermonkey/__tests__/interception.test.js
@@ -91,7 +91,13 @@ describe('API interception', () => {
                 {
                     refno: 'ref-1',
                     holdings: [
-                        { code: 'AAA', productType: 'STOCK' },
+                        {
+                            code: 'AAA',
+                            productType: 'STOCK',
+                            currentValueLcy: 1200,
+                            profitValueLcy: 120,
+                            profitPercentLcy: 10
+                        },
                         { code: 'HEADER', productType: 'DPMS_HEADER' }
                     ]
                 }
@@ -110,7 +116,15 @@ describe('API interception', () => {
 
         expect(global.GM_setValue).toHaveBeenCalledWith(
             'api_fsm_holdings',
-            JSON.stringify([{ code: 'AAA', productType: 'STOCK' }])
+            JSON.stringify([
+                {
+                    code: 'AAA',
+                    productType: 'STOCK',
+                    currentValueLcy: 1200,
+                    profitValueLcy: 120,
+                    profitPercentLcy: 10
+                }
+            ])
         );
     });
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.3
+// @version      2.14.4
 // @description  View and organize your investment portfolio by buckets with a modern interface. Groups goals by bucket names and displays comprehensive portfolio analytics. Currently supports Endowus (Singapore). Now with optional cross-device sync!
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*
@@ -29,6 +29,7 @@
 
     const DEBUG = false;
     const REMAINING_TARGET_ALERT_THRESHOLD = 2;
+    const FSM_PROFIT_PERCENT_SCALE = 'auto';
     const FSM_UNASSIGNED_PORTFOLIO_ID = 'unassigned';
     const FSM_ALL_PORTFOLIO_ID = 'all';
     const FSM_MAX_PORTFOLIO_NAME_LENGTH = 64;
@@ -300,6 +301,17 @@
         return Number.isFinite(numericValue) ? numericValue : fallback;
     }
 
+    function toOptionalFiniteNumber(value) {
+        if (typeof value === 'string' && value.trim() === '') {
+            return null;
+        }
+        if (value === null || value === undefined || value === '') {
+            return null;
+        }
+        const numericValue = Number(value);
+        return Number.isFinite(numericValue) ? numericValue : null;
+    }
+
     function formatMoney(val) {
         if (typeof val === 'number' && Number.isFinite(val)) {
             return MONEY_FORMATTER.format(val);
@@ -326,7 +338,7 @@
     }
 
     function formatSignedMoney(value) {
-        const numericValue = toFiniteNumber(value, null);
+        const numericValue = toOptionalFiniteNumber(value);
         if (numericValue === null) {
             return '-';
         }
@@ -335,6 +347,62 @@
             return '-';
         }
         return numericValue > 0 ? `+${money}` : money;
+    }
+
+    function resolveProfitPercentRatio(value, derivedPercent = null) {
+        const numericValue = toOptionalFiniteNumber(value);
+        if (numericValue === null) {
+            return derivedPercent;
+        }
+        const absoluteValue = Math.abs(numericValue);
+        const ratioCandidate = numericValue;
+        const pointsCandidate = numericValue / 100;
+        if (derivedPercent !== null) {
+            const ratioDistance = Math.abs(derivedPercent - ratioCandidate);
+            const pointsDistance = Math.abs(derivedPercent - pointsCandidate);
+            return pointsDistance <= ratioDistance ? pointsCandidate : ratioCandidate;
+        }
+        if (FSM_PROFIT_PERCENT_SCALE === 'ratio') {
+            return ratioCandidate;
+        }
+        if (FSM_PROFIT_PERCENT_SCALE === 'points') {
+            return pointsCandidate;
+        }
+        if (absoluteValue === 0) {
+            return pointsCandidate;
+        }
+        return null;
+    }
+
+    function calculateProfitPercentFromValue(currentValue, profitValue) {
+        const numericCurrentValue = toOptionalFiniteNumber(currentValue);
+        const numericProfitValue = toOptionalFiniteNumber(profitValue);
+        if (numericCurrentValue === null || numericProfitValue === null) {
+            return null;
+        }
+        const costBasis = numericCurrentValue - numericProfitValue;
+        if (!Number.isFinite(costBasis) || costBasis <= 0) {
+            return null;
+        }
+        return numericProfitValue / costBasis;
+    }
+
+    function formatProfitDisplay(profitValue, profitPercent) {
+        const valueDisplay = formatSignedMoney(profitValue);
+        const percentDisplay = formatPercent(profitPercent, {
+            multiplier: 100,
+            showSign: true
+        });
+        if (valueDisplay === '-' && percentDisplay === '-') {
+            return '-';
+        }
+        if (valueDisplay === '-') {
+            return percentDisplay;
+        }
+        if (percentDisplay === '-') {
+            return valueDisplay;
+        }
+        return `${valueDisplay} (${percentDisplay})`;
     }
 
     function getDriftSeverityClass(driftRatio) {
@@ -9464,13 +9532,14 @@ syncUi.update = function updateSyncUI() {
                 }
 
                 .gpv-table td[data-col="value"],
+                .gpv-table td[data-col="profit"],
                 .gpv-table td[data-col="current"],
                 .gpv-table td[data-col="drift"] {
                     text-align: right;
                 }
 
                 .gpv-fsm-table-wrap .gpv-table {
-                    min-width: 980px;
+                    min-width: 1120px;
                 }
 
                 .gpv-fsm-table-wrap thead th {
@@ -9752,6 +9821,8 @@ syncUi.update = function updateSyncUI() {
             const code = utils.normalizeString(row?.code, '');
             const subcode = utils.normalizeString(row?.subcode ?? row?.subCode, '');
             const currentValue = Number(row?.currentValueLcy);
+            const profitValue = toOptionalFiniteNumber(row?.profitValueLcy);
+            const profitPercent = toOptionalFiniteNumber(row?.profitPercentLcy);
             return {
                 ...row,
                 code,
@@ -9759,6 +9830,8 @@ syncUi.update = function updateSyncUI() {
                 name: utils.normalizeString(row?.name, '-'),
                 productType: utils.normalizeString(row?.productType, '-'),
                 currentValueLcy: Number.isFinite(currentValue) ? currentValue : 0,
+                profitValueLcy: profitValue,
+                profitPercentLcy: profitPercent,
                 portfolioId: assignmentByCode[code] || FSM_UNASSIGNED_PORTFOLIO_ID,
                 targetPercent: getFsmTarget(code),
                 fixed: getFsmFixed(code)
@@ -9772,6 +9845,16 @@ syncUi.update = function updateSyncUI() {
         const targetPercentTotal = activeRows.reduce((sum, row) => sum + (Number(row.targetPercent) || 0), 0);
         const fixedCount = rows.filter(row => row.fixed === true).length;
         const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
+        const hasCompleteProfit = rows.length > 0 && rows.every(row => toOptionalFiniteNumber(row?.profitValueLcy) !== null);
+        const totalProfitValue = hasCompleteProfit
+            ? rows.reduce((sum, row) => {
+                const value = toOptionalFiniteNumber(row?.profitValueLcy);
+                return sum + (value === null ? 0 : value);
+            }, 0)
+            : null;
+        const totalProfitPercent = hasCompleteProfit
+            ? calculateProfitPercentFromValue(total, totalProfitValue)
+            : null;
         const totalDrift = activeRows.reduce((sum, row) => {
             const rowDrift = calculateFsmRowDrift(total, row);
             return sum + (Number.isFinite(rowDrift?.driftPercent) ? Math.abs(rowDrift.driftPercent) : 0);
@@ -9783,7 +9866,10 @@ syncUi.update = function updateSyncUI() {
             driftClass: getDriftSeverityClass(totalDrift),
             holdingsCount: rows.length,
             fixedCount,
-            unassignedCount
+            unassignedCount,
+            totalProfitValue,
+            totalProfitPercent,
+            profitDisplay: formatProfitDisplay(totalProfitValue, totalProfitPercent)
         };
     }
 
@@ -9867,6 +9953,10 @@ syncUi.update = function updateSyncUI() {
             const driftModel = calculateFsmRowDrift(total, row);
             const driftPercent = driftModel?.driftPercent ?? null;
             const driftAmount = driftModel?.driftAmount ?? null;
+            const currentValue = toFiniteNumber(row?.currentValueLcy, null);
+            const profitValue = toOptionalFiniteNumber(row?.profitValueLcy);
+            const derivedProfitPercent = calculateProfitPercentFromValue(currentValue, profitValue);
+            const profitPercent = resolveProfitPercentRatio(row?.profitPercentLcy, derivedProfitPercent);
             return {
                 ...row,
                 currentAllocationPercent,
@@ -9874,6 +9964,9 @@ syncUi.update = function updateSyncUI() {
                     multiplier: 100,
                     showSign: false
                 }),
+                profitValue,
+                profitPercent,
+                profitDisplay: formatProfitDisplay(profitValue, profitPercent),
                 driftPercent,
                 driftAmount,
                 driftDisplay: formatDriftDisplay(driftPercent, driftAmount),
@@ -10008,10 +10101,18 @@ syncUi.update = function updateSyncUI() {
 
     function buildFsmSummaryRow(summary, options = {}) {
         const showDrift = options.showDrift !== false;
+        const showProfit = options.showProfit === true;
+        const showFixed = options.showFixed !== false;
         const summaryRow = createElement('div', 'gpv-summary-row');
         const driftClassName = summary?.driftClass
             ? `gpv-summary-card ${summary.driftClass}`
             : 'gpv-summary-card';
+        const profitCardHtml = showProfit
+            ? `<div class="gpv-summary-card"><strong>Profit:</strong> ${escapeHtml(summary?.profitDisplay || '-')}</div>`
+            : '';
+        const fixedCardHtml = showFixed
+            ? `<div class="gpv-summary-card"><strong>Fixed:</strong> ${escapeHtml(String(summary.fixedCount))}</div>`
+            : '';
         const driftCardHtml = showDrift
             ? `<div class="${escapeHtml(driftClassName)}"><strong>Drift:</strong> ${escapeHtml(summary.driftDisplay)}</div>`
             : '';
@@ -10020,7 +10121,8 @@ syncUi.update = function updateSyncUI() {
             <div class="gpv-summary-card"><strong>Target Assigned:</strong> ${escapeHtml(summary.targetAssignedDisplay)}</div>
             <div class="gpv-summary-card"><strong>Holdings:</strong> ${escapeHtml(String(summary.holdingsCount))}</div>
             <div class="gpv-summary-card"><strong>Unassigned:</strong> ${escapeHtml(String(summary.unassignedCount))}</div>
-            <div class="gpv-summary-card"><strong>Fixed:</strong> ${escapeHtml(String(summary.fixedCount))}</div>
+            ${profitCardHtml}
+            ${fixedCardHtml}
             ${driftCardHtml}
         `;
         return summaryRow;
@@ -10048,6 +10150,7 @@ syncUi.update = function updateSyncUI() {
                 driftDisplay: summary.driftDisplay,
                 driftClass: summary.driftClass,
                 fixedCount: summary.fixedCount,
+                profitDisplay: summary.profitDisplay,
                 isUnassigned: options.isUnassigned === true
             };
         };
@@ -10116,8 +10219,8 @@ syncUi.update = function updateSyncUI() {
                         <span class="gpv-fsm-overview-stat-value ${escapeHtml(card.driftClass || '')}">${escapeHtml(card.driftDisplay)}</span>
                     </div>
                     <div class="gpv-fsm-overview-stat">
-                        <span class="gpv-fsm-overview-stat-label">Fixed</span>
-                        <span class="gpv-fsm-overview-stat-value">${escapeHtml(String(card.fixedCount))}</span>
+                        <span class="gpv-fsm-overview-stat-label">Profit</span>
+                        <span class="gpv-fsm-overview-stat-value">${escapeHtml(card.profitDisplay || '-')}</span>
                     </div>
                 </div>
             `;
@@ -10270,6 +10373,7 @@ syncUi.update = function updateSyncUI() {
                     <th>Name</th>
                     <th>Product Type</th>
                     <th>Value (SGD)</th>
+                    <th>Profit</th>
                     <th>Current %</th>
                     <th>Target %</th>
                     ${showDrift ? '<th>Drift %</th>' : ''}
@@ -10299,6 +10403,7 @@ syncUi.update = function updateSyncUI() {
                 <td data-col="name">${escapeHtml(row.name)}</td>
                 <td data-col="product-type">${escapeHtml(row.productType)}</td>
                 <td data-col="value">${escapeHtml(formatMoney(row.currentValueLcy))}</td>
+                <td data-col="profit">${escapeHtml(row.profitDisplay || '-')}</td>
                 <td data-col="current">${escapeHtml(row.currentAllocationDisplay || '-')}</td>
                 <td data-col="target"></td>
                 ${showDrift ? `<td data-col="drift" class="${escapeHtml(row.driftClass || '')}">${escapeHtml(row.driftDisplay || '-')}</td>` : ''}
@@ -10596,7 +10701,11 @@ syncUi.update = function updateSyncUI() {
             if (viewMode === 'overview') {
                 toolbarSection.hidden = true;
                 setElementsDisabled(detailToolbarControls, true);
-                summarySection.appendChild(buildFsmSummaryRow(viewState.overviewModel.allSummary, { showDrift: true }));
+                summarySection.appendChild(buildFsmSummaryRow(viewState.overviewModel.allSummary, {
+                    showDrift: true,
+                    showProfit: true,
+                    showFixed: false
+                }));
                 bodySection.appendChild(buildFsmOverviewPanel({
                     overviewModel: viewState.overviewModel,
                     onSelectScope: scopeId => {
@@ -10622,7 +10731,10 @@ syncUi.update = function updateSyncUI() {
 
             toolbarSection.hidden = false;
             setElementsDisabled(detailToolbarControls, false);
-            summarySection.appendChild(buildFsmSummaryRow(viewState.summary, { showDrift: viewState.showDrift }));
+            summarySection.appendChild(buildFsmSummaryRow(viewState.summary, {
+                showDrift: viewState.showDrift,
+                showProfit: true
+            }));
             detailToolbar.setState({
                 scopeOptions: viewState.scopeOptions,
                 selectedScope,
@@ -11275,6 +11387,7 @@ syncUi.update = function updateSyncUI() {
             sortGoalTypes,
             formatMoney,
             formatPercent,
+            formatProfitDisplay,
             formatGrowthPercentFromEndingBalance,
             getReturnClass,
             calculatePercentOfType,

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -10337,8 +10337,10 @@ syncUi.update = function updateSyncUI() {
         };
         bulkRow.appendChild(bulkSelect);
 
-        const applyBulkBtn = createElement('button', 'gpv-sync-btn gpv-sync-btn-primary', `Apply to ${filteredCount} filtered holdings`);
-        applyBulkBtn.disabled = filteredCount === 0 || selectedCount === 0;
+        const selectedLabel = selectedCount === 1 ? 'holding' : 'holdings';
+        const applyBulkBtn = createElement('button', 'gpv-sync-btn gpv-sync-btn-primary', `Apply to ${selectedCount} selected ${selectedLabel}`);
+        applyBulkBtn.setAttribute('aria-label', `Apply portfolio assignment to ${selectedCount} selected ${selectedLabel}`);
+        applyBulkBtn.disabled = selectedCount === 0;
         applyBulkBtn.onclick = () => {
             if (typeof onApplyBulk === 'function') {
                 onApplyBulk();

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -88,6 +88,7 @@
         remainingAlert: 'gpv-remaining-alert',
         diffCell: 'gpv-diff-cell'
     };
+    const FSM_PROFIT_COLOR_THRESHOLD = 0.05;
 
     // ============================================
     // Sync Constants (Cross-Device Sync Feature)
@@ -403,6 +404,45 @@
             return valueDisplay;
         }
         return `${valueDisplay} (${percentDisplay})`;
+    }
+
+    function normalizeMoneyDisplaySpacing(value) {
+        if (typeof value !== 'string') {
+            return value;
+        }
+        return value.replace(/\u00A0/g, ' ');
+    }
+
+    function formatFsmProfitDisplay(profitValue, profitPercent) {
+        const percentDisplay = formatPercent(profitPercent, {
+            multiplier: 100,
+            showSign: true
+        });
+        const valueDisplay = normalizeMoneyDisplaySpacing(formatSignedMoney(profitValue));
+        if (percentDisplay === '-' && valueDisplay === '-') {
+            return '-';
+        }
+        if (percentDisplay === '-') {
+            return valueDisplay;
+        }
+        if (valueDisplay === '-') {
+            return percentDisplay;
+        }
+        return `${percentDisplay} (${valueDisplay})`;
+    }
+
+    function getFsmProfitClass(profitPercent) {
+        const numericPercent = toOptionalFiniteNumber(profitPercent);
+        if (numericPercent === null) {
+            return '';
+        }
+        if (numericPercent > FSM_PROFIT_COLOR_THRESHOLD) {
+            return 'positive';
+        }
+        if (numericPercent < -FSM_PROFIT_COLOR_THRESHOLD) {
+            return 'negative';
+        }
+        return '';
     }
 
     function getDriftSeverityClass(driftRatio) {
@@ -8120,6 +8160,20 @@ syncUi.update = function updateSyncUI() {
             .gpv-stat-value.negative {
                 color: #dc2626;
             }
+
+            .gpv-summary-profit-value {
+                font-weight: 700;
+            }
+
+            .gpv-summary-profit-value.positive,
+            .gpv-fsm-overview-stat-value.positive {
+                color: #059669;
+            }
+
+            .gpv-summary-profit-value.negative,
+            .gpv-fsm-overview-stat-value.negative {
+                color: #dc2626;
+            }
             
             .gpv-goal-type-row {
                 display: flex;
@@ -9538,6 +9592,10 @@ syncUi.update = function updateSyncUI() {
                     text-align: right;
                 }
 
+                .gpv-fsm-table-wrap .gpv-table td[data-col="profit"] {
+                    font-weight: 700;
+                }
+
                 .gpv-fsm-table-wrap .gpv-table {
                     min-width: 1120px;
                 }
@@ -9869,7 +9927,8 @@ syncUi.update = function updateSyncUI() {
             unassignedCount,
             totalProfitValue,
             totalProfitPercent,
-            profitDisplay: formatProfitDisplay(totalProfitValue, totalProfitPercent)
+            profitDisplay: formatFsmProfitDisplay(totalProfitValue, totalProfitPercent),
+            profitClass: getFsmProfitClass(totalProfitPercent)
         };
     }
 
@@ -9966,7 +10025,8 @@ syncUi.update = function updateSyncUI() {
                 }),
                 profitValue,
                 profitPercent,
-                profitDisplay: formatProfitDisplay(profitValue, profitPercent),
+                profitDisplay: formatFsmProfitDisplay(profitValue, profitPercent),
+                profitClass: getFsmProfitClass(profitPercent),
                 driftPercent,
                 driftAmount,
                 driftDisplay: formatDriftDisplay(driftPercent, driftAmount),
@@ -10107,8 +10167,11 @@ syncUi.update = function updateSyncUI() {
         const driftClassName = summary?.driftClass
             ? `gpv-summary-card ${summary.driftClass}`
             : 'gpv-summary-card';
+        const profitClassName = summary?.profitClass === 'positive' || summary?.profitClass === 'negative'
+            ? ` ${summary.profitClass}`
+            : '';
         const profitCardHtml = showProfit
-            ? `<div class="gpv-summary-card"><strong>Profit:</strong> ${escapeHtml(summary?.profitDisplay || '-')}</div>`
+            ? `<div class="gpv-summary-card"><strong>Profit:</strong> <span class="gpv-summary-profit-value${escapeHtml(profitClassName)}">${escapeHtml(summary?.profitDisplay || '-')}</span></div>`
             : '';
         const fixedCardHtml = showFixed
             ? `<div class="gpv-summary-card"><strong>Fixed:</strong> ${escapeHtml(String(summary.fixedCount))}</div>`
@@ -10151,6 +10214,7 @@ syncUi.update = function updateSyncUI() {
                 driftClass: summary.driftClass,
                 fixedCount: summary.fixedCount,
                 profitDisplay: summary.profitDisplay,
+                profitClass: summary.profitClass,
                 isUnassigned: options.isUnassigned === true
             };
         };
@@ -10220,7 +10284,7 @@ syncUi.update = function updateSyncUI() {
                     </div>
                     <div class="gpv-fsm-overview-stat">
                         <span class="gpv-fsm-overview-stat-label">Profit</span>
-                        <span class="gpv-fsm-overview-stat-value">${escapeHtml(card.profitDisplay || '-')}</span>
+                        <span class="gpv-fsm-overview-stat-value ${escapeHtml(card.profitClass || '')}">${escapeHtml(card.profitDisplay || '-')}</span>
                     </div>
                 </div>
             `;
@@ -10405,7 +10469,7 @@ syncUi.update = function updateSyncUI() {
                 <td data-col="name">${escapeHtml(row.name)}</td>
                 <td data-col="product-type">${escapeHtml(row.productType)}</td>
                 <td data-col="value">${escapeHtml(formatMoney(row.currentValueLcy))}</td>
-                <td data-col="profit">${escapeHtml(row.profitDisplay || '-')}</td>
+                <td data-col="profit" class="${escapeHtml(row.profitClass || '')}">${escapeHtml(row.profitDisplay || '-')}</td>
                 <td data-col="current">${escapeHtml(row.currentAllocationDisplay || '-')}</td>
                 <td data-col="target"></td>
                 ${showDrift ? `<td data-col="drift" class="${escapeHtml(row.driftClass || '')}">${escapeHtml(row.driftDisplay || '-')}</td>` : ''}
@@ -11390,6 +11454,8 @@ syncUi.update = function updateSyncUI() {
             formatMoney,
             formatPercent,
             formatProfitDisplay,
+            formatFsmProfitDisplay,
+            getFsmProfitClass,
             formatGrowthPercentFromEndingBalance,
             getReturnClass,
             calculatePercentOfType,

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -10437,7 +10437,7 @@ syncUi.update = function updateSyncUI() {
                     <th><input type="checkbox" aria-label="Select all holdings" ${selectAllFiltered ? 'checked' : ''} /></th>
                     <th>Ticker</th>
                     <th>Name</th>
-                    <th>Product Type</th>
+                    <th>Type</th>
                     <th>Value (SGD)</th>
                     <th>Profit</th>
                     <th>Current %</th>

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.2
+// @version      2.14.3
 // @description  View and organize your investment portfolio by buckets with a modern interface. Groups goals by bucket names and displays comprehensive portfolio analytics. Currently supports Endowus (Singapore). Now with optional cross-device sync!
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*
@@ -5293,7 +5293,37 @@ let GoalTargetStore;
             return [];
         }
         return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR))
-            .filter(element => !element.disabled && element.getAttribute('aria-hidden') !== 'true');
+            .filter(element => {
+                if (!element || element.disabled || element.getAttribute('aria-hidden') === 'true') {
+                    return false;
+                }
+                if (element.hidden === true) {
+                    return false;
+                }
+                const hiddenAncestor = typeof element.closest === 'function'
+                    ? element.closest('[hidden], [aria-hidden="true"]')
+                    : null;
+                return !hiddenAncestor;
+            });
+    }
+
+    function setElementsDisabled(elements, disabled) {
+        (Array.isArray(elements) ? elements : []).forEach(element => {
+            if (!element) {
+                return;
+            }
+            if (disabled) {
+                if ('disabled' in element) {
+                    element.disabled = true;
+                }
+                element.setAttribute('tabindex', '-1');
+                return;
+            }
+            if ('disabled' in element) {
+                element.disabled = false;
+            }
+            element.removeAttribute('tabindex');
+        });
     }
 
     function applyAriaHiddenToSiblings(overlay) {
@@ -9238,6 +9268,10 @@ syncUi.update = function updateSyncUI() {
                     margin-bottom: 10px;
                 }
 
+                .gpv-fsm-section[hidden] {
+                    display: none;
+                }
+
                 .gpv-summary-card {
                     background: #f8fafc;
                     border: 1px solid #e5e7eb;
@@ -9262,6 +9296,161 @@ syncUi.update = function updateSyncUI() {
                 .gpv-fsm-portfolio-actions {
                     display: flex;
                     gap: 6px;
+                }
+
+                .gpv-fsm-toolbar > *,
+                .gpv-fsm-manager-row > *,
+                .gpv-fsm-portfolio-list-row > *,
+                .gpv-fsm-portfolio-actions > * {
+                    box-sizing: border-box;
+                }
+
+                .gpv-fsm-toolbar .gpv-sync-btn,
+                .gpv-fsm-toolbar .gpv-select,
+                .gpv-fsm-toolbar .gpv-target-input,
+                .gpv-fsm-manager-row .gpv-sync-btn,
+                .gpv-fsm-manager-row .gpv-select,
+                .gpv-fsm-manager-row .gpv-target-input,
+                .gpv-fsm-portfolio-list-row .gpv-sync-btn,
+                .gpv-fsm-portfolio-list-row .gpv-select,
+                .gpv-fsm-portfolio-list-row .gpv-target-input,
+                .gpv-fsm-toolbar .gpv-summary-card {
+                    min-height: 40px;
+                }
+
+                .gpv-fsm-toolbar .gpv-sync-btn,
+                .gpv-fsm-manager-row .gpv-sync-btn,
+                .gpv-fsm-portfolio-list-row .gpv-sync-btn,
+                .gpv-fsm-toolbar .gpv-select,
+                .gpv-fsm-manager-row .gpv-select,
+                .gpv-fsm-portfolio-list-row .gpv-select {
+                    font-size: 14px;
+                }
+
+                .gpv-fsm-toolbar .gpv-summary-card {
+                    display: inline-flex;
+                    align-items: center;
+                }
+
+                .gpv-fsm-overview-header {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    gap: 12px;
+                    flex-wrap: wrap;
+                    margin-bottom: 12px;
+                }
+
+                .gpv-fsm-overview-copy {
+                    margin: 0;
+                    color: #4b5563;
+                    font-size: 13px;
+                    line-height: 1.5;
+                }
+
+                .gpv-fsm-overview-grid {
+                    display: grid;
+                    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+                    gap: 12px;
+                }
+
+                .gpv-fsm-overview-card {
+                    background: #ffffff;
+                    border: 2px solid #e5e7eb;
+                    border-radius: 12px;
+                    padding: 16px;
+                    cursor: pointer;
+                    transition: all 0.2s ease;
+                }
+
+                .gpv-fsm-overview-card:hover {
+                    border-color: #667eea;
+                    box-shadow: 0 6px 18px rgba(102, 126, 234, 0.12);
+                    transform: translateY(-1px);
+                }
+
+                .gpv-fsm-overview-card:focus-visible {
+                    outline: 3px solid rgba(102, 126, 234, 0.7);
+                    outline-offset: 2px;
+                }
+
+                .gpv-fsm-overview-card--unassigned {
+                    border-style: dashed;
+                }
+
+                .gpv-fsm-overview-card-header {
+                    display: flex;
+                    align-items: flex-start;
+                    justify-content: space-between;
+                    gap: 12px;
+                    margin-bottom: 12px;
+                }
+
+                .gpv-fsm-overview-card-title {
+                    margin: 0;
+                    color: #111827;
+                    font-size: 18px;
+                    font-weight: 700;
+                }
+
+                .gpv-fsm-overview-card-subtitle {
+                    margin: 4px 0 0 0;
+                    color: #6b7280;
+                    font-size: 12px;
+                    font-weight: 600;
+                    text-transform: uppercase;
+                    letter-spacing: 0.04em;
+                }
+
+                .gpv-fsm-overview-card-tag {
+                    background: #eef2ff;
+                    border-radius: 999px;
+                    color: #4338ca;
+                    font-size: 12px;
+                    font-weight: 700;
+                    padding: 6px 10px;
+                    white-space: nowrap;
+                }
+
+                .gpv-fsm-overview-stats {
+                    display: grid;
+                    grid-template-columns: repeat(2, minmax(0, 1fr));
+                    gap: 8px;
+                }
+
+                .gpv-fsm-overview-stat {
+                    background: #f8fafc;
+                    border: 1px solid #e5e7eb;
+                    border-radius: 8px;
+                    padding: 8px 10px;
+                }
+
+                .gpv-fsm-overview-stat-label {
+                    display: block;
+                    color: #6b7280;
+                    font-size: 11px;
+                    font-weight: 700;
+                    letter-spacing: 0.03em;
+                    margin-bottom: 4px;
+                    text-transform: uppercase;
+                }
+
+                .gpv-fsm-overview-stat-value {
+                    color: #111827;
+                    font-size: 14px;
+                    font-weight: 700;
+                }
+
+                .gpv-fsm-overview-stat-value.gpv-drift--green {
+                    color: #047857;
+                }
+
+                .gpv-fsm-overview-stat-value.gpv-drift--yellow {
+                    color: #b45309;
+                }
+
+                .gpv-fsm-overview-stat-value.gpv-drift--red {
+                    color: #b91c1c;
                 }
 
                 .gpv-fsm-table-wrap {
@@ -9394,6 +9583,14 @@ syncUi.update = function updateSyncUI() {
 
                     .gpv-fsm-toolbar {
                         align-items: stretch;
+                    }
+
+                    .gpv-fsm-overview-header {
+                        align-items: stretch;
+                    }
+
+                    .gpv-fsm-overview-stats {
+                        grid-template-columns: 1fr;
                     }
 
                     .gpv-fsm-filter-input {
@@ -9829,19 +10026,133 @@ syncUi.update = function updateSyncUI() {
         return summaryRow;
     }
 
-    function buildFsmToolbar({
-        scopeOptions,
-        selectedScope,
-        filterTerm,
-        onScopeChange,
-        onFilterChange
-    }) {
+    function buildFsmPortfolioOverviewModel(rows, activePortfolios) {
+        const safeRows = Array.isArray(rows) ? rows : [];
+        const safePortfolios = Array.isArray(activePortfolios) ? activePortfolios : [];
+        const groupedRows = safeRows.reduce((acc, row) => {
+            const portfolioId = utils.normalizeString(row?.portfolioId, FSM_UNASSIGNED_PORTFOLIO_ID);
+            if (!acc[portfolioId]) {
+                acc[portfolioId] = [];
+            }
+            acc[portfolioId].push(row);
+            return acc;
+        }, {});
+        const buildCardModel = (id, label, cardRows, options = {}) => {
+            const summary = buildFsmScopedSummary(cardRows);
+            return {
+                id,
+                label,
+                holdingsCount: summary.holdingsCount,
+                totalDisplay: formatMoney(summary.total),
+                targetAssignedDisplay: summary.targetAssignedDisplay,
+                driftDisplay: summary.driftDisplay,
+                driftClass: summary.driftClass,
+                fixedCount: summary.fixedCount,
+                isUnassigned: options.isUnassigned === true
+            };
+        };
+        const cards = safePortfolios.map(item => buildCardModel(item.id, item.name, groupedRows[item.id] || []));
+        cards.push(buildCardModel(
+            FSM_UNASSIGNED_PORTFOLIO_ID,
+            'Unassigned',
+            groupedRows[FSM_UNASSIGNED_PORTFOLIO_ID] || [],
+            { isUnassigned: true }
+        ));
+        return {
+            cards,
+            allSummary: buildFsmScopedSummary(safeRows)
+        };
+    }
+
+    function buildFsmOverviewPanel({ overviewModel, onSelectScope, onOpenAll }) {
+        const wrapper = createElement('div', 'gpv-fsm-overview');
+        const header = createElement('div', 'gpv-fsm-overview-header');
+        const copy = createElement(
+            'p',
+            'gpv-fsm-overview-copy',
+            'Start from a portfolio overview, then open a portfolio or unassigned holdings to manage individual instruments.'
+        );
+        header.appendChild(copy);
+        const allHoldingsBtn = createElement('button', 'gpv-sync-btn gpv-sync-btn-secondary', 'View all holdings');
+        allHoldingsBtn.type = 'button';
+        allHoldingsBtn.onclick = () => {
+            if (typeof onOpenAll === 'function') {
+                onOpenAll();
+            }
+        };
+        header.appendChild(allHoldingsBtn);
+        wrapper.appendChild(header);
+
+        const grid = createElement('div', 'gpv-fsm-overview-grid');
+        const cards = Array.isArray(overviewModel?.cards) ? overviewModel.cards : [];
+        cards.forEach(card => {
+            const className = card.isUnassigned === true
+                ? 'gpv-fsm-overview-card gpv-fsm-overview-card--unassigned'
+                : 'gpv-fsm-overview-card';
+            const buttonCard = createElement('div', className);
+            buttonCard.setAttribute('role', 'button');
+            buttonCard.setAttribute('tabindex', '0');
+            buttonCard.dataset.scope = card.id;
+            buttonCard.setAttribute('aria-label', `Open ${card.label} holdings`);
+            buttonCard.innerHTML = `
+                <div class="gpv-fsm-overview-card-header">
+                    <div>
+                        <h2 class="gpv-fsm-overview-card-title">${escapeHtml(card.label)}</h2>
+                        <p class="gpv-fsm-overview-card-subtitle">${escapeHtml(`${card.holdingsCount} holding${card.holdingsCount === 1 ? '' : 's'}`)}</p>
+                    </div>
+                    <span class="gpv-fsm-overview-card-tag">Open</span>
+                </div>
+                <div class="gpv-fsm-overview-stats">
+                    <div class="gpv-fsm-overview-stat">
+                        <span class="gpv-fsm-overview-stat-label">Total value</span>
+                        <span class="gpv-fsm-overview-stat-value">${escapeHtml(card.totalDisplay)}</span>
+                    </div>
+                    <div class="gpv-fsm-overview-stat">
+                        <span class="gpv-fsm-overview-stat-label">Target assigned</span>
+                        <span class="gpv-fsm-overview-stat-value">${escapeHtml(card.targetAssignedDisplay)}</span>
+                    </div>
+                    <div class="gpv-fsm-overview-stat">
+                        <span class="gpv-fsm-overview-stat-label">Drift</span>
+                        <span class="gpv-fsm-overview-stat-value ${escapeHtml(card.driftClass || '')}">${escapeHtml(card.driftDisplay)}</span>
+                    </div>
+                    <div class="gpv-fsm-overview-stat">
+                        <span class="gpv-fsm-overview-stat-label">Fixed</span>
+                        <span class="gpv-fsm-overview-stat-value">${escapeHtml(String(card.fixedCount))}</span>
+                    </div>
+                </div>
+            `;
+            const handleSelect = event => {
+                if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
+                    return;
+                }
+                if (event.type === 'keydown') {
+                    event.preventDefault();
+                }
+                if (typeof onSelectScope === 'function') {
+                    onSelectScope(card.id);
+                }
+            };
+            buttonCard.addEventListener('click', handleSelect);
+            buttonCard.addEventListener('keydown', handleSelect);
+            grid.appendChild(buttonCard);
+        });
+        wrapper.appendChild(grid);
+        return wrapper;
+    }
+
+    function createFsmDetailToolbar({ onBack, onScopeChange, onFilterChange }) {
         const toolbar = createElement('div', 'gpv-fsm-toolbar gpv-fsm-filter-toolbar');
+        const backBtn = createElement('button', 'gpv-sync-btn gpv-sync-btn-secondary', 'Back to portfolios');
+        backBtn.type = 'button';
+        backBtn.onclick = () => {
+            if (typeof onBack === 'function') {
+                onBack();
+            }
+        };
+        toolbar.appendChild(backBtn);
+
         const scopeSelect = createElement('select', 'gpv-select');
-        scopeSelect.innerHTML = scopeOptions.map(option => `
-            <option value="${escapeHtml(option.id)}">${escapeHtml(option.label)}</option>
-        `).join('');
-        scopeSelect.value = selectedScope;
+        scopeSelect.setAttribute('aria-label', 'Select portfolio scope');
         scopeSelect.onchange = () => {
             if (typeof onScopeChange === 'function') {
                 onScopeChange(scopeSelect.value);
@@ -9852,14 +10163,33 @@ syncUi.update = function updateSyncUI() {
         const searchInput = createElement('input', 'gpv-target-input gpv-fsm-filter-input');
         searchInput.placeholder = 'Filter holdings';
         searchInput.setAttribute('aria-label', 'Filter holdings by ticker, name, or product type');
-        searchInput.value = filterTerm;
         searchInput.oninput = () => {
             if (typeof onFilterChange === 'function') {
                 onFilterChange(searchInput.value);
             }
         };
         toolbar.appendChild(searchInput);
-        return toolbar;
+
+        let lastOptionsMarkup = '';
+        const setState = ({ scopeOptions, selectedScope, filterTerm }) => {
+            const nextOptionsMarkup = (Array.isArray(scopeOptions) ? scopeOptions : []).map(option => `
+                <option value="${escapeHtml(option.id)}">${escapeHtml(option.label)}</option>
+            `).join('');
+            if (nextOptionsMarkup !== lastOptionsMarkup) {
+                scopeSelect.innerHTML = nextOptionsMarkup;
+                lastOptionsMarkup = nextOptionsMarkup;
+            }
+            scopeSelect.value = selectedScope;
+            if (searchInput.value !== filterTerm) {
+                searchInput.value = filterTerm;
+            }
+        };
+        return {
+            element: toolbar,
+            setState,
+            searchInput,
+            scopeSelect
+        };
     }
 
     function buildFsmBulkRow({
@@ -10075,27 +10405,88 @@ syncUi.update = function updateSyncUI() {
         let selectedScope = FSM_ALL_PORTFOLIO_ID;
         let filterTerm = '';
         let bulkPortfolioId = FSM_UNASSIGNED_PORTFOLIO_ID;
-        let selectAllFiltered = false;
+        let selectedCodes = new Set();
         let isPortfolioManagerExpanded = false;
         let editingPortfolioId = null;
+        let viewMode = 'overview';
+        let nextFocusTarget = null;
         const targetErrorsByCode = {};
 
         const activePortfolios = () => portfolios.filter(item => item.archived !== true);
 
-        const rerender = () => {
+        const managerSection = createElement('div', 'gpv-fsm-section');
+        const summarySection = createElement('div', 'gpv-fsm-section');
+        const toolbarSection = createElement('div', 'gpv-fsm-section');
+        const bodySection = createElement('div', 'gpv-fsm-section');
+        contentDiv.appendChild(managerSection);
+        contentDiv.appendChild(summarySection);
+        contentDiv.appendChild(toolbarSection);
+        contentDiv.appendChild(bodySection);
+
+        const detailToolbar = createFsmDetailToolbar({
+            onBack: () => {
+                viewMode = 'overview';
+                filterTerm = '';
+                selectedScope = FSM_ALL_PORTFOLIO_ID;
+                selectedCodes = new Set();
+                nextFocusTarget = 'overview';
+                rerender();
+            },
+            onScopeChange: value => {
+                selectedScope = value;
+                selectedCodes = new Set();
+                rerender();
+            },
+            onFilterChange: value => {
+                filterTerm = value;
+                rerender();
+            }
+        });
+        toolbarSection.appendChild(detailToolbar.element);
+        const detailToolbarControls = [detailToolbar.searchInput, detailToolbar.scopeSelect];
+
+        const focusAfterRender = () => {
+            if (nextFocusTarget === 'overview') {
+                const firstOverviewCard = bodySection.querySelector('.gpv-fsm-overview-card');
+                if (firstOverviewCard && typeof firstOverviewCard.focus === 'function') {
+                    firstOverviewCard.focus();
+                }
+            } else if (nextFocusTarget === 'detail') {
+                if (detailToolbar.searchInput && typeof detailToolbar.searchInput.focus === 'function') {
+                    detailToolbar.searchInput.focus();
+                }
+            }
+            nextFocusTarget = null;
+        };
+
+        const buildViewState = () => {
             const rows = buildFsmRowsWithAssignment(fsmHoldings, assignmentByCode);
             const activePortfolioIds = activePortfolios().map(item => item.id);
             const activePortfolioSet = new Set(activePortfolioIds);
+            const validCodes = new Set();
 
             rows.forEach(row => {
                 if (!row.code) {
                     return;
                 }
+                validCodes.add(row.code);
                 if (!activePortfolioSet.has(row.portfolioId)) {
                     assignmentByCode[row.code] = FSM_UNASSIGNED_PORTFOLIO_ID;
                     row.portfolioId = FSM_UNASSIGNED_PORTFOLIO_ID;
                 }
             });
+
+            selectedCodes = new Set(Array.from(selectedCodes).filter(code => validCodes.has(code)));
+
+            const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
+            const scopeOptions = [
+                { id: FSM_ALL_PORTFOLIO_ID, label: 'All' },
+                ...activePortfolios().map(item => ({ id: item.id, label: item.name })),
+                { id: FSM_UNASSIGNED_PORTFOLIO_ID, label: `Unassigned (${unassignedCount})` }
+            ];
+            if (!scopeOptions.find(option => option.id === selectedScope)) {
+                selectedScope = FSM_ALL_PORTFOLIO_ID;
+            }
 
             const normalizedFilter = filterTerm.trim().toLowerCase();
             const filteredRows = rows.filter(row => {
@@ -10115,25 +10506,43 @@ syncUi.update = function updateSyncUI() {
                     || row.productType.toLowerCase().includes(normalizedFilter);
             });
 
-            const selectedCodes = new Set(selectAllFiltered ? filteredRows.map(row => row.code).filter(Boolean) : []);
-            const selectedCount = selectedCodes.size;
+            const filteredCodeSet = new Set(filteredRows.map(row => row.code).filter(Boolean));
+            const selectedCount = Array.from(selectedCodes).filter(code => filteredCodeSet.has(code)).length;
+            const selectAllFiltered = filteredRows.length > 0 && filteredRows.every(row => row.code && selectedCodes.has(row.code));
             const showDrift = selectedScope !== FSM_ALL_PORTFOLIO_ID;
             const summary = buildFsmScopedSummary(filteredRows);
             const displayRows = buildFsmDisplayRows(filteredRows, summary.total);
-            const unassignedCount = rows.filter(row => row.portfolioId === FSM_UNASSIGNED_PORTFOLIO_ID).length;
+            return {
+                rows,
+                activePortfolioIds,
+                unassignedCount,
+                scopeOptions,
+                filteredRows,
+                filteredCodeSet,
+                selectedCount,
+                selectAllFiltered,
+                showDrift,
+                summary,
+                displayRows,
+                overviewModel: buildFsmPortfolioOverviewModel(rows, activePortfolios())
+            };
+        };
 
-            contentDiv.innerHTML = '';
+        const rerender = () => {
+            const viewState = buildViewState();
+
+            managerSection.innerHTML = '';
 
             const managerSummary = buildFsmManagerSummary({
-                activePortfolioCount: activePortfolioIds.length,
-                unassignedCount,
+                activePortfolioCount: viewState.activePortfolioIds.length,
+                unassignedCount: viewState.unassignedCount,
                 isExpanded: isPortfolioManagerExpanded,
                 onToggle: () => {
                     isPortfolioManagerExpanded = !isPortfolioManagerExpanded;
                     rerender();
                 }
             });
-            contentDiv.appendChild(managerSummary);
+            managerSection.appendChild(managerSummary);
 
             if (isPortfolioManagerExpanded) {
                 const manager = buildFsmManagerPanel({
@@ -10178,48 +10587,72 @@ syncUi.update = function updateSyncUI() {
                         rerender();
                     }
                 });
-                contentDiv.appendChild(manager);
+                managerSection.appendChild(manager);
             }
 
-            contentDiv.appendChild(buildFsmSummaryRow(summary, { showDrift }));
+            summarySection.innerHTML = '';
+            bodySection.innerHTML = '';
 
-            const scopeOptions = [
-                { id: FSM_ALL_PORTFOLIO_ID, label: 'All' },
-                ...activePortfolios().map(item => ({ id: item.id, label: item.name })),
-                { id: FSM_UNASSIGNED_PORTFOLIO_ID, label: `Unassigned (${unassignedCount})` }
-            ];
-            if (!scopeOptions.find(option => option.id === selectedScope)) {
-                selectedScope = FSM_ALL_PORTFOLIO_ID;
+            if (viewMode === 'overview') {
+                toolbarSection.hidden = true;
+                setElementsDisabled(detailToolbarControls, true);
+                summarySection.appendChild(buildFsmSummaryRow(viewState.overviewModel.allSummary, { showDrift: true }));
+                bodySection.appendChild(buildFsmOverviewPanel({
+                    overviewModel: viewState.overviewModel,
+                    onSelectScope: scopeId => {
+                        selectedScope = scopeId;
+                        filterTerm = '';
+                        selectedCodes = new Set();
+                        viewMode = 'detail';
+                        nextFocusTarget = 'detail';
+                        rerender();
+                    },
+                    onOpenAll: () => {
+                        selectedScope = FSM_ALL_PORTFOLIO_ID;
+                        filterTerm = '';
+                        selectedCodes = new Set();
+                        viewMode = 'detail';
+                        nextFocusTarget = 'detail';
+                        rerender();
+                    }
+                }));
+                focusAfterRender();
+                return;
             }
-            contentDiv.appendChild(buildFsmToolbar({
-                scopeOptions,
+
+            toolbarSection.hidden = false;
+            setElementsDisabled(detailToolbarControls, false);
+            summarySection.appendChild(buildFsmSummaryRow(viewState.summary, { showDrift: viewState.showDrift }));
+            detailToolbar.setState({
+                scopeOptions: viewState.scopeOptions,
                 selectedScope,
-                filterTerm,
-                onScopeChange: value => {
-                    selectedScope = value;
-                    rerender();
-                },
-                onFilterChange: value => {
-                    filterTerm = value;
-                    rerender();
-                }
-            }));
+                filterTerm
+            });
 
-            contentDiv.appendChild(buildFsmBulkRow({
-                selectAllFiltered,
-                selectedCount,
+            bodySection.appendChild(buildFsmBulkRow({
+                selectAllFiltered: viewState.selectAllFiltered,
+                selectedCount: viewState.selectedCount,
                 activePortfolios: activePortfolios(),
                 bulkPortfolioId,
-                filteredCount: filteredRows.length,
+                filteredCount: viewState.filteredRows.length,
                 onSelectAllChange: value => {
-                    selectAllFiltered = value;
+                    viewState.filteredRows.forEach(row => {
+                        if (!row.code) {
+                            return;
+                        }
+                        if (value) {
+                            selectedCodes.add(row.code);
+                            return;
+                        }
+                        selectedCodes.delete(row.code);
+                    });
                     rerender();
                 },
                 onBulkPortfolioChange: value => {
                     bulkPortfolioId = value;
                 },
                 onApplyBulk: () => {
-                    const targetCodes = Array.from(selectedCodes);
+                    const targetCodes = Array.from(selectedCodes).filter(code => viewState.filteredCodeSet.has(code));
                     targetCodes.forEach(code => {
                         assignmentByCode[code] = bulkPortfolioId;
                     });
@@ -10229,23 +10662,32 @@ syncUi.update = function updateSyncUI() {
             }));
 
             const table = buildFsmHoldingsTable({
-                filteredRows: displayRows,
+                filteredRows: viewState.displayRows,
                 selectedCodes,
-                selectAllFiltered,
+                selectAllFiltered: viewState.selectAllFiltered,
                 activePortfolios: activePortfolios(),
                 targetErrorsByCode,
-                showDrift,
+                showDrift: viewState.showDrift,
                 onSelectAllChange: value => {
-                    selectAllFiltered = value;
+                    viewState.filteredRows.forEach(row => {
+                        if (!row.code) {
+                            return;
+                        }
+                        if (value) {
+                            selectedCodes.add(row.code);
+                            return;
+                        }
+                        selectedCodes.delete(row.code);
+                    });
                     rerender();
                 },
                 onRowSelectChange: (code, checked) => {
                     if (checked) {
                         selectedCodes.add(code);
-                        return;
+                    } else {
+                        selectedCodes.delete(code);
                     }
-                    selectedCodes.delete(code);
-                    selectAllFiltered = false;
+                    rerender();
                 },
                 onTargetChange: (row, rawValue) => {
                     if (!rawValue) {
@@ -10278,7 +10720,8 @@ syncUi.update = function updateSyncUI() {
                     rerender();
                 }
             });
-            contentDiv.appendChild(table);
+            bodySection.appendChild(table);
+            focusAfterRender();
         };
 
         rerender();

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",


### PR DESCRIPTION
## Summary
- replace the FSM overview summary fixed card with a profit card derived from holdings `profitValueLcy`, with aggregate percent computed from cost basis
- add a per-row FSM `Profit` column in detail view that shows `value (percent)` and preserves existing drift/current/fixed workflows
- harden profit percent handling for missing/partial fields and ambiguous scale values, only inferring scale when derivation data is available
- extend FSM tests for overview/detail profit rendering, missing-field fallbacks, percent-scale edge cases, and interception persistence

## Spec And Review Notes
- Spec-Clarity Gate: pass
- Acceptance criteria source: user request in this thread
- Open questions: none
- Review loop: completed with repeated `/review` and `/code-review` passes until both reported `No issues found`

## Verification
- `corepack pnpm --filter ./tampermonkey lint`
- `corepack pnpm --filter ./tampermonkey test -- --runInBand`
- `corepack pnpm --filter ./tampermonkey test:coverage`

## Residual Risk
- When `profitPercentLcy` is present without `profitValueLcy` and scale is ambiguous, the UI now intentionally renders `-` to avoid potentially incorrect percent assumptions.