### PR TITLE
Refactor Endowus local storage cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.12",
+  "version": "2.14.13",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.11",
+  "version": "2.14.12",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/tampermonkey/__tests__/handlers.test.js
+++ b/tampermonkey/__tests__/handlers.test.js
@@ -547,20 +547,39 @@ describe('handlers and cache', () => {
         Date.now = () => 8 * 24 * 60 * 60 * 1000;
         const stale = readPerformanceCache('goal-x');
         expect(stale).toBeNull();
-        expect(storage.has('gpv_performance_goal-x')).toBe(false);
+        const staleEndowus = JSON.parse(storage.get('endowus'));
+        expect(staleEndowus.performanceCache?.['goal-x']).toBeUndefined();
     });
 
     test('performance cache removes invalid payloads', () => {
         const { readPerformanceCache } = exportsModule;
         if (!readPerformanceCache) return;
 
-        storage.set('gpv_performance_bad-json', '{invalid');
+        storage.set('endowus', JSON.stringify({
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'bad-json': '{invalid'
+            },
+            uiPreferences: { bucketMode: 'allocation', collapseState: {} }
+        }));
         expect(readPerformanceCache('bad-json')).toBeNull();
-        expect(storage.has('gpv_performance_bad-json')).toBe(false);
+        expect(JSON.parse(storage.get('endowus')).performanceCache?.['bad-json']).toBeUndefined();
 
-        storage.set('gpv_performance_bad-shape', JSON.stringify({ fetchedAt: 'nope', response: 'bad' }));
+        storage.set('endowus', JSON.stringify({
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'bad-shape': { fetchedAt: 'nope', response: 'bad' }
+            },
+            uiPreferences: { bucketMode: 'allocation', collapseState: {} }
+        }));
         expect(readPerformanceCache('bad-shape')).toBeNull();
