### PR TITLE
Chore/goal portfolio viewer simplify

### DIFF
--- a/tampermonkey/__tests__/uiModels.test.js
+++ b/tampermonkey/__tests__/uiModels.test.js
@@ -272,6 +272,40 @@ describe('view model builders', () => {
         expect(retirement.health.score).toBeUndefined();
     });
 
+    test('should preserve duplicate target coverage issues across goal types in summary attention', () => {
+        const bucketMap = {
+            Retirement: {
+                _meta: { endingBalanceTotal: 2000 },
+                GENERAL_WEALTH_ACCUMULATION: {
+                    endingBalanceAmount: 1000,
+                    totalCumulativeReturn: 0,
+                    goals: [
+                        { goalId: 'g1', goalName: 'Core', endingBalanceAmount: 1000, totalCumulativeReturn: 0 }
+                    ]
+                },
+                CASH_MANAGEMENT: {
+                    endingBalanceAmount: 1000,
+                    totalCumulativeReturn: 0,
+                    goals: [
+                        { goalId: 'g3', goalName: 'Cash', endingBalanceAmount: 1000, totalCumulativeReturn: 0 }
+                    ]
+                }
+            }
+        };
+
+        const viewModel = buildSummaryViewModel(bucketMap, null, { g1: 80, g3: 80 }, {});
+        const firstReason = viewModel.buckets[0].goalTypes[0].targetCoverageIssue;
+        const secondReason = viewModel.buckets[0].goalTypes[1].targetCoverageIssue;
+
+        expect(firstReason).toBeTruthy();
+        expect(secondReason).toBe(firstReason);
+
+        const targetCoverageItems = viewModel.attentionItems
+            .filter(item => item.reason === firstReason);
+
+        expect(targetCoverageItems).toHaveLength(2);
+    });
+
     test('should build bucket detail view model with projections', () => {
         const bucketMap = createBucketMapFixture();
         const projected = createProjectedInvestmentFixture();

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -439,22 +439,26 @@
         return numericProfitValue / costBasis;
     }
 
+    function formatTwoPartDisplay(primaryDisplay, secondaryDisplay) {
+        if (primaryDisplay === '-' && secondaryDisplay === '-') {
+            return '-';
+        }
+        if (primaryDisplay === '-') {
+            return secondaryDisplay;
+        }
+        if (secondaryDisplay === '-') {
+            return primaryDisplay;
+        }
+        return `${primaryDisplay} (${secondaryDisplay})`;
+    }
+
     function formatProfitDisplay(profitValue, profitPercent) {
         const valueDisplay = formatSignedMoney(profitValue);
         const percentDisplay = formatPercent(profitPercent, {
             multiplier: 100,
             showSign: true
         });
-        if (valueDisplay === '-' && percentDisplay === '-') {
-            return '-';
-        }
-        if (valueDisplay === '-') {
-            return percentDisplay;
-        }
-        if (percentDisplay === '-') {
-            return valueDisplay;
-        }
-        return `${valueDisplay} (${percentDisplay})`;
+        return formatTwoPartDisplay(valueDisplay, percentDisplay);
     }
 
     function normalizeMoneyDisplaySpacing(value) {
@@ -470,16 +474,7 @@
             showSign: true
         });
         const valueDisplay = normalizeMoneyDisplaySpacing(formatSignedMoney(profitValue));
-        if (percentDisplay === '-' && valueDisplay === '-') {
-            return '-';
-        }
-        if (percentDisplay === '-') {
-            return valueDisplay;
-        }
-        if (valueDisplay === '-') {
-            return percentDisplay;
-        }
-        return `${percentDisplay} (${valueDisplay})`;
+        return formatTwoPartDisplay(percentDisplay, valueDisplay);
     }
 
     function getFsmProfitClass(profitPercent) {
@@ -520,7 +515,7 @@
         if (percentDisplay === '-' || amountDisplay === '-') {
             return '-';
         }
-        return `${percentDisplay} (${amountDisplay})`;
+        return formatTwoPartDisplay(percentDisplay, amountDisplay);
     }
 
     function getFiniteNumbers(values) {
@@ -1675,33 +1670,48 @@ function buildBucketPlanningModel(goalTypeModels) {
     };
 }
 
