### PR TITLE
feat(sync): run stale sync on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.5",
+  "version": "2.14.6",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -814,7 +814,129 @@ describe('SyncManager', () => {
 
             const syncPostCalls = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth'));
             expect(syncPostCalls).toHaveLength(0);
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
+            expect(storage.get('sync_last_sync')).toBe(serverTimestamp);
+            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+        });
+
+        test('performSync(both) bootstraps from remote when local sync metadata is missing', async () => {
+            seedConfiguredState();
+            storage.delete('sync_last_sync');
+            storage.delete('sync_last_hash');
+            storage.set('sync_access_token_expiry', Date.now() - 1_000);
+            global.GM_xmlhttpRequest = undefined;
+            const { SyncManager, SyncEncryption, storageKeys } = loadModule();
+            unlockSync(SyncManager);
+
+            const localTargetKey = storageKeys.goalTarget('local-goal');
+            storage.set(localTargetKey, 25);
+            global.GM_listValues = () => [localTargetKey];
+
+            const serverTimestamp = Date.now() + 60_000;
+            Date.now = jest.fn(() => serverTimestamp + 1);
+            storage.set('sync_refresh_token_expiry', serverTimestamp + 120_000);
+            const serverUrl = 'https://sync.example.com';
+            const serverConfig = {
+                version: 2,
+                platforms: {
+                    endowus: {
+                        goalTargets: { 'remote-goal': 45 },
+                        goalFixed: {},
+                        timestamp: serverTimestamp
+                    },
+                    fsm: {
+                        targetsByCode: {},
+                        fixedByCode: {},
+                        tagsByCode: {},
+                        tagCatalog: [],
+                        driftSettings: {},
+                        timestamp: serverTimestamp
+                    }
+                },
+                timestamp: serverTimestamp
+            };
+            const encryptedData = await SyncEncryption.encryptWithMasterKey(
+                JSON.stringify(serverConfig),
+                new Uint8Array([1, 2, 3, 4])
+            );
+
+            fetchMock = jest.fn((url, options = {}) => {
+                if (url === `${serverUrl}/auth/refresh`) {
+                    return Promise.resolve({
+                        status: 200,
+                        ok: true,
+                        json: () => Promise.resolve({
+                            success: true,
+                            tokens: {
+                                accessToken: 'access-token',
+                                refreshToken: 'refresh-token',
+                                accessExpiresAt: Date.now() + 60_000,
+                                refreshExpiresAt: Date.now() + 120_000
+                            }
+                        }),
+                        text: () => Promise.resolve(JSON.stringify({
+                            success: true,
+                            tokens: {
+                                accessToken: 'access-token',
+                                refreshToken: 'refresh-token',
+                                accessExpiresAt: Date.now() + 60_000,
+                                refreshExpiresAt: Date.now() + 120_000
+                            }
+                        })),
+                        headers: { get: () => null }
+                    });
+                }
+                if (url.includes('/sync/') && options.method === 'GET') {
+                    return Promise.resolve({
+                        status: 200,
+                        ok: true,
+                        json: () => Promise.resolve({
+                            success: true,
+                            data: {
+                                encryptedData,
+                                deviceId: 'other-device-id',
+                                timestamp: serverTimestamp,
+                                version: 2
+                            }
+                        }),
+                        text: () => Promise.resolve(JSON.stringify({
+                            success: true,
+                            data: {
+                                encryptedData,
+                                deviceId: 'other-device-id',
+                                timestamp: serverTimestamp,
+                                version: 2
+                            }
+                        })),
+                        headers: { get: () => null }
+                    });
+                }
+                if (url.includes('/sync') && options.method === 'POST') {
+                    return Promise.resolve({
+                        status: 200,
+                        ok: true,
+                        json: () => Promise.resolve({ success: true }),
+                        text: () => Promise.resolve('{"success":true}'),
+                        headers: { get: () => null }
+                    });
+                }
+                return Promise.resolve({
+                    status: 200,
+                    ok: true,
+                    json: () => Promise.resolve({}),
+                    text: () => Promise.resolve('{}'),
+                    headers: { get: () => null }
+                });
+            });
+            global.fetch = fetchMock;
+            window.fetch = fetchMock;
+
+            await expect(SyncManager.performSync({ direction: 'both' })).resolves.toEqual({ status: 'success' });
+
+            const syncPostCalls = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth'));
+            expect(syncPostCalls).toHaveLength(0);
+            expect(storage.has(localTargetKey)).toBe(false);
+            expect(storage.get(storageKeys.goalTarget('remote-goal'))).toBe(45);
+            expect(storage.get('sync_last_sync')).toBe(serverTimestamp);
             expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
         });
 

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -274,6 +274,20 @@ describe('SyncManager', () => {
         expect(SyncManager.__test.isStartupSyncDue()).toBe(false);
     });
 