-        expect(storage.has('gpv_performance_bad-shape')).toBe(false);
+        expect(JSON.parse(storage.get('endowus')).performanceCache?.['bad-shape']).toBeUndefined();
     });
 
     test('readPerformanceCache allows stale cache when ignoreFreshness=true', () => {
@@ -583,13 +602,23 @@ describe('handlers and cache', () => {
         const { clearPerformanceCache } = exportsModule;
         if (!clearPerformanceCache) return;
 
-        storage.set('gpv_performance_goal-a', JSON.stringify({ fetchedAt: 1, response: {} }));
-        storage.set('gpv_performance_goal-b', JSON.stringify({ fetchedAt: 1, response: {} }));
+        storage.set('endowus', JSON.stringify({
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'goal-a': { fetchedAt: 1, response: {} },
+                'goal-b': { fetchedAt: 1, response: {} }
+            },
+            uiPreferences: { bucketMode: 'allocation', collapseState: {} }
+        }));
 
         clearPerformanceCache(['goal-a', 'goal-b']);
 
-        expect(storage.has('gpv_performance_goal-a')).toBe(false);
-        expect(storage.has('gpv_performance_goal-b')).toBe(false);
+        const endowus = JSON.parse(storage.get('endowus'));
+        expect(endowus.performanceCache?.['goal-a']).toBeUndefined();
+        expect(endowus.performanceCache?.['goal-b']).toBeUndefined();
     });
 
     test('ensurePerformanceData returns null when fetch fails', async () => {

--- a/tampermonkey/__tests__/handlers.test.js
+++ b/tampermonkey/__tests__/handlers.test.js
@@ -792,7 +792,7 @@ describe('handlers and cache', () => {
     });
 
     test('hydrateVisibleGoalMetricRows updates all matching rows', () => {
-        const { hydrateVisibleGoalMetricRows, storageKeys } = exportsModule;
+        const { hydrateVisibleGoalMetricRows } = exportsModule;
         if (typeof hydrateVisibleGoalMetricRows !== 'function') return;
 
         const content = document.createElement('div');
@@ -802,22 +802,38 @@ describe('handlers and cache', () => {
             { goalId: 'goal-3', oneMonthValue: 0.01 }
         ];
 
-        goals.forEach(goal => {
-            storage.set(storageKeys.performanceCache(goal.goalId), JSON.stringify({
-                fetchedAt: Date.now(),
-                response: {
-                    returnsTable: {
-                        twr: {
-                            oneMonthValue: goal.oneMonthValue,
-                            sixMonthValue: null,
-                            ytdValue: null,
-                            oneYearValue: null,
-                            threeYearValue: null
+        storage.set('endowus', JSON.stringify({
+            performance: null,
+            investible: null,
+            summary: null,
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: goals.reduce((acc, goal) => {
+                acc[goal.goalId] = {
+                    fetchedAt: Date.now(),
+                    response: {
+                        returnsTable: {
+                            twr: {
+                                oneMonthValue: goal.oneMonthValue,
+                                sixMonthValue: null,
+                                ytdValue: null,
+                                oneYearValue: null,
+                                threeYearValue: null
+                            }
                         }
                     }
-                }
-            }));
+                };
+                return acc;
+            }, {}),
+            uiPreferences: {
+                bucketMode: 'allocation',
+                collapseState: {}
+            }
+        }));
 
+        goals.forEach(goal => {
             const metricsRow = document.createElement('tr');
             metricsRow.className = 'gpv-goal-metrics-row';
             metricsRow.dataset.goalId = goal.goalId;

--- a/tampermonkey/__tests__/handlers.test.js
+++ b/tampermonkey/__tests__/handlers.test.js
@@ -551,6 +551,63 @@ describe('handlers and cache', () => {
         expect(staleEndowus.performanceCache?.['goal-x']).toBeUndefined();
     });
 
+    test('readEndowusStore prunes orphaned performance cache entries', () => {
+        const { readPerformanceCache } = exportsModule;
+        if (!readPerformanceCache) return;
+
+        storage.set('endowus', JSON.stringify({
+            performance: [{ goalId: 'goal-keep', totalInvestmentValue: {} }],
+            investible: [{ goalId: 'goal-keep', goalName: 'Retirement - Keep', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }],
+            summary: [{ goalId: 'goal-keep', goalName: 'Retirement - Keep', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }],
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'goal-keep': { fetchedAt: Date.now(), response: { goalId: 'goal-keep' } },
+                'goal-drop': { fetchedAt: Date.now(), response: { goalId: 'goal-drop' } }
+            },
+            uiPreferences: { bucketMode: 'allocation', collapseState: {} }
+        }));
+
+        expect(readPerformanceCache('goal-keep')).not.toBeNull();
+        const endowus = JSON.parse(storage.get('endowus'));
+        expect(endowus.performanceCache?.['goal-keep']).toBeDefined();
+        expect(endowus.performanceCache?.['goal-drop']).toBeUndefined();
+    });
+
+    test('readEndowusStore prunes obsolete collapse-state entries', () => {
+        const { getCollapseState } = exportsModule;
+        if (!getCollapseState) return;
+
+        storage.set('endowus', JSON.stringify({
+            performance: [{ goalId: 'goal-1', totalInvestmentValue: {} }],
+            investible: [{ goalId: 'goal-1', goalName: 'Retirement - Goal 1', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }],
+            summary: [{ goalId: 'goal-1', goalName: 'Retirement - Goal 1', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }],
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {},
+            uiPreferences: {
+                bucketMode: 'performance',
+                collapseState: {
+                    'gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance': false,
+                    'gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|unknown-section': true,
+                    'gpv_collapse_Unknown|GENERAL_WEALTH_ACCUMULATION|projection': true,
+                    malformed: true
+                }
+            }
+        }));
+
+        expect(getCollapseState('Retirement', 'GENERAL_WEALTH_ACCUMULATION', 'performance')).toBe(false);
+        const endowus = JSON.parse(storage.get('endowus'));
+        expect(endowus.uiPreferences.bucketMode).toBe('performance');
+        expect(endowus.uiPreferences.collapseState).toEqual({
+            'gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance': false
+        });
+    });
+
     test('performance cache removes invalid payloads', () => {
         const { readPerformanceCache } = exportsModule;
         if (!readPerformanceCache) return;
@@ -582,7 +639,7 @@ describe('handlers and cache', () => {
         expect(JSON.parse(storage.get('endowus')).performanceCache?.['bad-shape']).toBeUndefined();
     });
 
-    test('readPerformanceCache allows stale cache when ignoreFreshness=true', () => {
+    test('readPerformanceCache cleanup removes stale cache even when ignoreFreshness=true', () => {
         const { writePerformanceCache, readPerformanceCache } = exportsModule;
         if (!writePerformanceCache || !readPerformanceCache) return;
 
@@ -592,10 +649,9 @@ describe('handlers and cache', () => {
         // Make entry stale (>7 days)
         Date.now = () => 8 * 24 * 60 * 60 * 1000;
 
-        // With ignoreFreshness=true, stale cache should be returned
+        // Local startup/read cleanup is aggressive and prunes stale entries.
         const stale = readPerformanceCache('goal-stale', true);
-        expect(stale).not.toBeNull();
-        expect(stale.response.data).toBe('old');
+        expect(stale).toBeNull();
     });
 
     test('clearPerformanceCache removes stored entries', () => {

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -4880,4 +4880,74 @@ describe('initialization and URL monitoring', () => {
         expect(document.activeElement).toBe(filterInput);
     });
 
+    test('startup cleanup removes unknown gpv and sync keys but preserves allowed and unrelated keys', () => {
+        storage.set('gpv_shell_compare_selection', 'stale');
+        storage.set('gpv_unknown_flag', 'stale');
+        storage.set('gpv_bucket_mode', 'allocation');
+        storage.set('gpv_performance_goal-1', JSON.stringify({ fetchedAt: Date.now(), response: {} }));
+        storage.set('gpv_collapse_bucket|goal|performance', true);
+        storage.set('sync_unknown_key', 'stale');
+        storage.set('sync_server_url', 'https://legacy.example.com');
+        storage.set('endowus', '{}');
+        storage.set('goal_target_pct_goal-1', 30);
+        global.GM_listValues = jest.fn(() => Array.from(storage.keys()));
+
+        require('../goal_portfolio_viewer.user.js');
+
+        expect(storage.has('gpv_shell_compare_selection')).toBe(false);
+        expect(storage.has('gpv_unknown_flag')).toBe(false);
+        expect(storage.has('sync_unknown_key')).toBe(false);
+        expect(storage.has('gpv_bucket_mode')).toBe(true);
+        expect(storage.has('gpv_performance_goal-1')).toBe(true);
+        expect(storage.has('gpv_collapse_bucket|goal|performance')).toBe(true);
+        expect(storage.has('endowus')).toBe(true);
+        expect(storage.has('goal_target_pct_goal-1')).toBe(true);
+    });
+
+    test('startup cleanup skips non-string GM_listValues entries and still removes stale string keys', () => {
+        storage.set('gpv_shell_compare_selection', 'stale');
+        storage.set('sync_unknown_key', 'stale');
+        global.GM_listValues = jest.fn(() => [null, 123, {}, 'gpv_shell_compare_selection', 'sync_unknown_key']);
+
+        expect(() => {
+            require('../goal_portfolio_viewer.user.js');
+        }).not.toThrow();
+
+        expect(storage.has('gpv_shell_compare_selection')).toBe(false);
+        expect(storage.has('sync_unknown_key')).toBe(false);
+    });
+
+    test('startup cleanup no-ops when GM_listValues is unavailable', () => {
+        storage.set('gpv_shell_compare_selection', 'stale');
+        delete global.GM_listValues;
+
+        expect(() => {
+            require('../goal_portfolio_viewer.user.js');
+        }).not.toThrow();
+
+        expect(storage.has('gpv_shell_compare_selection')).toBe(true);
+    });
+
+    test('startup does not throw when GM_listValues throws and stale keys are preserved', () => {
+        storage.set('gpv_shell_compare_selection', 'stale');
+        storage.set('sync_unknown_key', 'stale');
+        global.GM_listValues = jest.fn(() => {
+            throw new Error('enumeration failed');
+        });
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        expect(() => {
+            require('../goal_portfolio_viewer.user.js');
+        }).not.toThrow();
+
+        expect(storage.get('gpv_shell_compare_selection')).toBe('stale');
+        expect(storage.get('sync_unknown_key')).toBe('stale');
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[Goal Portfolio Viewer] Unable to enumerate storage keys for stale cleanup:',
+            expect.any(Error)
+        );
+
+        warnSpy.mockRestore();
+    });
+
 });

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -867,6 +867,60 @@ describe('SyncManager', () => {
         expect(config.platforms.endowus.summary).toBeUndefined();
     });
 
+    test('collectConfigData excludes Endowus local-only fields', () => {
+        const { SyncManager } = loadModule();
+        storage.set('endowus', JSON.stringify({
+            performance: [{ goalId: 'goal-1' }],
+            investible: [{ goalId: 'goal-1' }],
+            summary: [{ goalId: 'goal-1' }],
+            goalTargets: { 'goal-1': 42 },
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'goal-1': { fetchedAt: 1_234, response: { goalId: 'goal-1' } }
+            },
+            uiPreferences: {
+                bucketMode: 'performance',
+                collapseState: {
+                    'gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance': false
+                }
+            }
+        }));
+
+        const config = SyncManager.collectConfigData();
+        expect(config.platforms.endowus.goalTargets).toEqual({ 'goal-1': 42 });
+        expect(config.platforms.endowus.performanceCache).toBeUndefined();
+        expect(config.platforms.endowus.uiPreferences).toBeUndefined();
+    });
+
+    test('collectConfigData prunes stale Endowus performance cache on store read', () => {
+        const { SyncManager } = loadModule();
+        const now = 8 * 24 * 60 * 60 * 1000;
+        Date.now = jest.fn(() => now);
+        storage.set('endowus', JSON.stringify({
+            performance: [{ goalId: 'goal-1' }],
+            investible: [{ goalId: 'goal-1', goalName: 'Retirement - Goal 1', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }],
+            summary: [{ goalId: 'goal-1', goalName: 'Retirement - Goal 1', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }],
+            goalTargets: {},
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'goal-1': { fetchedAt: 1_000, response: { goalId: 'goal-1' } }
+            },
+            uiPreferences: {
+                bucketMode: 'allocation',
+                collapseState: {}
+            }
+        }));
+
+        SyncManager.collectConfigData();
+
+        const endowusStore = JSON.parse(storage.get('endowus'));
+        expect(endowusStore.performanceCache?.['goal-1']).toBeUndefined();
+    });
+
     test('applyConfigData preserves Endowus local-only fields', () => {
         const { SyncManager } = loadModule();
         storage.set('endowus', JSON.stringify({

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -788,6 +788,10 @@ describe('SyncManager', () => {
             assignmentByCode: {}
         }));
         storage.set('goal_target_pct_legacy-goal', 42);
+        const rollbackPerformancePayload = JSON.stringify({ fetchedAt: Date.now(), response: { goalId: 'goal-rollback' } });
+        storage.set('gpv_bucket_mode', 'target');
+        storage.set('gpv_performance_goal-rollback', rollbackPerformancePayload);
+        storage.set('gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance', 'true');
         global.GM_listValues = () => Array.from(storage.keys());
 
         global.GM_setValue = jest.fn((key, value) => {
@@ -808,6 +812,9 @@ describe('SyncManager', () => {
         })).toThrow('Failed to save OCBC sync config data');
 
         expect(storage.get('goal_target_pct_legacy-goal')).toBe(42);
+        expect(storage.get('gpv_bucket_mode')).toBe('target');
+        expect(storage.get('gpv_performance_goal-rollback')).toBe(rollbackPerformancePayload);
+        expect(storage.get('gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance')).toBe('true');
         expect(JSON.parse(storage.get('endowus')).goalTargets).toEqual({ keep: 25 });
         expect(storage.has('ocbc')).toBe(false);
     });

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -589,11 +589,15 @@ describe('SyncManager', () => {
     });
 
     test('collectConfigData migrates legacy platform keys and removes them', () => {
-        const { SyncManager } = loadModule();
+        const { SyncManager, storageKeys } = loadModule();
+        const freshFetchedAt = Date.now();
+        const collapseKey = storageKeys.collapseState('Retirement', 'GENERAL_WEALTH_ACCUMULATION', 'performance');
         storage.set('api_performance', JSON.stringify([{ goalId: 'goal-1' }]));
-        storage.set('gpv_performance_goal-1', JSON.stringify({ fetchedAt: 1234, response: { goalId: 'goal-1' } }));
+        storage.set('api_investible', JSON.stringify([{ goalId: 'goal-1', goalName: 'Retirement - Goal 1', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }]));
+        storage.set('api_summary', JSON.stringify([{ goalId: 'goal-1', goalName: 'Retirement - Goal 1', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }]));
+        storage.set('gpv_performance_goal-1', JSON.stringify({ fetchedAt: freshFetchedAt, response: { goalId: 'goal-1' } }));
         storage.set('gpv_bucket_mode', 'performance');
-        storage.set('gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance', 'false');
+        storage.set(collapseKey, 'false');
         storage.set('goal_target_pct_goal-1', 25);
         storage.set('goal_fixed_goal-2', true);
         storage.set('fsm_portfolios', JSON.stringify([{ id: 'core', name: 'Core', archived: false }]));
@@ -623,14 +627,14 @@ describe('SyncManager', () => {
         expect(storage.has('ocbc_target_pct_assets|P-1|core|P-1%3AEQ1')).toBe(false);
         expect(storage.has('gpv_performance_goal-1')).toBe(false);
         expect(storage.has('gpv_bucket_mode')).toBe(false);
-        expect(storage.has('gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance')).toBe(false);
+        expect(storage.has(collapseKey)).toBe(false);
 
         const endowusStore = JSON.parse(storage.get('endowus'));
-        expect(endowusStore.performanceCache?.['goal-1']).toEqual({ fetchedAt: 1234, response: { goalId: 'goal-1' } });
+        expect(endowusStore.performanceCache?.['goal-1']).toEqual({ fetchedAt: freshFetchedAt, response: { goalId: 'goal-1' } });
         expect(endowusStore.uiPreferences).toEqual(expect.objectContaining({
             bucketMode: 'performance'
         }));
-        expect(endowusStore.uiPreferences.collapseState?.['gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance']).toBe(false);
+        expect(endowusStore.uiPreferences.collapseState?.[collapseKey]).toBe(false);
     });
 
     test('collectConfigData preserves existing top-level store over legacy values while cleaning legacy keys', () => {
@@ -923,13 +927,14 @@ describe('SyncManager', () => {
 
     test('applyConfigData preserves Endowus local-only fields', () => {
         const { SyncManager } = loadModule();
+        const freshFetchedAt = Date.now();
         storage.set('endowus', JSON.stringify({
             goalTargets: { legacy: 10 },
             goalFixed: {},
             goalBuckets: {},
             clearedGoalBuckets: {},
             performanceCache: {
-                'goal-1': { fetchedAt: 1_234, response: { goalId: 'goal-1' } }
+                'goal-1': { fetchedAt: freshFetchedAt, response: { goalId: 'goal-1' } }
             },
             uiPreferences: {
                 bucketMode: 'performance',
@@ -957,7 +962,7 @@ describe('SyncManager', () => {
 
         const endowusStore = JSON.parse(storage.get('endowus'));
         expect(endowusStore.goalTargets).toEqual({ 'goal-new': 55 });
-        expect(endowusStore.performanceCache?.['goal-1']).toEqual({ fetchedAt: 1_234, response: { goalId: 'goal-1' } });
+        expect(endowusStore.performanceCache?.['goal-1']).toEqual({ fetchedAt: freshFetchedAt, response: { goalId: 'goal-1' } });
         expect(endowusStore.uiPreferences).toEqual(expect.objectContaining({
             bucketMode: 'performance'
         }));

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -591,6 +591,9 @@ describe('SyncManager', () => {
     test('collectConfigData migrates legacy platform keys and removes them', () => {
         const { SyncManager } = loadModule();
         storage.set('api_performance', JSON.stringify([{ goalId: 'goal-1' }]));
+        storage.set('gpv_performance_goal-1', JSON.stringify({ fetchedAt: 1234, response: { goalId: 'goal-1' } }));
+        storage.set('gpv_bucket_mode', 'performance');
+        storage.set('gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance', 'false');
         storage.set('goal_target_pct_goal-1', 25);
         storage.set('goal_fixed_goal-2', true);
         storage.set('fsm_portfolios', JSON.stringify([{ id: 'core', name: 'Core', archived: false }]));
@@ -618,6 +621,16 @@ describe('SyncManager', () => {
         expect(storage.has('api_fsm_holdings')).toBe(false);
         expect(storage.has('ocbc_sub_portfolios')).toBe(false);
         expect(storage.has('ocbc_target_pct_assets|P-1|core|P-1%3AEQ1')).toBe(false);
+        expect(storage.has('gpv_performance_goal-1')).toBe(false);
+        expect(storage.has('gpv_bucket_mode')).toBe(false);
+        expect(storage.has('gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance')).toBe(false);
+
+        const endowusStore = JSON.parse(storage.get('endowus'));
+        expect(endowusStore.performanceCache?.['goal-1']).toEqual({ fetchedAt: 1234, response: { goalId: 'goal-1' } });
+        expect(endowusStore.uiPreferences).toEqual(expect.objectContaining({
+            bucketMode: 'performance'
+        }));
+        expect(endowusStore.uiPreferences.collapseState?.['gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance']).toBe(false);
     });
 
     test('collectConfigData preserves existing top-level store over legacy values while cleaning legacy keys', () => {
@@ -852,6 +865,49 @@ describe('SyncManager', () => {
         expect(config.platforms.endowus.performance).toBeUndefined();
         expect(config.platforms.endowus.investible).toBeUndefined();
         expect(config.platforms.endowus.summary).toBeUndefined();
+    });
+
+    test('applyConfigData preserves Endowus local-only fields', () => {
+        const { SyncManager } = loadModule();
+        storage.set('endowus', JSON.stringify({
+            goalTargets: { legacy: 10 },
+            goalFixed: {},
+            goalBuckets: {},
+            clearedGoalBuckets: {},
+            performanceCache: {
+                'goal-1': { fetchedAt: 1_234, response: { goalId: 'goal-1' } }
+            },
+            uiPreferences: {
+                bucketMode: 'performance',
+                collapseState: {
+                    'gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance': false
+                }
+            }
+        }));
+
+        SyncManager.applyConfigData({
+            version: 2,
+            platforms: {
+                endowus: {
+                    goalTargets: { 'goal-new': 55 },
+                    goalFixed: {},
+                    goalBuckets: {},
+                    clearedGoalBuckets: {},
+                    timestamp: Date.now()
+                },
+                fsm: { targetsByCode: {}, fixedByCode: {}, portfolios: [], assignmentByCode: {}, timestamp: Date.now() },
+                ocbc: { subPortfolios: {}, assignmentByCode: {}, orderByScope: {}, targetsByScope: {}, timestamp: Date.now() }
+            },
+            timestamp: Date.now()
+        });
+
+        const endowusStore = JSON.parse(storage.get('endowus'));
+        expect(endowusStore.goalTargets).toEqual({ 'goal-new': 55 });
+        expect(endowusStore.performanceCache?.['goal-1']).toEqual({ fetchedAt: 1_234, response: { goalId: 'goal-1' } });
+        expect(endowusStore.uiPreferences).toEqual(expect.objectContaining({
+            bucketMode: 'performance'
+        }));
+        expect(endowusStore.uiPreferences.collapseState?.['gpv_collapse_Retirement|GENERAL_WEALTH_ACCUMULATION|performance']).toBe(false);
     });
 
     test('collectConfigData does not run legacy cleanup repeatedly without legacy keys', () => {

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -129,25 +129,140 @@ describe('SyncManager', () => {
         SyncManager.__test.setSessionMasterKey(new Uint8Array([1, 2, 3, 4]));
     }
 
+    function getSyncStore() {
+        return JSON.parse(storage.get('sync') || '{}');
+    }
+
     function seedConfiguredState() {
-        storage.set('sync_enabled', true);
-        storage.set('sync_server_url', 'https://sync.example.com');
-        storage.set('sync_user_id', 'user@example.com');
-        storage.set('sync_refresh_token', 'refresh-token');
-        storage.set('sync_refresh_token_expiry', Date.now() + 120_000);
-        storage.set('sync_access_token', 'access-token');
-        storage.set('sync_access_token_expiry', Date.now() + 120_000);
+        storage.set('sync', JSON.stringify({
+            enabled: true,
+            serverUrl: 'https://sync.example.com',
+            userId: 'user@example.com',
+            refreshToken: 'refresh-token',
+            refreshTokenExpiry: Date.now() + 120_000,
+            accessToken: 'access-token',
+            accessTokenExpiry: Date.now() + 120_000
+        }));
     }
 
     function seedConfiguredWithoutAccessToken() {
+        storage.set('sync', JSON.stringify({
+            enabled: true,
+            serverUrl: 'https://sync.example.com',
+            userId: 'user@example.com',
+            refreshToken: 'refresh-token',
+            refreshTokenExpiry: Date.now() + 120_000
+        }));
+    }
+
+    test('legacy flat sync keys migrate full sync schema into sync store and are removed', () => {
         storage.set('sync_enabled', true);
         storage.set('sync_server_url', 'https://sync.example.com');
         storage.set('sync_user_id', 'user@example.com');
-        storage.set('sync_refresh_token', 'refresh-token');
-        storage.set('sync_refresh_token_expiry', Date.now() + 120_000);
-        storage.delete('sync_access_token');
-        storage.delete('sync_access_token_expiry');
-    }
+        storage.set('sync_device_id', 'device-123');
+        storage.set('sync_last_sync', 2_000_000_000_000);
+        storage.set('sync_last_data_timestamp', 1_999_999_999_000);
+        storage.set('sync_last_sync_metadata_version', 2);
+        storage.set('sync_last_hash', 'abc123');
+        storage.set('sync_auto_sync', false);
+        storage.set('sync_interval_minutes', 45);
+        storage.set('sync_access_token', 'legacy-access-token');
+        storage.set('sync_refresh_token', 'legacy-refresh-token');
+        storage.set('sync_access_token_expiry', 2_000_000_030_000);
+        storage.set('sync_refresh_token_expiry', 2_000_000_060_000);
+        storage.set('sync_remember_key', true);
+        storage.set('sync_master_key', btoa(String.fromCharCode(1, 2, 3, 4)));
+
+        loadModule();
+
+        const syncStore = getSyncStore();
+        expect(syncStore.enabled).toBe(true);
+        expect(syncStore.serverUrl).toBe('https://sync.example.com');
+        expect(syncStore.userId).toBe('user@example.com');
+        expect(syncStore.deviceId).toBe('device-123');
+        expect(syncStore.lastSync).toBe(2_000_000_000_000);
+        expect(syncStore.lastDataTimestamp).toBe(1_999_999_999_000);
+        expect(syncStore.lastSyncMetadataVersion).toBe(2);
+        expect(syncStore.lastSyncHash).toBe('abc123');
+        expect(syncStore.autoSync).toBe(false);
+        expect(syncStore.syncInterval).toBe(45);
+        expect(syncStore.accessToken).toBe('legacy-access-token');
+        expect(syncStore.refreshToken).toBe('legacy-refresh-token');
+        expect(syncStore.accessTokenExpiry).toBe(2_000_000_030_000);
+        expect(syncStore.refreshTokenExpiry).toBe(2_000_000_060_000);
+        expect(syncStore.rememberKey).toBe(true);
+        expect(syncStore.rememberedMasterKey).toBe(btoa(String.fromCharCode(1, 2, 3, 4)));
+        expect(storage.has('sync_enabled')).toBe(false);
+        expect(storage.has('sync_server_url')).toBe(false);
+        expect(storage.has('sync_user_id')).toBe(false);
+        expect(storage.has('sync_device_id')).toBe(false);
+        expect(storage.has('sync_last_sync')).toBe(false);
+        expect(storage.has('sync_last_data_timestamp')).toBe(false);
+        expect(storage.has('sync_last_sync_metadata_version')).toBe(false);
+        expect(storage.has('sync_last_hash')).toBe(false);
+        expect(storage.has('sync_auto_sync')).toBe(false);
+        expect(storage.has('sync_interval_minutes')).toBe(false);
+        expect(storage.has('sync_access_token')).toBe(false);
+        expect(storage.has('sync_refresh_token')).toBe(false);
+        expect(storage.has('sync_access_token_expiry')).toBe(false);
+        expect(storage.has('sync_refresh_token_expiry')).toBe(false);
+        expect(storage.has('sync_remember_key')).toBe(false);
+        expect(storage.has('sync_master_key')).toBe(false);
+    });
+
+    test('legacy flat sync keys are retained when migrated sync write fails', () => {
+        storage.set('sync_enabled', true);
+        storage.set('sync_server_url', 'https://sync.example.com');
+        storage.set('sync_user_id', 'user@example.com');
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const originalSetValue = global.GM_setValue;
+        global.GM_setValue = (key, value) => {
+            if (key === 'sync') {
+                throw new Error('write failed');
+            }
+            return originalSetValue(key, value);
+        };
+
+        try {
+            loadModule();
+            expect(storage.has('sync')).toBe(false);
+            expect(storage.get('sync_enabled')).toBe(true);
+            expect(storage.get('sync_server_url')).toBe('https://sync.example.com');
+            expect(storage.get('sync_user_id')).toBe('user@example.com');
+            expect(errorSpy).toHaveBeenCalledWith('[Goal Portfolio Viewer] Error writing merged sync store:', expect.any(Error));
+        } finally {
+            global.GM_setValue = originalSetValue;
+            errorSpy.mockRestore();
+        }
+    });
+
+    test('malformed sync store migrates from legacy keys and removes legacy keys after successful write', () => {
+        storage.set('sync', '{malformed');
+        storage.set('sync_enabled', true);
+        storage.set('sync_user_id', 'user@example.com');
+
+        loadModule();
+
+        const syncStore = getSyncStore();
+        expect(syncStore.enabled).toBe(true);
+        expect(syncStore.userId).toBe('user@example.com');
+        expect(storage.has('sync_enabled')).toBe(false);
+        expect(storage.has('sync_user_id')).toBe(false);
+    });
+
+    test('existing sync values win over legacy with missing fields filled', () => {
+        storage.set('sync', JSON.stringify({ enabled: false, serverUrl: 'https://current.example.com' }));
+        storage.set('sync_enabled', true);
+        storage.set('sync_server_url', 'https://legacy.example.com');
+        storage.set('sync_user_id', 'legacy-user');
+
+        loadModule();
+
+        const syncStore = getSyncStore();
+        expect(syncStore.enabled).toBe(false);
+        expect(syncStore.serverUrl).toBe('https://current.example.com');
+        expect(syncStore.userId).toBe('legacy-user');
+    });
 
     test('startAutoSync does not schedule when auto-sync disabled', () => {
         jest.spyOn(global, 'setInterval');
@@ -270,7 +385,10 @@ describe('SyncManager', () => {
         expect(SyncManager.__test.getAutoSyncIntervalMs()).toBe(10 * 60 * 1000);
         expect(SyncManager.__test.isStartupSyncDue()).toBe(true);
 
-        storage.set('sync_last_sync', now - (9 * 60 * 1000));
+        storage.set('sync', JSON.stringify({
+            ...getSyncStore(),
+            lastSync: now - (9 * 60 * 1000)
+        }));
         expect(SyncManager.__test.isStartupSyncDue()).toBe(false);
     });
 
@@ -444,8 +562,9 @@ describe('SyncManager', () => {
             rememberKey: true
         })).resolves.toBeUndefined();
 
-        expect(storage.get('sync_remember_key')).toBe(true);
-        expect(typeof storage.get('sync_master_key')).toBe('string');
+        const syncStore = getSyncStore();
+        expect(syncStore.rememberKey).toBe(true);
+        expect(typeof syncStore.rememberedMasterKey).toBe('string');
         expect(SyncManager.getStatus().hasSessionKey).toBe(true);
     });
 
@@ -470,8 +589,9 @@ describe('SyncManager', () => {
             rememberKey: false
         });
 
-        expect(storage.get('sync_remember_key')).toBe(false);
-        expect(storage.has('sync_master_key')).toBe(false);
+        const syncStore = getSyncStore();
+        expect(syncStore.rememberKey).toBe(false);
+        expect(syncStore.rememberedMasterKey).toBeUndefined();
     });
 
     test('enable clears stale crypto lock error after unlocking session key', async () => {
@@ -1132,10 +1252,11 @@ describe('SyncManager', () => {
 
             expect(document.dispatchEvent).toHaveBeenCalled();
 
-            expect(storage.get('sync_last_sync')).toBe(now);
-            expect(storage.get('sync_last_sync_metadata_version')).toBe(2);
-            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
-            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+            const syncStore = getSyncStore();
+            expect(syncStore.lastSync).toBe(now);
+            expect(syncStore.lastSyncMetadataVersion).toBe(2);
+            expect(syncStore.lastDataTimestamp).toBe(serverTimestamp);
+            expect(syncStore.lastSyncHash).toEqual(expect.any(String));
         });
 
         test('resolveConflict(remote) records attempt time separately from remote data timestamp', async () => {
@@ -1175,10 +1296,11 @@ describe('SyncManager', () => {
 
             expect(document.dispatchEvent).toHaveBeenCalled();
             expect(JSON.parse(storage.get('endowus')).goalTargets['goal-1']).toBe(50);
-            expect(storage.get('sync_last_sync')).toBe(now);
-            expect(storage.get('sync_last_sync_metadata_version')).toBe(2);
-            expect(storage.get('sync_last_data_timestamp')).toBe(remoteTimestamp);
-            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+            const syncStore = getSyncStore();
+            expect(syncStore.lastSync).toBe(now);
+            expect(syncStore.lastSyncMetadataVersion).toBe(2);
+            expect(syncStore.lastDataTimestamp).toBe(remoteTimestamp);
+            expect(syncStore.lastSyncHash).toEqual(expect.any(String));
         });
 
         test('performSync(both) treats identical content from another device as up to date', async () => {
@@ -1194,7 +1316,16 @@ describe('SyncManager', () => {
 
             const serverTimestamp = Date.now() + 60_000;
             Date.now = jest.fn(() => serverTimestamp + 1);
-            storage.set('sync_refresh_token_expiry', serverTimestamp + 120_000);
+            storage.set('sync', JSON.stringify({
+                ...getSyncStore(),
+                enabled: true,
+                serverUrl: 'https://sync.example.com',
+                userId: 'user@example.com',
+                refreshToken: 'refresh-token',
+                refreshTokenExpiry: serverTimestamp + 120_000,
+                accessToken: 'access-token',
+                accessTokenExpiry: Date.now() - 1_000
+            }));
             const serverUrl = 'https://sync.example.com';
             const serverConfig = {
                 version: 2,
@@ -1295,9 +1426,10 @@ describe('SyncManager', () => {
 
             const syncPostCalls = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth'));
             expect(syncPostCalls).toHaveLength(0);
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
-            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
-            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+            const syncStore = getSyncStore();
+            expect(syncStore.lastSync).toBe(serverTimestamp + 1);
+            expect(syncStore.lastDataTimestamp).toBe(serverTimestamp);
+            expect(syncStore.lastSyncHash).toEqual(expect.any(String));
         });
 
         test('performSync(both) bootstraps from remote when local sync metadata is missing', async () => {
@@ -1315,7 +1447,16 @@ describe('SyncManager', () => {
 
             const serverTimestamp = Date.now() + 60_000;
             Date.now = jest.fn(() => serverTimestamp + 1);
-            storage.set('sync_refresh_token_expiry', serverTimestamp + 120_000);
+            storage.set('sync', JSON.stringify({
+                ...getSyncStore(),
+                enabled: true,
+                serverUrl: 'https://sync.example.com',
+                userId: 'user@example.com',
+                refreshToken: 'refresh-token',
+                refreshTokenExpiry: serverTimestamp + 120_000,
+                accessToken: 'access-token',
+                accessTokenExpiry: Date.now() - 1_000
+            }));
             const serverUrl = 'https://sync.example.com';
             const serverConfig = {
                 version: 2,
@@ -1418,9 +1559,10 @@ describe('SyncManager', () => {
             expect(syncPostCalls).toHaveLength(0);
             expect(storage.has(localTargetKey)).toBe(false);
             expect(JSON.parse(storage.get('endowus')).goalTargets['remote-goal']).toBe(45);
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
-            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
-            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+            const syncStore = getSyncStore();
+            expect(syncStore.lastSync).toBe(serverTimestamp + 1);
+            expect(syncStore.lastDataTimestamp).toBe(serverTimestamp);
+            expect(syncStore.lastSyncHash).toEqual(expect.any(String));
         });
 
         test('attempt-only sync after partial migration metadata does not become data freshness', async () => {
@@ -1463,8 +1605,16 @@ describe('SyncManager', () => {
 
             let phase = 'initial-upload';
             Date.now = jest.fn(() => initialTimestamp);
-            storage.set('sync_access_token_expiry', attemptTimestamp + 120_000);
-            storage.set('sync_refresh_token_expiry', attemptTimestamp + 120_000);
+            storage.set('sync', JSON.stringify({
+                ...getSyncStore(),
+                enabled: true,
+                serverUrl: 'https://sync.example.com',
+                userId: 'user@example.com',
+                refreshToken: 'refresh-token',
+                refreshTokenExpiry: attemptTimestamp + 120_000,
+                accessToken: 'access-token',
+                accessTokenExpiry: attemptTimestamp + 120_000
+            }));
             fetchMock = jest.fn((url, options = {}) => {
                 if (url === `${serverUrl}/auth/refresh`) {
                     return Promise.resolve({
@@ -1538,16 +1688,19 @@ describe('SyncManager', () => {
             window.fetch = fetchMock;
 
             await expect(SyncManager.performSync({ direction: 'both' })).resolves.toEqual({ status: 'success' });
-            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+            expect(getSyncStore().lastSyncHash).toEqual(expect.any(String));
 
-            storage.delete('sync_last_data_timestamp');
-            storage.delete('sync_last_sync_metadata_version');
+            const syncStoreBeforeAttempt = getSyncStore();
+            delete syncStoreBeforeAttempt.lastDataTimestamp;
+            delete syncStoreBeforeAttempt.lastSyncMetadataVersion;
+            storage.set('sync', JSON.stringify(syncStoreBeforeAttempt));
             Date.now = jest.fn(() => attemptTimestamp);
             phase = 'attempt-only';
             await expect(SyncManager.performSync({ direction: 'download' })).resolves.toEqual({ status: 'success' });
-            expect(storage.get('sync_last_sync')).toBe(attemptTimestamp);
-            expect(storage.get('sync_last_sync_metadata_version')).toBe(2);
-            expect(storage.has('sync_last_data_timestamp')).toBe(false);
+            const syncStore = getSyncStore();
+            expect(syncStore.lastSync).toBe(attemptTimestamp);
+            expect(syncStore.lastSyncMetadataVersion).toBe(2);
+            expect(syncStore.lastDataTimestamp).toBeUndefined();
 
             phase = 'remote-available';
             const postCountBeforeRemoteSync = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth')).length;
@@ -1557,8 +1710,9 @@ describe('SyncManager', () => {
             const postCountAfterRemoteSync = fetchMock.mock.calls.filter(([url, options = {}]) => options.method === 'POST' && url.includes('/sync') && !url.includes('/auth')).length;
             expect(postCountAfterRemoteSync).toBe(postCountBeforeRemoteSync);
             expect(JSON.parse(storage.get('endowus')).goalTargets['goal-1']).toBe(50);
-            expect(storage.get('sync_last_sync')).toBe(attemptTimestamp);
-            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
+            const syncStoreAfterRemote = getSyncStore();
+            expect(syncStoreAfterRemote.lastSync).toBe(attemptTimestamp);
+            expect(syncStoreAfterRemote.lastDataTimestamp).toBe(serverTimestamp);
         });
 
         test('performSync(download) stores attempt and data timestamps separately', async () => {
@@ -1657,9 +1811,10 @@ describe('SyncManager', () => {
 
             await expect(SyncManager.performSync({ direction: 'download' })).resolves.toEqual({ status: 'success' });
 
-            expect(storage.get('sync_last_sync')).toBe(serverTimestamp + 1);
-            expect(storage.get('sync_last_data_timestamp')).toBe(serverTimestamp);
-            expect(storage.get('sync_last_hash')).toEqual(expect.any(String));
+            const syncStore = getSyncStore();
+            expect(syncStore.lastSync).toBe(serverTimestamp + 1);
+            expect(syncStore.lastDataTimestamp).toBe(serverTimestamp);
+            expect(syncStore.lastSyncHash).toEqual(expect.any(String));
             expect(JSON.parse(storage.get('endowus')).goalTargets['goal-2']).toBe(40);
         });
     });
@@ -1682,7 +1837,6 @@ describe('SyncManager', () => {
 
     describe('token helpers', () => {
         const ACCESS_EXPIRY_KEY = 'sync_access_token_expiry';
-        const REFRESH_EXPIRY_KEY = 'sync_refresh_token_expiry';
 
         function createJwt(payload) {
             const base64 = Buffer.from(JSON.stringify(payload))
@@ -1740,10 +1894,13 @@ describe('SyncManager', () => {
             const { SyncManager } = loadModule();
             const { refreshAccessToken } = SyncManager.__test;
 
-            storage.set('sync_refresh_token', 'refresh-token');
-            storage.set('sync_access_token', 'access-token');
-            storage.set(ACCESS_EXPIRY_KEY, Date.now() + 120_000);
-            storage.set(REFRESH_EXPIRY_KEY, Date.now() + 240_000);
+            storage.set('sync', JSON.stringify({
+                ...getSyncStore(),
+                refreshToken: 'refresh-token',
+                accessToken: 'access-token',
+                accessTokenExpiry: Date.now() + 120_000,
+                refreshTokenExpiry: Date.now() + 240_000
+            }));
 
             const errorMock = jest.fn(() => Promise.resolve({
                 ok: false,
@@ -1758,10 +1915,11 @@ describe('SyncManager', () => {
             global.GM_xmlhttpRequest = undefined;
 
             await expect(refreshAccessToken()).rejects.toThrow('Session expired.');
-            expect(storage.has('sync_access_token')).toBe(false);
-            expect(storage.has('sync_refresh_token')).toBe(false);
-            expect(storage.has(ACCESS_EXPIRY_KEY)).toBe(false);
-            expect(storage.has(REFRESH_EXPIRY_KEY)).toBe(false);
+            const syncStore = getSyncStore();
+            expect(syncStore.accessToken).toBeUndefined();
+            expect(syncStore.refreshToken).toBeUndefined();
+            expect(syncStore.accessTokenExpiry).toBeUndefined();
+            expect(syncStore.refreshTokenExpiry).toBeUndefined();
         });
 
         test('refreshAccessToken stores new tokens on success', async () => {
@@ -1770,7 +1928,10 @@ describe('SyncManager', () => {
             const { refreshAccessToken } = SyncManager.__test;
             const now = Date.now();
 
-            storage.set('sync_refresh_token', 'refresh-token');
+            storage.set('sync', JSON.stringify({
+                ...getSyncStore(),
+                refreshToken: 'refresh-token'
+            }));
 
             const successMock = jest.fn(() => Promise.resolve({
                 ok: true,
@@ -1807,10 +1968,11 @@ describe('SyncManager', () => {
             window.fetch = successMock;
 
             await expect(refreshAccessToken()).resolves.toBe('new-access');
-            expect(storage.get('sync_access_token')).toBe('new-access');
-            expect(storage.get('sync_refresh_token')).toBe('new-refresh');
-            expect(storage.get(ACCESS_EXPIRY_KEY)).toBe(now + 60_000);
-            expect(storage.get(REFRESH_EXPIRY_KEY)).toBe(now + 120_000);
+            const syncStore = getSyncStore();
+            expect(syncStore.accessToken).toBe('new-access');
+            expect(syncStore.refreshToken).toBe('new-refresh');
+            expect(syncStore.accessTokenExpiry).toBe(now + 60_000);
+            expect(syncStore.refreshTokenExpiry).toBe(now + 120_000);
         });
 
         test('getAccessToken refreshes expired access tokens and preserves valid ones', async () => {
@@ -1865,8 +2027,9 @@ describe('SyncManager', () => {
             window.fetch = refreshMock;
 
             await expect(getAccessToken()).resolves.toBe('refreshed-access');
-            expect(storage.get('sync_access_token')).toBe('refreshed-access');
-            expect(storage.get('sync_refresh_token')).toBe('refreshed-refresh');
+            const syncStore = getSyncStore();
+            expect(syncStore.accessToken).toBe('refreshed-access');
+            expect(syncStore.refreshToken).toBe('refreshed-refresh');
         });
     });
 });

--- a/tampermonkey/__tests__/uiModels.test.js
+++ b/tampermonkey/__tests__/uiModels.test.js
@@ -27,7 +27,6 @@ const {
     buildGoalFixedById,
     buildMergedInvestmentData,
     buildBucketPlanningModel,
-    getPerformanceCacheKey,
     getBucketViewModePreference,
     setBucketViewModePreference,
     getCollapseState,
@@ -422,9 +421,9 @@ describe('view model builders', () => {
         global.GM_setValue = (key, value) => storage.set(key, value);
         global.GM_deleteValue = key => storage.delete(key);
         try {
-            Object.entries(cacheFixture).forEach(([goalId, payload]) => {
-                storage.set(getPerformanceCacheKey(goalId), JSON.stringify(payload));
-            });
+            storage.set('endowus', JSON.stringify({
+                performanceCache: cacheFixture
+            }));
             const viewModel = buildBucketDetailViewModel({
                 bucketName: 'Retirement',
                 bucketMap,

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -4579,11 +4579,13 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         const collectRelevantLegacyKeys = () => {
             const exactKeys = [
                 ...LEGACY_ENDOWUS_EXACT_KEYS,
+                ...LEGACY_ENDOWUS_LOCAL_EXACT_KEYS,
                 ...LEGACY_FSM_EXACT_KEYS,
                 ...LEGACY_OCBC_EXACT_KEYS
             ];
             const prefixes = [
                 ...LEGACY_ENDOWUS_PREFIXES,
+                ...LEGACY_ENDOWUS_LOCAL_PREFIXES,
                 ...LEGACY_FSM_PREFIXES,
                 ...LEGACY_OCBC_PREFIXES
             ];
@@ -4719,6 +4721,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 ...(typeof GM_listValues === 'function'
                     ? GM_listValues().filter(key => (
                         LEGACY_ENDOWUS_PREFIXES
+                            .concat(LEGACY_ENDOWUS_LOCAL_PREFIXES)
                             .concat(LEGACY_FSM_PREFIXES)
                             .concat(LEGACY_OCBC_PREFIXES)
                             .some(prefix => key.startsWith(prefix))

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.12
+// @version      2.14.13
 // @description  View and organize your investment portfolio with a modern interface across Endowus, FSM, and OCBC holdings. Includes bucket analytics and optional cross-device sync for configuration.
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*
@@ -55,6 +55,7 @@
         endowus: 'endowus',
         fsm: 'fsm',
         ocbc: 'ocbc',
+        sync: 'sync',
         performance: 'api_performance',
         investible: 'api_investible',
         summary: 'api_summary',
@@ -135,6 +136,11 @@
         rememberKey: 'sync_remember_key',
         rememberedMasterKey: 'sync_master_key'
     };
+    const SYNC_STORAGE_FIELDS_BY_KEY = Object.freeze(Object.entries(SYNC_STORAGE_KEYS).reduce((acc, [field, key]) => {
+        acc[key] = field;
+        return acc;
+    }, {}));
+    const ACTIVE_SYNC_STORAGE_KEY_SET = new Set(Object.values(SYNC_STORAGE_KEYS));
 
     const SYNC_DEFAULTS = {
         serverUrl: 'https://goal-portfolio-sync.laurenceputra.workers.dev',
@@ -2877,7 +2883,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
     const Storage = {
         missing: Object.freeze({ __gpvStorageMissing: true }),
-        get(key, fallback, context) {
+        getRaw(key, fallback, context) {
             try {
                 return GM_getValue(key, fallback);
             } catch (error) {
@@ -2886,10 +2892,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 return fallback;
             }
         },
-        has(key, context) {
-            return Storage.get(key, Storage.missing, context) !== Storage.missing;
-        },
-        set(key, value, context) {
+        setRaw(key, value, context) {
             try {
                 GM_setValue(key, value);
                 return true;
@@ -2899,7 +2902,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 return false;
             }
         },
-        remove(key, context) {
+        removeRaw(key, context) {
             try {
                 GM_deleteValue(key);
                 return true;
@@ -2909,8 +2912,72 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 return false;
             }
         },
+        get(key, fallback, context) {
+            const syncField = SYNC_STORAGE_FIELDS_BY_KEY[key];
+            if (syncField) {
+                const syncStore = Storage.readJson(
+                    STORAGE_KEYS.sync,
+                    data => data && typeof data === 'object' && !Array.isArray(data),
+                    context || 'Error reading sync store'
+                ) || {};
+                if (Object.prototype.hasOwnProperty.call(syncStore, syncField)) {
+                    return syncStore[syncField];
+                }
+                if (Storage.hasRaw(key)) {
+                    return Storage.getRaw(key, fallback, context);
+                }
+                return fallback;
+            }
+            return Storage.getRaw(key, fallback, context);
+        },
+        has(key, context) {
+            return Storage.get(key, Storage.missing, context) !== Storage.missing;
+        },
+        hasRaw(key, context) {
+            return Storage.getRaw(key, Storage.missing, context) !== Storage.missing;
+        },
+        set(key, value, context) {
+            const syncField = SYNC_STORAGE_FIELDS_BY_KEY[key];
+            if (syncField) {
+                const syncStore = Storage.readJson(
+                    STORAGE_KEYS.sync,
+                    data => data && typeof data === 'object' && !Array.isArray(data),
+                    context || 'Error reading sync store'
+                ) || {};
+                syncStore[syncField] = value;
+                const didWrite = Storage.writeJson(STORAGE_KEYS.sync, syncStore, context || 'Error writing sync store');
+                if (didWrite && Storage.hasRaw(key)) {
+                    Storage.removeRaw(key, context || `Error deleting legacy sync key: ${key}`);
+                }
+                return didWrite;
+            }
+            return Storage.setRaw(key, value, context);
+        },
+        remove(key, context) {
+            const syncField = SYNC_STORAGE_FIELDS_BY_KEY[key];
+            if (syncField) {
+                const syncStore = Storage.readJson(
+                    STORAGE_KEYS.sync,
+                    data => data && typeof data === 'object' && !Array.isArray(data),
+                    context || 'Error reading sync store'
+                ) || {};
+                if (!Object.prototype.hasOwnProperty.call(syncStore, syncField)) {
+                    if (Storage.hasRaw(key)) {
+                        return Storage.removeRaw(key, context || `Error deleting legacy sync key: ${key}`);
+                    }
+                    return true;
+                }
+                delete syncStore[syncField];
+                const didWrite = Storage.writeJson(STORAGE_KEYS.sync, syncStore, context || 'Error writing sync store');
+                if (didWrite && Storage.hasRaw(key)) {
+                    Storage.removeRaw(key, context || `Error deleting legacy sync key: ${key}`);
+                }
+                return didWrite;
+            }
+            return Storage.removeRaw(key, context);
+        },
         readJson(key, validateFn, context) {
-            const stored = Storage.get(key, null, context);
+            const stored = Storage.getRaw(key, null, context);
             if (!stored) {
                 return null;
             }
@@ -2923,7 +2990,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             return parsed;
         },
         writeJson(key, value, context) {
-            return Storage.set(key, JSON.stringify(value), context);
+            return Storage.setRaw(key, JSON.stringify(value), context);
         }
     };
 
@@ -3122,6 +3189,94 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         Storage.remove(STORAGE_KEYS.ocbcAllocationOrderByScope, 'Error deleting legacy OCBC order data');
         removeLegacyPrefixedKeys(STORAGE_KEY_PREFIXES.ocbcTarget, 'Error deleting legacy OCBC target key');
     }
+
+    function normalizeSyncStore(data) {
+        return data && typeof data === 'object' && !Array.isArray(data) ? { ...data } : {};
+    }
+
+    function readSyncStore() {
+        return normalizeSyncStore(Storage.readJson(
+            STORAGE_KEYS.sync,
+            data => data && typeof data === 'object' && !Array.isArray(data),
+            'Error loading sync store'
+        ));
+    }
+
+    function writeSyncStore(store, context = 'Error saving sync store') {
+        return Storage.writeJson(STORAGE_KEYS.sync, normalizeSyncStore(store), context);
+    }
+
+    function cleanupLegacySyncKeys() {
+        ACTIVE_SYNC_STORAGE_KEY_SET.forEach(key => {
+            Storage.removeRaw(key, `Error deleting legacy sync key: ${key}`);
+        });
+    }
+
+    function migrateLegacySyncStore() {
+        const currentSyncStore = readSyncStore();
+        const mergedSyncStore = { ...currentSyncStore };
+        let didMergeLegacy = false;
+
+        Object.entries(SYNC_STORAGE_KEYS).forEach(([field, legacyKey]) => {
+            if (Object.prototype.hasOwnProperty.call(mergedSyncStore, field)) {
+                return;
+            }
+            if (!Storage.hasRaw(legacyKey)) {
+                return;
+            }
+            mergedSyncStore[field] = Storage.getRaw(legacyKey, null, `Error reading legacy sync key: ${legacyKey}`);
+            didMergeLegacy = true;
+        });
+
+        if (didMergeLegacy) {
+            const didWrite = writeSyncStore(mergedSyncStore, 'Error writing merged sync store');
+            if (didWrite) {
+                cleanupLegacySyncKeys();
+            }
+            return;
+        }
+
+        cleanupLegacySyncKeys();
+    }
+
+    function cleanupStaleNamespacedKeys() {
+        if (typeof GM_listValues !== 'function') {
+            return;
+        }
+
+        let allKeys;
+        try {
+            allKeys = GM_listValues();
+        } catch (error) {
+            console.warn('[Goal Portfolio Viewer] Unable to enumerate storage keys for stale cleanup:', error);
+            return;
+        }
+        const allowedGpvExactKeys = new Set([VIEW_STATE_KEYS.bucketMode]);
+        const allowedGpvPrefixes = [STORAGE_KEY_PREFIXES.performanceCache, STORAGE_KEY_PREFIXES.collapseState];
+
+        allKeys.forEach(key => {
+            if (typeof key !== 'string') {
+                return;
+            }
+
+            if (key.startsWith('gpv_')) {
+                const isAllowed = allowedGpvExactKeys.has(key)
+                    || allowedGpvPrefixes.some(prefix => key.startsWith(prefix));
+                if (!isAllowed) {
+                    Storage.removeRaw(key, `Error deleting stale GPV key: ${key}`);
+                }
+            }
+
+            // Unknown flat sync_* keys are intentionally treated as stale post-migration;
+            // active sync state now lives under the exact "sync" store key.
+            if (key.startsWith('sync_') && !ACTIVE_SYNC_STORAGE_KEY_SET.has(key)) {
+                Storage.removeRaw(key, `Error deleting stale sync key: ${key}`);
+            }
+        });
+    }
+
+    migrateLegacySyncStore();
+    cleanupStaleNamespacedKeys();
 
     const legacyCleanupSessionState = {
         endowus: false,

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -2219,11 +2219,36 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     };
     const PERFORMANCE_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
+    function readEndowusStoreRaw() {
+        const rawStored = Storage.readJson(STORAGE_KEYS.endowus, data => data && typeof data === 'object' && !Array.isArray(data));
+        return rawStored ? normalizeEndowusStore(rawStored) : null;
+    }
+
+    function readWindowReturnsPerformanceCache(goalId) {
+        const normalizedGoalId = utils.normalizeString(goalId, '');
+        if (!normalizedGoalId) {
+            return null;
+        }
+        const cache = readEndowusStoreRaw()?.performanceCache;
+        const parsed = cache && typeof cache === 'object' && !Array.isArray(cache)
+            ? cache[normalizedGoalId]
+            : null;
+        const isValid = Boolean(
+            parsed &&
+            typeof parsed.fetchedAt === 'number' &&
+            parsed.fetchedAt > 0 &&
+            parsed.response &&
+            typeof parsed.response === 'object' &&
+            isCacheFresh(parsed.fetchedAt, PERFORMANCE_CACHE_MAX_AGE_MS)
+        );
+        return isValid ? parsed : null;
+    }
+
     function getGoalWindowReturns(goalId) {
         if (!goalId) {
             return {};
         }
-        const parsed = readPerformanceCache(goalId);
+        const parsed = readWindowReturnsPerformanceCache(goalId);
         if (!parsed) {
             return {};
         }
@@ -3469,6 +3494,8 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             : {};
         const localGoalIds = getLocalEndowusGoalIds(endowusStore);
         const validCollapseKeys = buildLocalEndowusCollapseKeySet(endowusStore);
+        const shouldFilterByGoalIds = localGoalIds.size > 0;
+        const shouldFilterCollapseKeys = validCollapseKeys.size > 0;
 
         let didMutate = false;
 
@@ -3477,7 +3504,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             const goalId = utils.normalizeString(rawGoalId, '');
             const isValid = Boolean(
                 goalId &&
-                localGoalIds.has(goalId) &&
+                (!shouldFilterByGoalIds || localGoalIds.has(goalId)) &&
                 typeof value?.fetchedAt === 'number' &&
                 value.fetchedAt > 0 &&
                 value.response &&
@@ -3494,7 +3521,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         const nextCollapseState = {};
         Object.entries(collapseState).forEach(([rawKey, rawValue]) => {
             const key = utils.normalizeString(rawKey, '');
-            if (!key || !validCollapseKeys.has(key)) {
+            if (!key || (shouldFilterCollapseKeys && !validCollapseKeys.has(key))) {
                 didMutate = true;
                 return;
             }
@@ -3526,13 +3553,28 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         const rawStored = Storage.readJson(STORAGE_KEYS.endowus, data => data && typeof data === 'object' && !Array.isArray(data));
         if (rawStored) {
             const normalized = normalizeEndowusStore(rawStored);
-            const legacy = collectLegacyEndowusStore();
-            const { merged, didMerge } = mergeMissingFieldsFromLegacy(
-                rawStored,
-                normalized,
-                legacy,
-                ['performance', 'investible', 'summary', 'goalTargets', 'goalFixed', 'goalBuckets', 'clearedGoalBuckets', 'performanceCache', 'uiPreferences']
+            const hasLegacyKeys = hasAnyLegacyStoreKeys(
+                [
+                    STORAGE_KEYS.performance,
+                    STORAGE_KEYS.investible,
+                    STORAGE_KEYS.summary,
+                    ...LEGACY_ENDOWUS_LOCAL_EXACT_KEYS
+                ],
+                [
+                    STORAGE_KEY_PREFIXES.goalTarget,
+                    STORAGE_KEY_PREFIXES.goalFixed,
+                    STORAGE_KEY_PREFIXES.goalBucket,
+                    ...LEGACY_ENDOWUS_LOCAL_PREFIXES
+                ]
             );
+            const { merged, didMerge } = hasLegacyKeys
+                ? mergeMissingFieldsFromLegacy(
+                    rawStored,
+                    normalized,
+                    collectLegacyEndowusStore(),
+                    ['performance', 'investible', 'summary', 'goalTargets', 'goalFixed', 'goalBuckets', 'clearedGoalBuckets', 'performanceCache', 'uiPreferences']
+                )
+                : { merged: normalized, didMerge: false };
             if (didMerge) {
                 const didWrite = writePlatformStore(STORAGE_KEYS.endowus, merged, 'Error writing merged Endowus store');
                 if (didWrite) {

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -91,6 +91,8 @@
     const VIEW_STATE_KEYS = {
         bucketMode: 'gpv_bucket_mode'
     };
+    const LEGACY_ENDOWUS_LOCAL_EXACT_KEYS = [VIEW_STATE_KEYS.bucketMode];
+    const LEGACY_ENDOWUS_LOCAL_PREFIXES = [STORAGE_KEY_PREFIXES.performanceCache, STORAGE_KEY_PREFIXES.collapseState];
     const BUCKET_VIEW_MODES = {
         allocation: 'allocation',
         performance: 'performance'
@@ -2221,21 +2223,8 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         if (!goalId) {
             return {};
         }
-        const key = getPerformanceCacheKey(goalId);
-        const parsed = Storage.readJson(
-            key,
-            data => {
-                const fetchedAt = data?.fetchedAt;
-                const response = data?.response;
-                return typeof fetchedAt === 'number' && fetchedAt > 0 && response && typeof response === 'object';
-            },
-            'Error reading performance cache'
-        );
+        const parsed = readPerformanceCache(goalId);
         if (!parsed) {
-            return {};
-        }
-        if (!isCacheFresh(parsed.fetchedAt, PERFORMANCE_CACHE_MAX_AGE_MS)) {
-            Storage.remove(key, 'Error deleting stale performance cache');
             return {};
         }
         const cachedResponse = parsed.response ? utils.normalizePerformanceResponse(parsed.response) : null;
@@ -2915,6 +2904,20 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
     function normalizeEndowusStore(data) {
         const source = data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+        const uiPreferencesSource = source.uiPreferences && typeof source.uiPreferences === 'object' && !Array.isArray(source.uiPreferences)
+            ? source.uiPreferences
+            : {};
+        const collapseStateSource = uiPreferencesSource.collapseState && typeof uiPreferencesSource.collapseState === 'object' && !Array.isArray(uiPreferencesSource.collapseState)
+            ? uiPreferencesSource.collapseState
+            : {};
+        const normalizedCollapseState = Object.entries(collapseStateSource).reduce((acc, [key, value]) => {
+            const normalizedKey = utils.normalizeString(key, '');
+            if (!normalizedKey) {
+                return acc;
+            }
+            acc[normalizedKey] = normalizeBooleanPreference(value, true);
+            return acc;
+        }, {});
         return {
             performance: Array.isArray(source.performance) ? source.performance : null,
             investible: Array.isArray(source.investible) ? source.investible : null,
@@ -2922,7 +2925,14 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             goalTargets: source.goalTargets && typeof source.goalTargets === 'object' ? source.goalTargets : {},
             goalFixed: source.goalFixed && typeof source.goalFixed === 'object' ? source.goalFixed : {},
             goalBuckets: source.goalBuckets && typeof source.goalBuckets === 'object' ? source.goalBuckets : {},
-            clearedGoalBuckets: source.clearedGoalBuckets && typeof source.clearedGoalBuckets === 'object' ? source.clearedGoalBuckets : {}
+            clearedGoalBuckets: source.clearedGoalBuckets && typeof source.clearedGoalBuckets === 'object' ? source.clearedGoalBuckets : {},
+            performanceCache: source.performanceCache && typeof source.performanceCache === 'object' && !Array.isArray(source.performanceCache)
+                ? source.performanceCache
+                : {},
+            uiPreferences: {
+                bucketMode: normalizeBucketViewMode(uiPreferencesSource.bucketMode),
+                collapseState: normalizedCollapseState
+            }
         };
     }
 
@@ -3056,6 +3066,9 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         removeLegacyPrefixedKeys(STORAGE_KEY_PREFIXES.goalTarget, 'Error deleting legacy Endowus target key');
         removeLegacyPrefixedKeys(STORAGE_KEY_PREFIXES.goalFixed, 'Error deleting legacy Endowus fixed key');
         removeLegacyPrefixedKeys(STORAGE_KEY_PREFIXES.goalBucket, 'Error deleting legacy Endowus bucket key');
+        Storage.remove(VIEW_STATE_KEYS.bucketMode, 'Error deleting legacy bucket mode key');
+        removeLegacyPrefixedKeys(STORAGE_KEY_PREFIXES.performanceCache, 'Error deleting legacy performance cache key');
+        removeLegacyPrefixedKeys(STORAGE_KEY_PREFIXES.collapseState, 'Error deleting legacy collapse state key');
     }
 
     function cleanupLegacyFsmKeys() {
@@ -3108,8 +3121,18 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             return false;
         }
         const hasLegacyKeys = hasAnyLegacyStoreKeys(
-            [STORAGE_KEYS.performance, STORAGE_KEYS.investible, STORAGE_KEYS.summary],
-            [STORAGE_KEY_PREFIXES.goalTarget, STORAGE_KEY_PREFIXES.goalFixed, STORAGE_KEY_PREFIXES.goalBucket]
+            [
+                STORAGE_KEYS.performance,
+                STORAGE_KEYS.investible,
+                STORAGE_KEYS.summary,
+                ...LEGACY_ENDOWUS_LOCAL_EXACT_KEYS
+            ],
+            [
+                STORAGE_KEY_PREFIXES.goalTarget,
+                STORAGE_KEY_PREFIXES.goalFixed,
+                STORAGE_KEY_PREFIXES.goalBucket,
+                ...LEGACY_ENDOWUS_LOCAL_PREFIXES
+            ]
         );
         if (!hasLegacyKeys) {
             legacyCleanupSessionState.endowus = true;
@@ -3267,11 +3290,43 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
     function collectLegacyEndowusStore() {
         const config = collectLegacyEndowusConfigForStore();
+        const performanceCache = {};
+        const collapseState = {};
+        const allKeys = typeof GM_listValues === 'function' ? GM_listValues() : [];
+        allKeys.forEach(key => {
+            if (key.startsWith(STORAGE_KEY_PREFIXES.performanceCache)) {
+                const goalId = key.substring(STORAGE_KEY_PREFIXES.performanceCache.length);
+                if (!goalId) {
+                    return;
+                }
+                const parsed = Storage.readJson(
+                    key,
+                    data => {
+                        const fetchedAt = data?.fetchedAt;
+                        const response = data?.response;
+                        return typeof fetchedAt === 'number' && fetchedAt > 0 && response && typeof response === 'object';
+                    },
+                    'Error loading legacy performance cache data'
+                );
+                if (parsed) {
+                    performanceCache[goalId] = parsed;
+                }
+                return;
+            }
+            if (key.startsWith(STORAGE_KEY_PREFIXES.collapseState)) {
+                collapseState[key] = normalizeBooleanPreference(Storage.get(key, null), true);
+            }
+        });
         return normalizeEndowusStore({
             ...config,
             performance: Storage.readJson(STORAGE_KEYS.performance, data => Array.isArray(data), 'Error loading legacy performance data'),
             investible: Storage.readJson(STORAGE_KEYS.investible, data => Array.isArray(data), 'Error loading legacy investible data'),
-            summary: Storage.readJson(STORAGE_KEYS.summary, data => Array.isArray(data), 'Error loading legacy summary data')
+            summary: Storage.readJson(STORAGE_KEYS.summary, data => Array.isArray(data), 'Error loading legacy summary data'),
+            performanceCache,
+            uiPreferences: {
+                bucketMode: Storage.get(VIEW_STATE_KEYS.bucketMode, BUCKET_VIEW_MODES.allocation, 'Error loading legacy bucket mode'),
+                collapseState
+            }
         });
     }
 
@@ -3368,7 +3423,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 rawStored,
                 normalized,
                 legacy,
-                ['performance', 'investible', 'summary', 'goalTargets', 'goalFixed', 'goalBuckets', 'clearedGoalBuckets']
+                ['performance', 'investible', 'summary', 'goalTargets', 'goalFixed', 'goalBuckets', 'clearedGoalBuckets', 'performanceCache', 'uiPreferences']
             );
             if (didMerge) {
                 const didWrite = writePlatformStore(STORAGE_KEYS.endowus, merged, 'Error writing merged Endowus store');
@@ -3524,37 +3579,65 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     }
 
     function getBucketViewModePreference() {
-        const rawValue = Storage.get(
-            VIEW_STATE_KEYS.bucketMode,
-            BUCKET_VIEW_MODES.allocation,
-            'Error reading bucket mode'
-        );
+        const endowus = readEndowusStore();
+        const rawValue = endowus?.uiPreferences?.bucketMode;
         const normalized = normalizeBucketViewMode(rawValue);
         if (rawValue !== normalized) {
-            Storage.set(VIEW_STATE_KEYS.bucketMode, normalized, 'Error writing bucket mode');
+            updateEndowusStore(current => ({
+                ...current,
+                uiPreferences: {
+                    ...current.uiPreferences,
+                    bucketMode: normalized
+                }
+            }), 'Error writing bucket mode');
         }
         return normalized;
     }
 
     function setBucketViewModePreference(mode) {
         const normalized = normalizeBucketViewMode(mode);
-        Storage.set(VIEW_STATE_KEYS.bucketMode, normalized, 'Error writing bucket mode');
+        updateEndowusStore(current => ({
+            ...current,
+            uiPreferences: {
+                ...current.uiPreferences,
+                bucketMode: normalized
+            }
+        }), 'Error writing bucket mode');
         return normalized;
     }
 
     function getCollapseState(bucket, goalType, section) {
         const key = storageKeys.collapseState(bucket, goalType, section);
-        const rawValue = Storage.get(key, null, 'Error reading collapse state');
+        const endowus = readEndowusStore();
+        const rawValue = endowus?.uiPreferences?.collapseState?.[key];
         const normalized = normalizeBooleanPreference(rawValue, true);
         if (rawValue !== null && rawValue !== undefined && normalized !== rawValue) {
-            Storage.set(key, normalized ? 'true' : 'false', 'Error writing collapse state');
+            updateEndowusStore(current => ({
+                ...current,
+                uiPreferences: {
+                    ...current.uiPreferences,
+                    collapseState: {
+                        ...(current.uiPreferences?.collapseState || {}),
+                        [key]: normalized
+                    }
+                }
+            }), 'Error writing collapse state');
         }
         return normalized;
     }
 
     function setCollapseState(bucket, goalType, section, isCollapsed) {
         const key = storageKeys.collapseState(bucket, goalType, section);
-        Storage.set(key, isCollapsed ? 'true' : 'false', 'Error writing collapse state');
+        updateEndowusStore(current => ({
+            ...current,
+            uiPreferences: {
+                ...current.uiPreferences,
+                collapseState: {
+                    ...(current.uiPreferences?.collapseState || {}),
+                    [key]: isCollapsed === true
+                }
+            }
+        }), 'Error writing collapse state');
     }
 
     function bytesToBase64(bytes) {
@@ -6489,34 +6572,50 @@ let GoalTargetStore;
     }
 
     function readPerformanceCache(goalId, ignoreFreshness = false) {
-        const key = getPerformanceCacheKey(goalId);
-        const parsed = Storage.readJson(
-            key,
-            data => {
-                const fetchedAt = data?.fetchedAt;
-                const response = data?.response;
-                return typeof fetchedAt === 'number' && fetchedAt > 0 && response && typeof response === 'object';
-            },
-            'Error reading performance cache'
-        );
+        const endowus = readEndowusStore();
+        const parsed = endowus?.performanceCache?.[goalId] || null;
         if (!parsed) {
+            return null;
+        }
+        const isValid = typeof parsed?.fetchedAt === 'number' && parsed.fetchedAt > 0 && parsed.response && typeof parsed.response === 'object';
+        if (!isValid) {
+            updateEndowusStore(current => {
+                const nextCache = { ...(current.performanceCache || {}) };
+                delete nextCache[goalId];
+                return {
+                    ...current,
+                    performanceCache: nextCache
+                };
+            }, 'Error deleting invalid performance cache');
             return null;
         }
         const shouldEnforceFreshness = !ignoreFreshness;
         if (shouldEnforceFreshness && !isCacheFresh(parsed.fetchedAt, PERFORMANCE_CACHE_MAX_AGE_MS)) {
-            Storage.remove(key, 'Error deleting stale performance cache');
+            updateEndowusStore(current => {
+                const nextCache = { ...(current.performanceCache || {}) };
+                delete nextCache[goalId];
+                return {
+                    ...current,
+                    performanceCache: nextCache
+                };
+            }, 'Error deleting stale performance cache');
             return null;
         }
         return parsed;
     }
 
     function writePerformanceCache(goalId, responseData) {
-        const key = getPerformanceCacheKey(goalId);
         const payload = {
             fetchedAt: Date.now(),
             response: responseData
         };
-        Storage.writeJson(key, payload, 'Error writing performance cache');
+        updateEndowusStore(current => ({
+            ...current,
+            performanceCache: {
+                ...(current.performanceCache || {}),
+                [goalId]: payload
+            }
+        }), 'Error writing performance cache');
     }
 
     function getCachedPerformanceResponse(goalId, ignoreFreshness = false) {
@@ -6685,14 +6784,27 @@ let GoalTargetStore;
         if (!Array.isArray(goalIds)) {
             return;
         }
+        const cacheKeys = [];
         goalIds.forEach(goalId => {
             if (!goalId) {
                 return;
             }
-            const key = getPerformanceCacheKey(goalId);
-            Storage.remove(key, 'Error deleting performance cache');
+            cacheKeys.push(goalId);
             delete state.performance.goalData[goalId];
         });
+        if (!cacheKeys.length) {
+            return;
+        }
+        updateEndowusStore(current => {
+            const nextCache = { ...(current.performanceCache || {}) };
+            cacheKeys.forEach(goalId => {
+                delete nextCache[goalId];
+            });
+            return {
+                ...current,
+                performanceCache: nextCache
+            };
+        }, 'Error deleting performance cache');
     }
 
     // ============================================

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.11
+// @version      2.14.12
 // @description  View and organize your investment portfolio with a modern interface across Endowus, FSM, and OCBC holdings. Includes bucket analytics and optional cross-device sync for configuration.
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -3414,6 +3414,114 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         return { merged, didMerge };
     }
 
+    function getLocalEndowusGoalIds(endowusStore) {
+        const goalIds = new Set();
+        const addGoalId = rawGoalId => {
+            const goalId = utils.normalizeString(rawGoalId, '');
+            if (goalId) {
+                goalIds.add(goalId);
+            }
+        };
+
+        const datasets = [endowusStore?.performance, endowusStore?.investible, endowusStore?.summary];
+        datasets.forEach(dataset => {
+            if (!Array.isArray(dataset)) {
+                return;
+            }
+            dataset.forEach(item => {
+                addGoalId(item?.goalId);
+            });
+        });
+
+        return goalIds;
+    }
+
+    function buildLocalEndowusCollapseKeySet(endowusStore) {
+        const bucketMap = buildMergedInvestmentData(
+            Array.isArray(endowusStore?.performance) ? endowusStore.performance : [],
+            Array.isArray(endowusStore?.investible) ? endowusStore.investible : [],
+            Array.isArray(endowusStore?.summary) ? endowusStore.summary : [],
+            endowusStore?.goalBuckets && typeof endowusStore.goalBuckets === 'object' ? endowusStore.goalBuckets : {}
+        ) || {};
+        const keys = new Set();
+        Object.entries(bucketMap).forEach(([bucketName, bucketObj]) => {
+            if (!bucketObj || typeof bucketObj !== 'object') {
+                return;
+            }
+            Object.keys(bucketObj).forEach(goalType => {
+                if (!goalType || goalType === '_meta') {
+                    return;
+                }
+                Object.values(COLLAPSE_SECTIONS).forEach(section => {
+                    keys.add(storageKeys.collapseState(bucketName, goalType, section));
+                });
+            });
+        });
+        return keys;
+    }
+
+    function cleanupEndowusLocalStore(endowusStore, nowMs = Date.now()) {
+        const performanceCache = endowusStore?.performanceCache && typeof endowusStore.performanceCache === 'object' && !Array.isArray(endowusStore.performanceCache)
+            ? endowusStore.performanceCache
+            : {};
+        const collapseState = endowusStore?.uiPreferences?.collapseState && typeof endowusStore.uiPreferences.collapseState === 'object' && !Array.isArray(endowusStore.uiPreferences.collapseState)
+            ? endowusStore.uiPreferences.collapseState
+            : {};
+        const localGoalIds = getLocalEndowusGoalIds(endowusStore);
+        const validCollapseKeys = buildLocalEndowusCollapseKeySet(endowusStore);
+
+        let didMutate = false;
+
+        const nextPerformanceCache = {};
+        Object.entries(performanceCache).forEach(([rawGoalId, value]) => {
+            const goalId = utils.normalizeString(rawGoalId, '');
+            const isValid = Boolean(
+                goalId &&
+                localGoalIds.has(goalId) &&
+                typeof value?.fetchedAt === 'number' &&
+                value.fetchedAt > 0 &&
+                value.response &&
+                typeof value.response === 'object' &&
+                isCacheFresh(value.fetchedAt, PERFORMANCE_CACHE_MAX_AGE_MS, nowMs)
+            );
+            if (!isValid) {
+                didMutate = true;
+                return;
+            }
+            nextPerformanceCache[goalId] = value;
+        });
+
+        const nextCollapseState = {};
+        Object.entries(collapseState).forEach(([rawKey, rawValue]) => {
+            const key = utils.normalizeString(rawKey, '');
+            if (!key || !validCollapseKeys.has(key)) {
+                didMutate = true;
+                return;
+            }
+            const normalized = normalizeBooleanPreference(rawValue, true);
+            if (normalized !== rawValue) {
+                didMutate = true;
+            }
+            nextCollapseState[key] = normalized;
+        });
+
+        if (!didMutate) {
+            return { value: endowusStore, didMutate: false };
+        }
+
+        return {
+            value: normalizeEndowusStore({
+                ...endowusStore,
+                performanceCache: nextPerformanceCache,
+                uiPreferences: {
+                    ...(endowusStore?.uiPreferences || {}),
+                    collapseState: nextCollapseState
+                }
+            }),
+            didMutate: true
+        };
+    }
+
     function readEndowusStore() {
         const rawStored = Storage.readJson(STORAGE_KEYS.endowus, data => data && typeof data === 'object' && !Array.isArray(data));
         if (rawStored) {
@@ -3431,21 +3539,30 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                     cleanupLegacyEndowusKeys();
                     legacyCleanupSessionState.endowus = true;
                 }
-                return merged;
+                const { value: cleanedMerged, didMutate } = cleanupEndowusLocalStore(merged);
+                if (didMutate) {
+                    writePlatformStore(STORAGE_KEYS.endowus, cleanedMerged, 'Error writing cleaned Endowus store');
+                }
+                return cleanedMerged;
             }
             if (shouldCleanupLegacyEndowusKeysOnRead()) {
                 cleanupLegacyEndowusKeys();
                 legacyCleanupSessionState.endowus = true;
             }
-            return normalized;
+            const { value: cleanedNormalized, didMutate } = cleanupEndowusLocalStore(normalized);
+            if (didMutate) {
+                writePlatformStore(STORAGE_KEYS.endowus, cleanedNormalized, 'Error writing cleaned Endowus store');
+            }
+            return cleanedNormalized;
         }
         const migrated = collectLegacyEndowusStore();
-        const didWrite = writePlatformStore(STORAGE_KEYS.endowus, migrated, 'Error writing migrated Endowus store');
+        const { value: cleanedMigrated } = cleanupEndowusLocalStore(migrated);
+        const didWrite = writePlatformStore(STORAGE_KEYS.endowus, cleanedMigrated, 'Error writing migrated Endowus store');
         if (didWrite) {
             cleanupLegacyEndowusKeys();
             legacyCleanupSessionState.endowus = true;
         }
-        return migrated;
+        return cleanedMigrated;
     }
 
     function readFsmStore() {

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.11",
+  "version": "2.14.12",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.12",
+  "version": "2.14.13",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",


### PR DESCRIPTION
## Summary
- Move Endowus-local performance cache and UI preferences into the namespaced `endowus` GM store.
- Migrate and delete legacy flat local keys for performance cache, bucket view mode, and collapse state.
- Move sync configuration/session state from flat `sync_*` GM keys into a single `sync` JSON store with legacy migration and cleanup.
- Add startup cleanup for stale script-owned `gpv_*` and flat `sync_*` keys while preserving active keys and unrelated storage.

## Change Brief
This change cleans up Tampermonkey local storage only. It consolidates Endowus local cache/UI preference data into `endowus`, consolidates sync state into `sync`, and leaves Worker/KV behavior unchanged.

## Risks & Tradeoffs
- Raw Endowus intercepted data remains persisted until overwritten to preserve fallback behavior.
- Performance cache retention remains 7 days, but stale entries are now swept more aggressively on local store reads.
- Local-only Endowus fields are intentionally excluded from sync and preserved across sync apply operations.
- Unknown flat `sync_*` and unknown `gpv_*` keys are treated as stale by design; this favors namespace cleanup over forward/backward compatibility for unrecognized local keys.

## Acceptance Criteria
- Legacy `gpv_performance_*`, `gpv_bucket_mode`, and `gpv_collapse_*` keys migrate into `endowus` and are deleted after successful migration.
- `endowus.performanceCache` keeps 7-day retention and prunes invalid/stale/orphaned entries locally.
- `endowus.uiPreferences.bucketMode` persists locally; obsolete collapse-state entries are pruned locally.
- Sync state is stored under exact key `sync`; legacy flat `sync_*` keys migrate into `sync` and are deleted after successful migration.
- Unknown `gpv_*` and unknown flat `sync_*` keys are removed on startup; active `gpv_*`, `sync`, and unrelated keys are preserved.
- Remote sync payloads do not include local-only cache/preferences.
- Sync rollback restores local legacy keys if a sync apply fails mid-transaction.
- Version metadata is bumped from `2.14.11` to `2.14.13`.

## Verification Matrix
| Check | Result | Notes |
| --- | --- | --- |
| `corepack pnpm install --frozen-lockfile` | Passed | Installed locked workspace dependencies locally earlier in this PR. |
| `corepack pnpm --filter ./tampermonkey test -- __tests__/init.test.js __tests__/syncManager.test.js` | Passed | 2 suites, 134 tests. Existing expected console warnings/errors from failure-path tests. |
| `corepack pnpm --filter ./tampermonkey test` | Passed | 13 suites, 538 tests. Existing expected console warnings/errors from failure-path tests. |
| `corepack pnpm --filter ./tampermonkey lint` | Passed | ESLint clean. |
| `node scripts/check-version-bump.js main` | Passed | Validated `2.14.11 -> 2.14.13`. |
| Fresh code review | Passed | Final post-fix review found no blocking/important/minor issues for sync namespace cleanup. |
| GitHub CI after latest push | Passed | Detect changed paths, Version Bump, Dependency Audit, Lint, Test on Node.js 20.x, and E2E Demo passed. |

## Self-Review Evidence
- Confirmed changes are limited to Tampermonkey source/tests plus required version metadata; no Worker/KV files changed.
- Confirmed `collectConfigData()` excludes Endowus `performanceCache` and `uiPreferences`.
- Confirmed `applyConfigData()` preserves local-only fields and rollback snapshots local legacy keys.
- Confirmed sync state writes now persist through the `sync` object while legacy flat `sync_*` reads migrate safely.
- Confirmed legacy sync keys are retained if migrated `sync` store write fails.
- Confirmed startup cleanup handles missing, throwing, and malformed `GM_listValues()` results without startup failure.

## Skill Alignment Notes
- Requirements research clarified local-only cleanup, 7-day retention, and requested whitelist-based stale key cleanup.
- Review-fix loop executed for rollback data-loss and sync cleanup robustness findings.
- CI failure triage executed for the prior failed Version Bump check.
- PR completion workflow executed after the latest push and green checks.
- Implementation was delegated to `codex-implementer`; review was delegated to `code-reviewer`.

## Review Response Matrix
| Finding | Severity | Disposition | Fix Location | Verification Evidence | Residual Risk |
| --- | --- | --- | --- | --- | --- |
| `applyConfigData` rollback did not snapshot Endowus local-only legacy keys, risking data loss after failed apply. | Blocking | Fixed | `tampermonkey/goal_portfolio_viewer.user.js`; `tampermonkey/__tests__/syncManager.test.js` | Fresh assessment confirmed validity; targeted syncManager test passed; full Tampermonkey tests/lint passed; post-fix review found no issues. | Future local legacy key families must be added to the local legacy constants to remain rollback-covered. |
| `GM_listValues()` startup cleanup path could throw and break initialization. | Important | Fixed | `tampermonkey/goal_portfolio_viewer.user.js`; `tampermonkey/__tests__/init.test.js` | Added try/catch and non-string key guards; added throwing/malformed enumeration tests; targeted tests and full Tampermonkey tests/lint passed; final post-fix review found no issues. | Low; cleanup no-ops if enumeration fails, leaving stale keys for that load. |
| Broad unknown `gpv_*` / `sync_*` cleanup may delete future-version keys. | Important | Declined with rationale | `tampermonkey/goal_portfolio_viewer.user.js`; `tampermonkey/__tests__/init.test.js` | Fresh assessment confirmed this is the explicit requested whitelist cleanup behavior; inline comment documents unknown flat `sync_*` policy; tests lock removal behavior. | Accepted compatibility tradeoff for script-owned namespaces during downgrade/mixed-version scenarios. |

## CI Failure Triage
Check: Version Bump  
Run/Job: https://github.com/laurenceputra/goal-portfolio-viewer/actions/runs/25267062666/job/74083243571  
Classification: policy/version metadata failure  
Evidence: CI log reported `Version must be bumped above 2.14.11; current version is 2.14.11.`  
Remediation: Bumped aligned versions in `package.json`, `tampermonkey/package.json`, and userscript `@version`; latest bump is `2.14.13`.  
Verification: `node scripts/check-version-bump.js main` passed locally; replacement CI Version Bump check passed after latest push.  
Residual Risk: Low; future code PRs must continue to bump all aligned version files.  
Status: Fixed.

## Final PR Completion
- Latest pushed commit: `af796a261485dd3f107786c5c755cd2e29a6259d`
- Required check status after final push: passing (`Detect changed paths`, `Version Bump`, `Dependency Audit`, `Lint`, `Test on Node.js 20.x`, `E2E Demo`).
- Expected skipped checks: `Worker Unit Tests` skipped because changed-path detection found no Worker surface changes.
- Local verification evidence: `corepack pnpm --filter ./tampermonkey test -- __tests__/init.test.js __tests__/syncManager.test.js`, `corepack pnpm --filter ./tampermonkey test`, `corepack pnpm --filter ./tampermonkey lint`, and `node scripts/check-version-bump.js main` passed locally.
- Review-fix loops: rollback snapshot finding fixed; sync cleanup robustness finding fixed; intentional whitelist cleanup tradeoff documented and accepted.
- CI triage loops: prior Version Bump failure remediated; replacement CI run passed.
- Final status: ready.