+function collectAttentionItemsFromReasons(parents, options = {}) {
+    const safeParents = Array.isArray(parents) ? parents : [];
+    const getReasons = typeof options.getReasons === 'function' ? options.getReasons : () => [];
+    const buildItem = typeof options.buildItem === 'function' ? options.buildItem : () => null;
+    const shouldSkip = typeof options.shouldSkip === 'function' ? options.shouldSkip : () => false;
+    const items = [];
+
+    safeParents.forEach(parent => {
+        const reasons = getReasons(parent);
+        reasons.forEach(reason => {
+            if (shouldSkip(reason, parent, items)) {
+                return;
+            }
+            const item = buildItem(reason, parent, items);
+            if (item) {
+                items.push(item);
+            }
+        });
+    });
+
+    return items;
+}
+
 function buildNeedsAttentionItemsForSummary(summaryViewModel) {
     if (!summaryViewModel || !Array.isArray(summaryViewModel.buckets)) {
         return [];
     }
-    const items = [];
-    summaryViewModel.buckets.forEach(bucket => {
-        const goalTypes = Array.isArray(bucket.goalTypes) ? bucket.goalTypes : [];
-        goalTypes.forEach(goalType => {
-            if (goalType.targetCoverageIssue) {
-                items.push({
-                    bucketName: bucket.bucketName,
-                    label: `${bucket.bucketName}: ${goalType.targetCoverageIssue}`,
-                    reason: goalType.targetCoverageIssue
-                });
-            }
-        });
-        const healthReasons = Array.isArray(bucket.health?.reasons) ? bucket.health.reasons : [];
-        healthReasons.forEach(reason => {
-            if (items.some(item => item.bucketName === bucket.bucketName && item.reason === reason)) {
-                return;
-            }
-            items.push({
-                bucketName: bucket.bucketName,
-                label: `${bucket.bucketName}: ${reason}`,
-                reason
-            });
-        });
+    const items = collectAttentionItemsFromReasons(summaryViewModel.buckets, {
+        getReasons: bucket => {
+            const goalTypeReasons = (Array.isArray(bucket.goalTypes) ? bucket.goalTypes : [])
+                .map(goalType => goalType?.targetCoverageIssue)
+                .filter(Boolean);
+            const healthReasons = Array.isArray(bucket.health?.reasons) ? bucket.health.reasons : [];
+            return [...goalTypeReasons, ...healthReasons];
+        },
+        shouldSkip: (reason, bucket, currentItems) => currentItems
+            .some(item => item.bucketName === bucket.bucketName && item.reason === reason),
+        buildItem: (reason, bucket) => ({
+            bucketName: bucket.bucketName,
+            label: `${bucket.bucketName}: ${reason}`,
+            reason
+        })
     });
     return items.slice(0, 6);
 }
@@ -1710,16 +1720,13 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     if (!overviewModel || !Array.isArray(overviewModel.cards)) {
         return [];
     }
-    const items = [];
-    overviewModel.cards.forEach(card => {
-        const reasons = Array.isArray(card.health?.reasons) ? card.health.reasons : [];
-        reasons.forEach(reason => {
-            items.push({
-                scopeId: card.id,
-                label: `${card.label}: ${reason}`,
-                reason
-            });
-        });
+    const items = collectAttentionItemsFromReasons(overviewModel.cards, {
+        getReasons: card => (Array.isArray(card.health?.reasons) ? card.health.reasons : []),
+        buildItem: (reason, card) => ({
+            scopeId: card.id,
+            label: `${card.label}: ${reason}`,
+            reason
+        })
     });
     return items.slice(0, 6);
 }
@@ -7516,16 +7523,6 @@ let GoalTargetStore;
     function showInfoMessage(message) {
         setSyncMessage(message, 'info');
     }
-
-    /**
-     * Format timestamp for display
-     */
-    function _formatTimestamp(timestamp) {
-        if (!timestamp) return 'Never';
-        const date = new Date(timestamp);
-        return date.toLocaleString();
-    }
-
 
     // ============================================
     // UI: Sync Functions

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1701,16 +1701,18 @@ function buildNeedsAttentionItemsForSummary(summaryViewModel) {
         getReasons: bucket => {
             const goalTypeReasons = (Array.isArray(bucket.goalTypes) ? bucket.goalTypes : [])
                 .map(goalType => goalType?.targetCoverageIssue)
-                .filter(Boolean);
-            const healthReasons = Array.isArray(bucket.health?.reasons) ? bucket.health.reasons : [];
+                .filter(Boolean)
+                .map(reason => ({ reason, dedupe: false }));
+            const healthReasons = (Array.isArray(bucket.health?.reasons) ? bucket.health.reasons : [])
+                .map(reason => ({ reason, dedupe: true }));
             return [...goalTypeReasons, ...healthReasons];
         },
         shouldSkip: (reason, bucket, currentItems) => currentItems
-            .some(item => item.bucketName === bucket.bucketName && item.reason === reason),
+            .some(item => reason?.dedupe && item.bucketName === bucket.bucketName && item.reason === reason.reason),
         buildItem: (reason, bucket) => ({
             bucketName: bucket.bucketName,
-            label: `${bucket.bucketName}: ${reason}`,
-            reason
+            label: `${bucket.bucketName}: ${reason.reason}`,
+            reason: reason.reason
         })
     });
     return items.slice(0, 6);


### PR DESCRIPTION
Summary:

• Kept the userscript single-file.
• Reduced helper duplication in tampermonkey/goal_portfolio_viewer.user.js.
• Removed dead _formatTimestamp.
• Added shared formatting helpers and an attention-item collector.
• Fixed a subtle regression in summary attention dedupe so duplicate targetCoverageIssue entries stay duplicated.
• Added a regression test for that behavior.
• Ran review-fix loop, fresh review passed cleanly.
• Verified with focused test, lint, and full Tampermonkey suite.
• Committed and pushed on chore/goal-portfolio-viewer-simplify.

Latest commit:

• 6739a08 fix(userscript): preserve summary attention duplicates