+    test('last data timestamp falls back only for legacy sync metadata', () => {
+        const legacyTimestamp = 2_000_000_000_000;
+        const { SyncManager } = loadModule();
+
+        storage.set('sync_last_sync', legacyTimestamp);
+        expect(SyncManager.__test.getLastDataTimestamp()).toBe(legacyTimestamp);
+
+        storage.set('sync_last_sync_metadata_version', 2);
+        expect(SyncManager.__test.getLastDataTimestamp()).toBeNull();
+
+        storage.set('sync_last_data_timestamp', legacyTimestamp - 1000);
+        expect(SyncManager.__test.getLastDataTimestamp()).toBe(legacyTimestamp - 1000);
+    });
+
     test('scheduleSyncOnChange schedules a buffered sync', () => {
         jest.useFakeTimers();
         const { SyncManager } = loadModule();
@@ -615,7 +629,7 @@ describe('SyncManager', () => {
     });
 
     describe('multi-device reconciliation', () => {
-        test('resolveConflict(local) forces overwrite and stores server timestamp', async () => {
+        test('resolveConflict(local) records attempt time separately from forced data timestamp', async () => {
             seedConfiguredState();
             global.GM_xmlhttpRequest = undefined;
             const { SyncManager } = loadModule();
@@ -696,7 +710,52 @@ describe('SyncManager', () => {
 
             expect(document.dispatchEvent).toHaveBeenCalled();
 
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp);
+            expect(storage.get('sync_last_sync')).toBe(now);
+            expect(storage.get('sync_last_sync_metadata_version')).toBe(2);
+            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
+            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+        });
+
+        test('resolveConflict(remote) records attempt time separately from remote data timestamp', async () => {
+            seedConfiguredState();
+            const { SyncManager, storageKeys } = loadModule();
+            unlockSync(SyncManager);
+
+            const remoteTimestamp = 2_000_000_000_000;
+            const now = remoteTimestamp + 5000;
+            Date.now = jest.fn(() => now);
+            document.dispatchEvent = jest.fn();
+
+            const conflict = {
+                local: {
+                    version: 2,
+                    platforms: {
+                        endowus: { goalTargets: { 'goal-1': 25 }, goalFixed: {}, timestamp: now - 10_000 },
+                        fsm: { targetsByCode: {}, fixedByCode: {}, tagsByCode: {}, tagCatalog: [], portfolios: [], assignmentByCode: {}, driftSettings: {}, timestamp: now - 10_000 }
+                    },
+                    metadata: { lastModified: now - 10_000 },
+                    timestamp: now - 10_000
+                },
+                remote: {
+                    version: 2,
+                    platforms: {
+                        endowus: { goalTargets: { 'goal-1': 50 }, goalFixed: {}, timestamp: remoteTimestamp },
+                        fsm: { targetsByCode: {}, fixedByCode: {}, tagsByCode: {}, tagCatalog: [], portfolios: [], assignmentByCode: {}, driftSettings: {}, timestamp: remoteTimestamp }
+                    },
+                    metadata: { lastModified: remoteTimestamp },
+                    timestamp: remoteTimestamp
+                },
+                localTimestamp: now - 10_000,
+                remoteTimestamp
+            };
+
+            await expect(SyncManager.resolveConflict('remote', conflict)).resolves.toBeUndefined();
+
+            expect(document.dispatchEvent).toHaveBeenCalled();
+            expect(storage.get(storageKeys.goalTarget('goal-1'))).toBe(50);
+            expect(storage.get('sync_last_sync')).toBe(now);
+            expect(storage.get('sync_last_sync_metadata_version')).toBe(2);
+            expect(storage.get('sync_last_data_timestamp')).toBe(remoteTimestamp);
             expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
         });
 
@@ -814,7 +873,8 @@ describe('SyncManager', () => {
 
             const syncPostCalls = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth'));
             expect(syncPostCalls).toHaveLength(0);
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp);
+            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
+            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
             expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
         });
 
@@ -936,11 +996,150 @@ describe('SyncManager', () => {
             expect(syncPostCalls).toHaveLength(0);
             expect(storage.has(localTargetKey)).toBe(false);
             expect(storage.get(storageKeys.goalTarget('remote-goal'))).toBe(45);
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp);
+            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
+            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
             expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
         });
 
-        test('performSync(download) stores server timestamp as lastSync metadata', async () => {
+        test('attempt-only sync after partial migration metadata does not become data freshness', async () => {
+            seedConfiguredState();
+            global.GM_xmlhttpRequest = undefined;
+            const { SyncManager, SyncEncryption, storageKeys } = loadModule();
+            unlockSync(SyncManager);
+
+            const localTargetKey = storageKeys.goalTarget('goal-1');
+            storage.set(localTargetKey, 25);
+            global.GM_listValues = () => [localTargetKey];
+
+            const initialTimestamp = 2_000_000_000_000;
+            const attemptTimestamp = initialTimestamp + 60_000;
+            const serverTimestamp = initialTimestamp + 30_000;
+            const serverUrl = 'https://sync.example.com';
+            const serverConfig = {
+                version: 2,
+                platforms: {
+                    endowus: {
+                        goalTargets: { 'goal-1': 50 },
+                        goalFixed: {},
+                        timestamp: serverTimestamp
+                    },
+                    fsm: {
+                        targetsByCode: {},
+                        fixedByCode: {},
+                        tagsByCode: {},
+                        tagCatalog: [],
+                        driftSettings: {},
+                        timestamp: serverTimestamp
+                    }
+                },
+                timestamp: serverTimestamp
+            };
+            const encryptedData = await SyncEncryption.encryptWithMasterKey(
+                JSON.stringify(serverConfig),
+                new Uint8Array([1, 2, 3, 4])
+            );
+
+            let phase = 'initial-upload';
+            Date.now = jest.fn(() => initialTimestamp);
+            storage.set('sync_access_token_expiry', attemptTimestamp + 120_000);
+            storage.set('sync_refresh_token_expiry', attemptTimestamp + 120_000);
+            fetchMock = jest.fn((url, options = {}) => {
+                if (url === `${serverUrl}/auth/refresh`) {
+                    return Promise.resolve({
+                        status: 200,
+                        ok: true,
+                        json: () => Promise.resolve({
+                            success: true,
+                            tokens: {
+                                accessToken: 'access-token',
+                                refreshToken: 'refresh-token',
+                                accessExpiresAt: Date.now() + 60_000,
+                                refreshExpiresAt: Date.now() + 120_000
+                            }
+                        }),
+                        text: () => Promise.resolve('{"success":true}'),
+                        headers: { get: () => null }
+                    });
+                }
+                if (url.includes('/sync/') && options.method === 'GET') {
+                    if (phase === 'remote-available') {
+                        return Promise.resolve({
+                            status: 200,
+                            ok: true,
+                            json: () => Promise.resolve({
+                                success: true,
+                                data: {
+                                    encryptedData,
+                                    deviceId: 'other-device-id',
+                                    timestamp: serverTimestamp,
+                                    version: 2
+                                }
+                            }),
+                            text: () => Promise.resolve(JSON.stringify({
+                                success: true,
+                                data: {
+                                    encryptedData,
+                                    deviceId: 'other-device-id',
+                                    timestamp: serverTimestamp,
+                                    version: 2
+                                }
+                            })),
+                            headers: { get: () => null }
+                        });
+                    }
+                    return Promise.resolve({
+                        status: 404,
+                        ok: false,
+                        json: () => Promise.resolve({}),
+                        text: () => Promise.resolve('{}'),
+                        headers: { get: () => null }
+                    });
+                }
+                if (url.includes('/sync') && options.method === 'POST') {
+                    return Promise.resolve({
+                        status: 200,
+                        ok: true,
+                        json: () => Promise.resolve({ success: true }),
+                        text: () => Promise.resolve('{"success":true}'),
+                        headers: { get: () => null }
+                    });
+                }
+                return Promise.resolve({
+                    status: 200,
+                    ok: true,
+                    json: () => Promise.resolve({}),
+                    text: () => Promise.resolve('{}'),
+                    headers: { get: () => null }
+                });
+            });
+            global.fetch = fetchMock;
+            window.fetch = fetchMock;
+
+            await expect(SyncManager.performSync({ direction: 'both' })).resolves.toEqual({ status: 'success' });
+            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+
+            storage.delete('sync_last_data_timestamp');
+            storage.delete('sync_last_sync_metadata_version');
+            Date.now = jest.fn(() => attemptTimestamp);
+            phase = 'attempt-only';
+            await expect(SyncManager.performSync({ direction: 'download' })).resolves.toEqual({ status: 'success' });
+            expect(storage.get('sync_last_sync')).toBe(attemptTimestamp);
+            expect(storage.get('sync_last_sync_metadata_version')).toBe(2);
+            expect(storage.has('sync_last_data_timestamp')).toBe(false);
+
+            phase = 'remote-available';
+            const postCountBeforeRemoteSync = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth')).length;
+
+            await expect(SyncManager.performSync({ direction: 'both' })).resolves.toEqual({ status: 'success' });
+
+            const postCountAfterRemoteSync = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth')).length;
+            expect(postCountAfterRemoteSync).toBe(postCountBeforeRemoteSync);
+            expect(storage.get(storageKeys.goalTarget('goal-1'))).toBe(50);
+            expect(storage.get('sync_last_sync')).toBe(attemptTimestamp);
+            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
+        });
+
+        test('performSync(download) stores attempt and data timestamps separately', async () => {
             seedConfiguredState();
             storage.set('sync_access_token_expiry', Date.now() - 1_000);
             global.GM_xmlhttpRequest = undefined;
@@ -1036,7 +1235,8 @@ describe('SyncManager', () => {
 
             await expect(SyncManager.performSync({ direction: 'download' })).resolves.toEqual({ status: 'success' });
 
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp);
+            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
+            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
             expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
             expect(storage.get(storageKeys.goalTarget('goal-2'))).toBe(40);
         });

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -160,6 +160,120 @@ describe('SyncManager', () => {
         expect(global.setInterval).not.toHaveBeenCalled();
     });
 
+    test('startAutoSync schedules an immediate first sync when last sync is missing', () => {
+        jest.useFakeTimers();
+        jest.spyOn(global, 'setTimeout');
+        seedConfiguredState();
+        storage.set('sync_auto_sync', true);
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+
+        SyncManager.startAutoSync();
+
+        expect(global.setTimeout).toHaveBeenCalledWith(expect.any(Function), 0);
+    });
+
+    test('startAutoSync schedules an immediate first sync when last sync exceeds configured interval', () => {
+        jest.useFakeTimers();
+        jest.spyOn(global, 'setTimeout');
+        const now = 2_000_000_000_000;
+        Date.now = jest.fn(() => now);
+        seedConfiguredState();
+        storage.set('sync_auto_sync', true);
+        storage.set('sync_interval_minutes', 45);
+        storage.set('sync_last_sync', now - (45 * 60 * 1000) - 1);
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+
+        SyncManager.startAutoSync();
+
+        expect(global.setTimeout).toHaveBeenCalledWith(expect.any(Function), 0);
+    });
+
+    test('startAutoSync does not schedule first sync when last sync is within configured interval', () => {
+        jest.useFakeTimers();
+        jest.spyOn(global, 'setTimeout');
+        const now = 2_000_000_000_000;
+        Date.now = jest.fn(() => now);
+        seedConfiguredState();
+        storage.set('sync_auto_sync', true);
+        storage.set('sync_interval_minutes', 45);
+        storage.set('sync_last_sync', now - (44 * 60 * 1000));
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+
+        SyncManager.startAutoSync();
+
+        expect(global.setTimeout).not.toHaveBeenCalledWith(expect.any(Function), 0);
+    });
+
+    test('stopAutoSync clears pending startup sync timer', () => {
+        jest.useFakeTimers();
+        seedConfiguredState();
+        storage.set('sync_auto_sync', true);
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+
+        SyncManager.startAutoSync();
+        expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+        SyncManager.stopAutoSync();
+
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    test('startup sync retries when another sync is already in progress', () => {
+        jest.useFakeTimers();
+        const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+        seedConfiguredState();
+        storage.set('sync_auto_sync', true);
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+        SyncManager.__test.setSyncStatus('syncing');
+
+        SyncManager.startAutoSync();
+        jest.advanceTimersByTime(0);
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 3000);
+
+        SyncManager.__test.setSyncStatus('idle');
+        jest.advanceTimersByTime(3000);
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    });
+
+    test('stopAutoSync clears pending startup retry timer', () => {
+        jest.useFakeTimers();
+        seedConfiguredState();
+        storage.set('sync_auto_sync', true);
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+        SyncManager.__test.setSyncStatus('syncing');
+
+        SyncManager.startAutoSync();
+        jest.advanceTimersByTime(0);
+        expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+        SyncManager.stopAutoSync();
+
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    test('startup sync staleness uses configured interval value', () => {
+        const now = 2_000_000_000_000;
+        Date.now = jest.fn(() => now);
+        seedConfiguredState();
+        storage.set('sync_interval_minutes', 10);
+        storage.set('sync_last_sync', now - (11 * 60 * 1000));
+        const { SyncManager } = loadModule();
+
+        expect(SyncManager.__test.getAutoSyncIntervalMs()).toBe(10 * 60 * 1000);
+        expect(SyncManager.__test.isStartupSyncDue()).toBe(true);
+
+        storage.set('sync_last_sync', now - (9 * 60 * 1000));
+        expect(SyncManager.__test.isStartupSyncDue()).toBe(false);
+    });
+
     test('scheduleSyncOnChange schedules a buffered sync', () => {
         jest.useFakeTimers();
         const { SyncManager } = loadModule();

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.5
+// @version      2.14.6
 // @description  View and organize your investment portfolio by buckets with a modern interface. Groups goals by bucket names and displays comprehensive portfolio analytics. Currently supports Endowus (Singapore). Now with optional cross-device sync!
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -3887,7 +3887,8 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             const localHash = await hashConfigData(localConfig);
             const lastSyncHash = Storage.get(SYNC_STORAGE_KEYS.lastSyncHash, null);
             const lastSyncTimestamp = Storage.get(SYNC_STORAGE_KEYS.lastSync, null);
-            if (localHash && lastSyncHash === localHash && typeof lastSyncTimestamp === 'number') {
+            const hasLastSyncMetadata = typeof lastSyncTimestamp === 'number' && Number.isFinite(lastSyncTimestamp);
+            if (localHash && lastSyncHash === localHash && hasLastSyncMetadata) {
                 localConfig.timestamp = lastSyncTimestamp;
             }
             
@@ -3933,7 +3934,16 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 } else {
                     const serverHash = await hashConfigData(serverData.config);
 
-                    if (localHash && serverHash && localHash === serverHash) {
+                    if (!hasLastSyncMetadata) {
+                        applyConfigData(serverData.config);
+                        Storage.set(SYNC_STORAGE_KEYS.lastSync, serverData.metadata.timestamp);
+                        Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, serverHash);
+
+                        syncStatus = SYNC_STATUS.success;
+                        lastError = null;
+                        lastErrorMeta = null;
+                        logDebug('[Goal Portfolio Viewer] Missing sync metadata, bootstrapped from server snapshot');
+                    } else if (localHash && serverHash && localHash === serverHash) {
                         Storage.set(SYNC_STORAGE_KEYS.lastSync, Math.max(localConfig.timestamp, serverData.metadata.timestamp));
                         Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, localHash);
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -2949,7 +2949,9 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     let lastError = null;
     let lastErrorMeta = null;
     const SYNC_ON_CHANGE_BUFFER_MS = 15000;
+    const STARTUP_SYNC_RETRY_DELAY_MS = 3000;
     let autoSyncTimer = null;
+    let startupSyncTimer = null;
     let syncOnChangeTimer = null;
     let syncOnChangeRetryTimer = null;
     let sessionMasterKey = getRememberedMasterKey();
@@ -4139,11 +4141,56 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     /**
      * Start automatic sync
      */
+    function getAutoSyncIntervalMs() {
+        const intervalMinutes = Number(Storage.get(SYNC_STORAGE_KEYS.syncInterval, SYNC_DEFAULTS.syncInterval));
+        const safeIntervalMinutes = Number.isFinite(intervalMinutes) && intervalMinutes > 0
+            ? intervalMinutes
+            : SYNC_DEFAULTS.syncInterval;
+        return safeIntervalMinutes * 60 * 1000;
+    }
+
+    function isStartupSyncDue(intervalMs = getAutoSyncIntervalMs()) {
+        const lastSync = Storage.get(SYNC_STORAGE_KEYS.lastSync, null);
+        if (typeof lastSync !== 'number' || !Number.isFinite(lastSync)) {
+            return true;
+        }
+        return Date.now() - lastSync >= intervalMs;
+    }
+
+    function scheduleStartupSyncIfDue(intervalMs) {
+        if (!isStartupSyncDue(intervalMs)) {
+            return;
+        }
+
+        startupSyncTimer = setTimeout(() => {
+            startupSyncTimer = null;
+            if (syncStatus === SYNC_STATUS.syncing) {
+                startupSyncTimer = setTimeout(() => {
+                    startupSyncTimer = null;
+                    scheduleStartupSyncIfDue(intervalMs);
+                }, STARTUP_SYNC_RETRY_DELAY_MS);
+                if (startupSyncTimer && typeof startupSyncTimer.unref === 'function') {
+                    startupSyncTimer.unref();
+                }
+                return;
+            }
+            performSync({ direction: 'both' }).catch(error => {
+                if (error?.code === 'SYNC_IN_PROGRESS') {
+                    return;
+                }
+                console.error('[Goal Portfolio Viewer] Startup sync failed:', error);
+            });
+        }, 0);
+        if (startupSyncTimer && typeof startupSyncTimer.unref === 'function') {
+            startupSyncTimer.unref();
+        }
+    }
+
     function startAutoSync() {
         stopAutoSync(); // Clear any existing timer
 
         const autoSync = Storage.get(SYNC_STORAGE_KEYS.autoSync, SYNC_DEFAULTS.autoSync);
-        const intervalMinutes = Storage.get(SYNC_STORAGE_KEYS.syncInterval, SYNC_DEFAULTS.syncInterval);
+        const intervalMs = getAutoSyncIntervalMs();
 
         if (!autoSync || !isEnabled() || !isConfigured()) {
             return;
@@ -4154,14 +4201,15 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             return;
         }
 
-        const intervalMs = intervalMinutes * 60 * 1000;
+        scheduleStartupSyncIfDue(intervalMs);
+
         autoSyncTimer = setInterval(() => {
             performSync({ direction: 'both' }).catch(error => {
                 console.error('[Goal Portfolio Viewer] Auto-sync failed:', error);
             });
         }, intervalMs);
 
-        logDebug(`[Goal Portfolio Viewer] Auto-sync started (interval: ${intervalMinutes} minutes)`);
+        logDebug(`[Goal Portfolio Viewer] Auto-sync started (interval: ${Math.round(intervalMs / 60000)} minutes)`);
     }
 
     /**
@@ -4172,6 +4220,10 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             clearInterval(autoSyncTimer);
             autoSyncTimer = null;
             logDebug('[Goal Portfolio Viewer] Auto-sync stopped');
+        }
+        if (startupSyncTimer) {
+            clearTimeout(startupSyncTimer);
+            startupSyncTimer = null;
         }
         if (syncOnChangeTimer) {
             clearTimeout(syncOnChangeTimer);
@@ -4384,7 +4436,12 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             getAccessToken,
             setSessionMasterKey,
             storeTokens,
-            clearTokens
+            clearTokens,
+            setSyncStatus: status => {
+                syncStatus = status;
+            },
+            getAutoSyncIntervalMs,
+            isStartupSyncDue
         }
         : null;
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -98,6 +98,8 @@
         userId: 'sync_user_id',
         deviceId: 'sync_device_id',
         lastSync: 'sync_last_sync',
+        lastDataTimestamp: 'sync_last_data_timestamp',
+        lastSyncMetadataVersion: 'sync_last_sync_metadata_version',
         lastSyncHash: 'sync_last_hash',
         autoSync: 'sync_auto_sync',
         syncInterval: 'sync_interval_minutes',
@@ -114,6 +116,7 @@
         autoSync: true,
         syncInterval: 30 // minutes
     };
+    const SYNC_METADATA_VERSION = 2;
     const SYNC_REQUEST_TIMEOUT_MS = 15000;
     const FSM_HOLDING_ID_SEPARATOR = '|sub:';
 
@@ -3074,6 +3077,10 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         return SyncEncryption.hash(JSON.stringify(sanitized));
     }
 
+    function isFiniteTimestamp(value) {
+        return typeof value === 'number' && Number.isFinite(value);
+    }
+
     function storeTokens(tokens) {
         if (!tokens || typeof tokens !== 'object') {
             return;
@@ -3855,6 +3862,31 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         return null;
     }
 
+    function getLastDataTimestamp() {
+        const dataTimestamp = Storage.get(SYNC_STORAGE_KEYS.lastDataTimestamp, null);
+        if (isFiniteTimestamp(dataTimestamp)) {
+            return dataTimestamp;
+        }
+
+        // Migration fallback: older versions used lastSync as the synced data timestamp.
+        if (Storage.get(SYNC_STORAGE_KEYS.lastSyncMetadataVersion, null) === SYNC_METADATA_VERSION) {
+            return null;
+        }
+        const legacyTimestamp = Storage.get(SYNC_STORAGE_KEYS.lastSync, null);
+        return isFiniteTimestamp(legacyTimestamp) ? legacyTimestamp : null;
+    }
+
+    function recordSuccessfulSync({ dataTimestamp = null, hash = null, syncedAt = Date.now() } = {}) {
+        Storage.set(SYNC_STORAGE_KEYS.lastSync, syncedAt);
+        Storage.set(SYNC_STORAGE_KEYS.lastSyncMetadataVersion, SYNC_METADATA_VERSION);
+        if (isFiniteTimestamp(dataTimestamp)) {
+            Storage.set(SYNC_STORAGE_KEYS.lastDataTimestamp, dataTimestamp);
+        }
+        if (hash) {
+            Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, hash);
+        }
+    }
+
     /**
      * Perform sync operation
      */
@@ -3886,16 +3918,15 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             const localConfig = collectConfigData();
             const localHash = await hashConfigData(localConfig);
             const lastSyncHash = Storage.get(SYNC_STORAGE_KEYS.lastSyncHash, null);
-            const lastSyncTimestamp = Storage.get(SYNC_STORAGE_KEYS.lastSync, null);
-            const hasLastSyncMetadata = typeof lastSyncTimestamp === 'number' && Number.isFinite(lastSyncTimestamp);
-            if (localHash && lastSyncHash === localHash && hasLastSyncMetadata) {
-                localConfig.timestamp = lastSyncTimestamp;
+            const lastDataTimestamp = getLastDataTimestamp();
+            const hasLastDataTimestamp = isFiniteTimestamp(lastDataTimestamp);
+            if (localHash && lastSyncHash === localHash && hasLastDataTimestamp) {
+                localConfig.timestamp = lastDataTimestamp;
             }
-            
+
             if (direction === 'upload') {
                 await uploadConfig(localConfig);
-                Storage.set(SYNC_STORAGE_KEYS.lastSync, localConfig.timestamp);
-                Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, localHash);
+                recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
 
                 syncStatus = SYNC_STATUS.success;
                 lastError = null;
@@ -3904,15 +3935,15 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             } else if (direction === 'download') {
                 const serverData = await downloadConfig();
                 if (!serverData) {
+                    recordSuccessfulSync();
                     syncStatus = SYNC_STATUS.success;
                     lastError = null;
                     lastErrorMeta = null;
                     logDebug('[Goal Portfolio Viewer] No server data to download');
                 } else {
                     applyConfigData(serverData.config);
-                    Storage.set(SYNC_STORAGE_KEYS.lastSync, serverData.metadata.timestamp);
                     const serverHash = await hashConfigData(serverData.config);
-                    Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, serverHash);
+                    recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
 
                     syncStatus = SYNC_STATUS.success;
                     lastError = null;
@@ -3924,8 +3955,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
                 if (!serverData) {
                     await uploadConfig(localConfig);
-                    Storage.set(SYNC_STORAGE_KEYS.lastSync, localConfig.timestamp);
-                    Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, localHash);
+                    recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
 
                     syncStatus = SYNC_STATUS.success;
                     lastError = null;
@@ -3934,18 +3964,19 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 } else {
                     const serverHash = await hashConfigData(serverData.config);
 
-                    if (!hasLastSyncMetadata) {
+                    if (!hasLastDataTimestamp) {
                         applyConfigData(serverData.config);
-                        Storage.set(SYNC_STORAGE_KEYS.lastSync, serverData.metadata.timestamp);
-                        Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, serverHash);
+                        recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
 
                         syncStatus = SYNC_STATUS.success;
                         lastError = null;
                         lastErrorMeta = null;
                         logDebug('[Goal Portfolio Viewer] Missing sync metadata, bootstrapped from server snapshot');
                     } else if (localHash && serverHash && localHash === serverHash) {
-                        Storage.set(SYNC_STORAGE_KEYS.lastSync, Math.max(localConfig.timestamp, serverData.metadata.timestamp));
-                        Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, localHash);
+                        recordSuccessfulSync({
+                            dataTimestamp: Math.max(localConfig.timestamp, serverData.metadata.timestamp),
+                            hash: localHash
+                        });
 
                         syncStatus = SYNC_STATUS.success;
                         lastError = null;
@@ -3964,8 +3995,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
                         if (localConfig.timestamp > serverData.metadata.timestamp) {
                             await uploadConfig(localConfig);
-                            Storage.set(SYNC_STORAGE_KEYS.lastSync, localConfig.timestamp);
-                            Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, localHash);
+                            recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
 
                             syncStatus = SYNC_STATUS.success;
                             lastError = null;
@@ -3973,14 +4003,14 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                             logDebug('[Goal Portfolio Viewer] Local config newer, uploaded to server');
                         } else if (localConfig.timestamp < serverData.metadata.timestamp) {
                             applyConfigData(serverData.config);
-                            Storage.set(SYNC_STORAGE_KEYS.lastSync, serverData.metadata.timestamp);
-                            Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, serverHash);
+                            recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
 
                             syncStatus = SYNC_STATUS.success;
                             lastError = null;
                             lastErrorMeta = null;
                             logDebug('[Goal Portfolio Viewer] Server config newer, applied locally');
                         } else {
+                            recordSuccessfulSync();
                             syncStatus = SYNC_STATUS.success;
                             lastError = null;
                             lastErrorMeta = null;
@@ -4049,15 +4079,13 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 const responseTimestamp = typeof response?.timestamp === 'number'
                     ? response.timestamp
                     : forcedTimestamp;
-                Storage.set(SYNC_STORAGE_KEYS.lastSync, responseTimestamp);
                 const hash = await hashConfigData(forcedConfig);
-                Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, hash);
+                recordSuccessfulSync({ dataTimestamp: responseTimestamp, hash });
             } else if (resolution === 'remote') {
                 // Apply remote, keep server
                 applyConfigData(conflict.remote);
-                Storage.set(SYNC_STORAGE_KEYS.lastSync, conflict.remoteTimestamp);
                 const hash = await hashConfigData(conflict.remote);
-                Storage.set(SYNC_STORAGE_KEYS.lastSyncHash, hash);
+                recordSuccessfulSync({ dataTimestamp: conflict.remoteTimestamp, hash });
             } else {
                 throw new Error('Invalid resolution');
             }
@@ -4451,7 +4479,8 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 syncStatus = status;
             },
             getAutoSyncIntervalMs,
-            isStartupSyncDue
+            isStartupSyncDue,
+            getLastDataTimestamp
         }
         : null;
 

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.5",
+  "version": "2.14.6",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",


### PR DESCRIPTION
## Summary
- Run an immediate startup sync when auto-sync is enabled and the last sync is missing or older than the configured sync interval.
- Reuse the existing `sync_interval_minutes` setting for staleness, with safe fallback to the default interval.
- Add retry and cleanup handling for startup sync timers, including the case where another sync is already in progress.
- Prevent first-run metadata gaps from uploading fresh local defaults over existing remote data by bootstrapping from the server snapshot when sync metadata is missing.
- Split sync timestamps so `sync_last_sync` records the actual successful sync attempt time while `sync_last_data_timestamp` preserves data freshness for conflict logic.
- Bump aligned workspace/userscript versions to `2.14.6` for release policy compliance.

## Change Brief
This improves cross-device sync freshness on new page loads by triggering the first sync immediately when the stored sync state is stale, while preserving conflict safety by separating successful sync attempt time from synced data modification time.

## Risks & Tradeoffs
- Startup sync still requires sync to be enabled, configured, auto-sync enabled, and the encryption key unlocked.
- Startup failures are logged and do not block page load, matching existing auto-sync behavior.
- If another sync is already running at startup, a short retry is scheduled to avoid dropping the catch-up sync.
- When local sync metadata is missing but server data exists, server state is applied to avoid accidental overwrite risk.
- Existing users migrate safely because legacy `sync_last_sync` is used as data freshness only until the new sync metadata version marker is written.

## Acceptance Criteria
- A new page load triggers startup sync when `sync_last_sync` is missing.
- A new page load triggers startup sync when `sync_last_sync` is older than `sync_interval_minutes`.
- A new page load does not trigger startup sync when `sync_last_sync` is within `sync_interval_minutes`.
- Startup sync timers are cleared by `stopAutoSync()`.
- Startup sync retries when an existing sync is already in progress.
- When local sync metadata is missing and server data exists, startup/both sync does not upload local defaults over remote data.
- `Last Sync` reflects the actual successful sync attempt time.
- Conflict detection and conflict resolution continue to use data freshness timestamps, not sync attempt timestamps.
- Version metadata is aligned and bumped above `2.14.5`.

## Verification Matrix
- `npm test -- syncManager.test.js` from `tampermonkey/` - passed, 38 tests
- `npm test` from `tampermonkey/` - passed, 441 tests; Jest emitted the existing open-handle warning after all suites completed
- `npm run lint` from `tampermonkey/` - passed
- `git diff --check` - passed
- Prior version validation: `node scripts/check-version-bump.js main` - passed before this follow-up commit
- CI after latest push: Dependency Audit, E2E Demo, Lint, Test on Node.js 20.x, Version Bump, and Detect changed paths passed
- CI after latest push: Worker Unit Tests skipped as expected because changed paths do not affect `workers/`

## Self-Review Evidence
- Reviewed SyncManager startup and interval logic to keep existing enable/config/session-key gates intact.
- Added regression tests for missing sync timestamp, stale timestamp, fresh timestamp, custom configured interval, timer cleanup, in-progress retry behavior, and missing-sync-metadata bootstrap behavior.
- Verified that missing local sync metadata now prefers server snapshot application before any upload path.
- Verified `sync_last_sync` is written as attempt time while `sync_last_data_timestamp` is written as data freshness for upload, download, identical-content, bootstrap, and conflict-resolution paths.
- Verified migration fallback only treats legacy `sync_last_sync` as data freshness before the new metadata-version marker exists.

## Skill Alignment Notes
- Network resilience: startup network sync is non-blocking, preserves existing request timeout/error handling, and logs failures without disrupting page load.
- QA/testing: focused SyncManager coverage added for staleness decisions, timer lifecycle, retry behavior, metadata bootstrap safety, timestamp separation, and migration guard behavior.
- Debugging: traced stale Last Sync display to conflated sync-attempt and data-freshness metadata.
- Review-fix loop: resolved the migration edge reported by fresh review where attempt-only syncs could otherwise be reused as data freshness.
- CI failure triage: version policy failure was diagnosed from CI logs and remediated with aligned version bumps.

## CI Failure Triage
### Version Bump Failure
Check: Version Bump
Run/Job: https://github.com/laurenceputra/goal-portfolio-viewer/actions/runs/24955888369/job/73073961521
Classification: release/version policy
Evidence: CI log reported `Version must be bumped above 2.14.5; current version is 2.14.5.`
Remediation: Bumped `package.json`, `tampermonkey/package.json`, and userscript `@version` to `2.14.6`.
Verification: `node scripts/check-version-bump.js main` passed locally; updated CI Version Bump passed before the latest follow-up commit and passed again after latest push.
Residual Risk: none identified.
Status: resolved.

## Review Response Matrix
| Finding | Severity | Disposition | Fix Location | Verification Evidence | Residual Risk |
| --- | --- | --- | --- | --- | --- |
| Startup sync dropped during an in-progress sync | Important | Fixed | `tampermonkey/goal_portfolio_viewer.user.js` startup retry scheduling | `npm test -- syncManager.test.js`; full `npm test`; `npm run lint`; CI passed | None identified |
| Missing cleanup coverage for startup timers | Important | Fixed | `tampermonkey/__tests__/syncManager.test.js` startup timer cleanup tests | `npm test -- syncManager.test.js`; full `npm test`; `npm run lint`; CI passed | None identified |
| Startup overwrite risk when local sync metadata is missing | Important | Fixed | `tampermonkey/goal_portfolio_viewer.user.js` missing metadata bootstrap path | `npm test -- syncManager.test.js`; full `npm test`; `npm run lint`; CI passed | Metadata-gap bootstrap intentionally prefers remote state |
| Sync attempt timestamp could be reused as data freshness after timestamp split | Important | Fixed | `tampermonkey/goal_portfolio_viewer.user.js` `sync_last_data_timestamp` + metadata-version guard | Fresh-context post-fix review found no blocking/important issues; `npm test -- syncManager.test.js`; full `npm test`; `npm run lint`; `git diff --check`; CI passed | Partial metadata states still bootstrap from remote by design |

## Final PR Completion
Latest pushed commit: `d630c8e fix(sync): separate sync attempt and data timestamps`
Required check status after final push: Dependency Audit, E2E Demo, Lint, Test on Node.js 20.x, Version Bump, and Detect changed paths passed.
Expected skipped checks and rationale: Worker Unit Tests skipped because changed paths do not affect `workers/`.
Local verification evidence: focused SyncManager tests, full tampermonkey Jest suite, tampermonkey lint, and whitespace check passed.
Open review-fix or CI-triage loops: none.
Final status: ready.