### PR TITLE
Refactor shared portfolio overlay flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.16",
+  "version": "2.14.17",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -1854,6 +1854,10 @@ describe('initialization and URL monitoring', () => {
         const liabilityCard = overviewCards.find(card => card.textContent.includes('Liabilities'));
         expect(assetCard).toBeTruthy();
         expect(liabilityCard).toBeTruthy();
+        expect(assetCard.tagName).toBe('BUTTON');
+        expect(assetCard.type).toBe('button');
+        expect(assetCard.hasAttribute('role')).toBe(false);
+        expect(assetCard.hasAttribute('tabindex')).toBe(false);
         expect(assetCard.textContent).toContain('2 holding');
         expect(assetCard.textContent).not.toContain('OCBC Liability');
         expect(liabilityCard.textContent).toContain('1 holding');

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -35,6 +35,49 @@ describe('initialization and URL monitoring', () => {
         return overlay;
     };
 
+    const loadModuleForUrl = (url) => {
+        jest.resetModules();
+        teardownDom();
+        setupDom({ url });
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+
+        const responseFactory = body => ({
+            clone: () => responseFactory(body),
+            json: () => Promise.resolve(body),
+            ok: true,
+            status: 200
+        });
+
+        global.fetch = jest.fn(() => Promise.resolve(responseFactory({})));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, requestUrl) {
+                this._url = requestUrl;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+        return require('../goal_portfolio_viewer.user.js');
+    };
+
     beforeEach(() => {
         jest.resetModules();
         setupDom();
@@ -128,6 +171,30 @@ describe('initialization and URL monitoring', () => {
 
         window.history.pushState({}, '', 'https://app.sg.endowus.com/settings');
         expect(document.querySelector('.gpv-trigger-btn')).toBeNull();
+    });
+
+    test('overlay platform descriptor resolves FSM, OCBC, then Endowus fallback by route', () => {
+        let exportsModule = loadModuleForUrl('https://app.sg.endowus.com/goals');
+        expect(exportsModule.getOverlayPlatformDescriptor().id).toBe('endowus');
+        const endowusReadiness = exportsModule.getOverlayPlatformDescriptor().getReadinessOverlayConfig();
+        expect(endowusReadiness.title).toBe('Portfolio Viewer');
+        expect(endowusReadiness.getItems().map(item => item.label)).toEqual([
+            'Goal performance',
+            'Investible balances',
+            'Goal summaries'
+        ]);
+
+        exportsModule = loadModuleForUrl('https://secure.fundsupermart.com/fsmone/holdings/investments');
+        expect(exportsModule.getOverlayPlatformDescriptor().id).toBe('fsm');
+        const fsmReadiness = exportsModule.getOverlayPlatformDescriptor().getReadinessOverlayConfig();
+        expect(fsmReadiness.title).toBe('Portfolio Viewer (FSM)');
+        expect(fsmReadiness.getItems().map(item => item.label)).toEqual(['FSM holdings data']);
+
+        exportsModule = loadModuleForUrl('https://internet.ocbc.com/internet-banking/digital/web/sg/cfo/dashboard?menuId=e62c3103-da60-4e8a-8717-72f11ebaaebe');
+        expect(exportsModule.getOverlayPlatformDescriptor().id).toBe('ocbc');
+        const ocbcReadiness = exportsModule.getOverlayPlatformDescriptor().getReadinessOverlayConfig();
+        expect(ocbcReadiness.title).toBe('Portfolio Viewer (OCBC)');
+        expect(ocbcReadiness.getItems().map(item => item.label)).toEqual(['OCBC portfolio holdings data']);
     });
 
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -8728,23 +8728,25 @@ let GoalTargetStore;
         if (!element) {
             return element;
         }
-        element.setAttribute('role', 'button');
-        element.setAttribute('tabindex', '0');
+        const isNativeButton = element.tagName === 'BUTTON';
+        if (!isNativeButton) {
+            element.setAttribute('role', 'button');
+            element.setAttribute('tabindex', '0');
+        }
         if (ariaLabel) {
             element.setAttribute('aria-label', ariaLabel);
         }
         if (typeof onSelect === 'function') {
-            const handleSelect = event => {
-                if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
-                    return;
-                }
-                if (event.type === 'keydown') {
+            element.addEventListener('click', onSelect);
+            if (!isNativeButton) {
+                element.addEventListener('keydown', event => {
+                    if (event.key !== 'Enter' && event.key !== ' ') {
+                        return;
+                    }
                     event.preventDefault();
-                }
-                onSelect(event);
-            };
-            element.addEventListener('click', handleSelect);
-            element.addEventListener('keydown', handleSelect);
+                    onSelect(event);
+                });
+            }
         }
         return element;
     }
@@ -14716,6 +14718,22 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         `;
     }
 
+    function createOverviewScopeCard({ elementTag = 'div', className = 'gpv-fsm-overview-card', scopeId, ariaLabel, onSelect, cardHtml, healthReasons = [], healthReasonLimit }) {
+        const card = createElement(elementTag, className);
+        if (elementTag === 'button') {
+            card.type = 'button';
+        }
+        if (scopeId) {
+            card.dataset.scope = scopeId;
+        }
+        createKeyboardSelectableCard(card, { ariaLabel, onSelect });
+        card.innerHTML = buildOverviewCardHtml(cardHtml || {});
+        if (Array.isArray(healthReasons) && healthReasons.length > 0) {
+            card.appendChild(createHealthReasonList(healthReasons, { limit: healthReasonLimit }));
+        }
+        return card;
+    }
+
     function buildFsmPortfolioOverviewModel(rows, activePortfolios) {
         const safeRows = Array.isArray(rows) ? rows : [];
         const safePortfolios = Array.isArray(activePortfolios) ? activePortfolios : [];
@@ -14790,33 +14808,26 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         const grid = createElement('div', 'gpv-fsm-overview-grid');
         const cards = Array.isArray(overviewModel?.cards) ? overviewModel.cards : [];
         cards.forEach(card => {
-            const className = card.isUnassigned === true
-                ? 'gpv-fsm-overview-card gpv-fsm-overview-card--unassigned'
-                : 'gpv-fsm-overview-card';
-            const buttonCard = createElement('div', className);
-            buttonCard.dataset.scope = card.id;
-            createKeyboardSelectableCard(buttonCard, {
+            const className = card.isUnassigned === true ? 'gpv-fsm-overview-card gpv-fsm-overview-card--unassigned' : 'gpv-fsm-overview-card';
+            const buttonCard = createOverviewScopeCard({
+                className,
+                scopeId: card.id,
                 ariaLabel: `Open ${card.label} holdings`,
-                onSelect: () => {
-                    if (typeof onSelectScope === 'function') {
-                        onSelectScope(card.id);
-                    }
-                }
+                onSelect: () => onSelectScope?.(card.id),
+                cardHtml: {
+                    title: card.label,
+                    subtitle: `${card.holdingsCount} holding${card.holdingsCount === 1 ? '' : 's'}`,
+                    badgeHtml: `<span class="gpv-health-badge ${escapeHtml(card.health?.className || 'gpv-health--healthy')}">${escapeHtml(card.health?.label || 'Healthy')}</span>`,
+                    stats: [
+                        { label: 'Total value', value: card.totalDisplay },
+                        { label: 'Target assigned', value: card.targetAssignedDisplay },
+                        { label: 'Drift', value: card.driftDisplay, valueClass: card.driftClass || '' },
+                        { label: 'Profit', value: card.profitDisplay || '-', valueClass: card.profitClass || '' }
+                    ]
+                },
+                healthReasons: card.health?.reasons,
+                healthReasonLimit: 2
             });
-            buttonCard.innerHTML = buildOverviewCardHtml({
-                title: card.label,
-                subtitle: `${card.holdingsCount} holding${card.holdingsCount === 1 ? '' : 's'}`,
-                badgeHtml: `<span class="gpv-health-badge ${escapeHtml(card.health?.className || 'gpv-health--healthy')}">${escapeHtml(card.health?.label || 'Healthy')}</span>`,
-                stats: [
-                    { label: 'Total value', value: card.totalDisplay },
-                    { label: 'Target assigned', value: card.targetAssignedDisplay },
-                    { label: 'Drift', value: card.driftDisplay, valueClass: card.driftClass || '' },
-                    { label: 'Profit', value: card.profitDisplay || '-', valueClass: card.profitClass || '' }
-                ]
-            });
-            if (Array.isArray(card.health?.reasons) && card.health.reasons.length > 0) {
-                buttonCard.appendChild(createHealthReasonList(card.health.reasons, { limit: 2 }));
-            }
             grid.appendChild(buttonCard);
         });
         wrapper.appendChild(grid);
@@ -15152,6 +15163,29 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         toolbarSection.appendChild(detailToolbar.element);
         const detailToolbarControls = [detailToolbar.searchInput];
 
+        const setFilteredSelection = (rows, selected) => {
+            rows.forEach(row => {
+                const holdingId = row.holdingId || row.code;
+                if (!holdingId) {
+                    return;
+                }
+                if (selected) {
+                    selectedHoldingIds.add(holdingId);
+                } else {
+                    selectedHoldingIds.delete(holdingId);
+                }
+            });
+        };
+
+        const openFsmDetail = scopeId => {
+            selectedScope = scopeId;
+            filterTerm = '';
+            selectedHoldingIds = new Set();
+            viewMode = 'detail';
+            nextFocusTarget = 'detail';
+            rerender();
+        };
+
         const focusAfterRender = () => {
             if (nextFocusTarget === 'overview') {
                 const firstOverviewCard = bodySection.querySelector('.gpv-fsm-overview-card');
@@ -15347,22 +15381,8 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 }));
                 bodySection.appendChild(buildFsmOverviewPanel({
                     overviewModel: viewState.overviewModel,
-                    onSelectScope: scopeId => {
-                        selectedScope = scopeId;
-                        filterTerm = '';
-                        selectedHoldingIds = new Set();
-                        viewMode = 'detail';
-                        nextFocusTarget = 'detail';
-                        rerender();
-                    },
-                    onOpenAll: () => {
-                        selectedScope = FSM_ALL_PORTFOLIO_ID;
-                        filterTerm = '';
-                        selectedHoldingIds = new Set();
-                        viewMode = 'detail';
-                        nextFocusTarget = 'detail';
-                        rerender();
-                    }
+                    onSelectScope: openFsmDetail,
+                    onOpenAll: () => openFsmDetail(FSM_ALL_PORTFOLIO_ID)
                 }));
                 focusAfterRender();
                 return;
@@ -15421,17 +15441,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 bulkPortfolioId,
                 filteredCount: viewState.filteredRows.length,
                 onSelectAllChange: value => {
-                    viewState.filteredRows.forEach(row => {
-                        const holdingId = row.holdingId || row.code;
-                        if (!holdingId) {
-                            return;
-                        }
-                        if (value) {
-                            selectedHoldingIds.add(holdingId);
-                            return;
-                        }
-                        selectedHoldingIds.delete(holdingId);
-                    });
+                    setFilteredSelection(viewState.filteredRows, value);
                     rerender();
                 },
                 onBulkPortfolioChange: value => {
@@ -15455,17 +15465,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 targetErrorsByHoldingId,
                 showDrift: viewState.showDrift,
                 onSelectAllChange: value => {
-                    viewState.filteredRows.forEach(row => {
-                        const holdingId = row.holdingId || row.code;
-                        if (!holdingId) {
-                            return;
-                        }
-                        if (value) {
-                            selectedHoldingIds.add(holdingId);
-                            return;
-                        }
-                        selectedHoldingIds.delete(holdingId);
-                    });
+                    setFilteredSelection(viewState.filteredRows, value);
                     rerender();
                 },
                 onRowSelectChange: (holdingId, checked) => {
@@ -16653,30 +16653,29 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 portfolioNos.forEach(portfolioNo => {
                     const portfolioRows = grouped[portfolioNo] || [];
                     const summary = buildOcbcSummary(portfolioRows);
-                    const card = createElement('button', 'gpv-fsm-overview-card');
-                    card.type = 'button';
                     const meta = holdingsByPortfolio[portfolioNo] || {};
                     const statusText = latestPortfolioNos.has(portfolioNo)
                         ? 'Current session'
                         : (meta.lastSeenAt ? `Cached · ${new Date(meta.lastSeenAt).toLocaleString()}` : 'Cached');
-                    createKeyboardSelectableCard(card, {
+                    const card = createOverviewScopeCard({
+                        elementTag: 'button',
                         ariaLabel: `Open portfolio ${portfolioNo} ${sectionView}`,
                         onSelect: () => {
                             viewSelect.value = sectionView;
                             selectedPortfolioNo = portfolioNo;
                             viewMode = 'detail';
                             rerender();
+                        },
+                        cardHtml: {
+                            title: `Portfolio ${portfolioNo}`,
+                            subtitle: `${portfolioRows.length} holding${portfolioRows.length === 1 ? '' : 's'}`,
+                            tagHtml: `<span class="gpv-fsm-overview-card-tag">${escapeHtml(sectionTitle)}</span>`,
+                            stats: [
+                                { label: 'Total value', value: formatMoney(summary.total) },
+                                { label: 'Profit', value: summary.profitDisplay || '-', valueClass: summary.profitClass || '' },
+                                { label: 'Status', value: statusText }
+                            ]
                         }
-                    });
-                    card.innerHTML = buildOverviewCardHtml({
-                        title: `Portfolio ${portfolioNo}`,
-                        subtitle: `${portfolioRows.length} holding${portfolioRows.length === 1 ? '' : 's'}`,
-                        tagHtml: `<span class="gpv-fsm-overview-card-tag">${escapeHtml(sectionTitle)}</span>`,
-                        stats: [
-                            { label: 'Total value', value: formatMoney(summary.total) },
-                            { label: 'Profit', value: summary.profitDisplay || '-', valueClass: summary.profitClass || '' },
-                            { label: 'Status', value: statusText }
-                        ]
                     });
                     grid.appendChild(card);
                 });

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.16
+// @version      2.14.17
 // @description  View and organize your investment portfolio with a modern interface across Endowus, FSM, and OCBC holdings. Includes bucket analytics and optional cross-device sync for configuration.
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -16039,6 +16039,39 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         return Array.from(mergedMap.values());
     }
 
+    function buildPersistedOcbcSubPortfoliosForPortfolio(activeView, portfolioNo, portfolioRows, subPortfoliosByView, bucketsByView, assignmentByCode) {
+        const safePortfolioRows = Array.isArray(portfolioRows) ? portfolioRows : [];
+        const scopedSubPortfolios = getActiveOcbcSubPortfolios(subPortfoliosByView, activeView, portfolioNo);
+        const legacySubPortfolios = buildLegacyOcbcSubPortfolios(activeView, bucketsByView);
+        const persistedSubPortfolios = mergeOcbcSubPortfolios(scopedSubPortfolios, legacySubPortfolios);
+        const assignmentReferencedProductTypeById = new Map();
+        safePortfolioRows.forEach(row => {
+            const assignment = resolveOcbcAssignmentByRow(assignmentByCode, row, persistedSubPortfolios);
+            const assignmentId = utils.normalizeString(assignment?.subPortfolioId, '');
+            if (!assignmentId || assignmentReferencedProductTypeById.has(assignmentId)) {
+                return;
+            }
+            assignmentReferencedProductTypeById.set(assignmentId, utils.normalizeString(row?.productType, ''));
+        });
+        const assignmentReferencedIds = Array.from(new Set(safePortfolioRows
+            .map(row => resolveOcbcAssignmentByRow(assignmentByCode, row, persistedSubPortfolios).subPortfolioId)
+            .filter(Boolean)));
+        assignmentReferencedIds.forEach(id => {
+            const referencedProductType = assignmentReferencedProductTypeById.get(id) || '';
+            const ambiguousLegacyMatches = persistedSubPortfolios.filter(item => (
+                utils.normalizeString(item?.legacyBucketId, '') === id
+                && utils.normalizeString(item?.legacyProductType, '') === referencedProductType
+            ));
+            if (ambiguousLegacyMatches.length > 1) {
+                return;
+            }
+            if (!persistedSubPortfolios.some(item => item.id === id)) {
+                persistedSubPortfolios.push({ id, name: id, archived: false });
+            }
+        });
+        return persistedSubPortfolios;
+    }
+
     function renderOcbcOverlay(ocbcHoldings, options = {}) {
         const shell = createOverlayShell({
             title: 'Portfolio Viewer (OCBC)',
@@ -16116,34 +16149,14 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 const portfolioRows = groupedByPortfolio[portfolioNo] || [];
                 const portfolioSummary = buildOcbcSummary(portfolioRows);
                 const portfolioTotal = toFiniteNumber(portfolioSummary.total, 0);
-                const scopedSubPortfolios = getActiveOcbcSubPortfolios(subPortfoliosByView, activeView, portfolioNo);
-                const legacySubPortfolios = buildLegacyOcbcSubPortfolios(activeView, bucketsByView);
-                const persistedSubPortfolios = mergeOcbcSubPortfolios(scopedSubPortfolios, legacySubPortfolios);
-                const assignmentReferencedProductTypeById = new Map();
-                portfolioRows.forEach(row => {
-                    const assignment = resolveOcbcAssignmentByRow(assignmentByCode, row, persistedSubPortfolios);
-                    const assignmentId = utils.normalizeString(assignment?.subPortfolioId, '');
-                    if (!assignmentId || assignmentReferencedProductTypeById.has(assignmentId)) {
-                        return;
-                    }
-                    assignmentReferencedProductTypeById.set(assignmentId, utils.normalizeString(row?.productType, ''));
-                });
-                const assignmentReferencedIds = Array.from(new Set(portfolioRows
-                    .map(row => resolveOcbcAssignmentByRow(assignmentByCode, row, persistedSubPortfolios).subPortfolioId)
-                    .filter(Boolean)));
-                assignmentReferencedIds.forEach(id => {
-                    const referencedProductType = assignmentReferencedProductTypeById.get(id) || '';
-                    const ambiguousLegacyMatches = persistedSubPortfolios.filter(item => (
-                        utils.normalizeString(item?.legacyBucketId, '') === id
-                        && utils.normalizeString(item?.legacyProductType, '') === referencedProductType
-                    ));
-                    if (ambiguousLegacyMatches.length > 1) {
-                        return;
-                    }
-                    if (!persistedSubPortfolios.some(item => item.id === id)) {
-                        persistedSubPortfolios.push({ id, name: id, archived: false });
-                    }
-                });
+                const persistedSubPortfolios = buildPersistedOcbcSubPortfoliosForPortfolio(
+                    activeView,
+                    portfolioNo,
+                    portfolioRows,
+                    subPortfoliosByView,
+                    bucketsByView,
+                    assignmentByCode
+                );
 
                 persistedSubPortfolios.forEach(subPortfolio => {
                     if (subPortfolio?.id) {
@@ -16247,34 +16260,14 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 const section = createElement('section', 'gpv-bucket-detail-section');
                 section.appendChild(buildOcbcPortfolioHeader(portfolioNo, portfolioSummary));
 
-                const scopedSubPortfolios = getActiveOcbcSubPortfolios(subPortfoliosByView, activeView, portfolioNo);
-                const legacySubPortfolios = buildLegacyOcbcSubPortfolios(activeView, bucketsByView);
-                const persistedSubPortfolios = mergeOcbcSubPortfolios(scopedSubPortfolios, legacySubPortfolios);
-                const assignmentReferencedProductTypeById = new Map();
-                portfolioRows.forEach(row => {
-                    const assignment = resolveOcbcAssignmentByRow(assignmentByCode, row, persistedSubPortfolios);
-                    const assignmentId = utils.normalizeString(assignment?.subPortfolioId, '');
-                    if (!assignmentId || assignmentReferencedProductTypeById.has(assignmentId)) {
-                        return;
-                    }
-                    assignmentReferencedProductTypeById.set(assignmentId, utils.normalizeString(row?.productType, ''));
-                });
-                const assignmentReferencedIds = Array.from(new Set(portfolioRows
-                    .map(row => resolveOcbcAssignmentByRow(assignmentByCode, row, persistedSubPortfolios).subPortfolioId)
-                    .filter(Boolean)));
-                assignmentReferencedIds.forEach(id => {
-                    const referencedProductType = assignmentReferencedProductTypeById.get(id) || '';
-                    const ambiguousLegacyMatches = persistedSubPortfolios.filter(item => (
-                        utils.normalizeString(item?.legacyBucketId, '') === id
-                        && utils.normalizeString(item?.legacyProductType, '') === referencedProductType
-                    ));
-                    if (ambiguousLegacyMatches.length > 1) {
-                        return;
-                    }
-                    if (!persistedSubPortfolios.some(item => item.id === id)) {
-                        persistedSubPortfolios.push({ id, name: id, archived: false });
-                    }
-                });
+                const persistedSubPortfolios = buildPersistedOcbcSubPortfoliosForPortfolio(
+                    activeView,
+                    portfolioNo,
+                    portfolioRows,
+                    subPortfoliosByView,
+                    bucketsByView,
+                    assignmentByCode
+                );
 
                 const createSubPortfolioId = `gpv-ocbc-sub-portfolio-create-${activeView}-${encodeURIComponent(portfolioNo)}`;
                 const { row: managerRow } = createManagerCreateRow({

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -4313,13 +4313,17 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 }
                 return merged;
             }
-            if (shouldCleanupLegacyFsmKeysOnRead()) {
-                cleanupLegacyFsmKeys();
-                legacyCleanupSessionState.fsm = true;
-            }
-            if (!hasOwnField(rawStored, 'allocationModel')) {
-                writePlatformStore(STORAGE_KEYS.fsm, normalized, 'Error writing migrated FSM allocation model');
-            }
+            cleanupLegacySessionOnRead({
+                shouldCleanup: shouldCleanupLegacyFsmKeysOnRead(),
+                cleanupLegacyKeys: cleanupLegacyFsmKeys,
+                platform: 'fsm'
+            });
+            persistAllocationModelMigration(
+                rawStored,
+                normalized,
+                STORAGE_KEYS.fsm,
+                'Error writing migrated FSM allocation model'
+            );
             return normalized;
         }
         const migrated = collectLegacyFsmStore();
@@ -4354,13 +4358,17 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 }
                 return merged;
             }
-            if (shouldCleanupLegacyOcbcKeysOnRead()) {
-                cleanupLegacyOcbcKeys();
-                legacyCleanupSessionState.ocbc = true;
-            }
-            if (!hasOwnField(rawStored, 'allocationModel')) {
-                writePlatformStore(STORAGE_KEYS.ocbc, normalized, 'Error writing migrated OCBC allocation model');
-            }
+            cleanupLegacySessionOnRead({
+                shouldCleanup: shouldCleanupLegacyOcbcKeysOnRead(),
+                cleanupLegacyKeys: cleanupLegacyOcbcKeys,
+                platform: 'ocbc'
+            });
+            persistAllocationModelMigration(
+                rawStored,
+                normalized,
+                STORAGE_KEYS.ocbc,
+                'Error writing migrated OCBC allocation model'
+            );
             return normalized;
         }
         const migrated = collectLegacyOcbcStore();
@@ -4370,6 +4378,20 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             legacyCleanupSessionState.ocbc = true;
         }
         return migrated;
+    }
+
+    function cleanupLegacySessionOnRead({ shouldCleanup, cleanupLegacyKeys, platform }) {
+        if (!shouldCleanup) {
+            return;
+        }
+        cleanupLegacyKeys();
+        legacyCleanupSessionState[platform] = true;
+    }
+
+    function persistAllocationModelMigration(rawStored, normalized, storageKey, context) {
+        if (!hasOwnField(rawStored, 'allocationModel')) {
+            writePlatformStore(storageKey, normalized, context);
+        }
     }
 
     function updatePlatformStore({ readStore, normalizeStore, storageKey, cleanupLegacyKeys, updater, context }) {
@@ -14680,6 +14702,20 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         `;
     }
 
+    function buildOverviewCardHtml({ title, subtitle, tagHtml = '', badgeHtml = '', stats = [] }) {
+        const metadataHtml = `${badgeHtml || ''}${tagHtml || ''}`;
+        return `
+                <div class="gpv-fsm-overview-card-header">
+                    <div>
+                        <h2 class="gpv-fsm-overview-card-title">${escapeHtml(title || '')}</h2>
+                        <p class="gpv-fsm-overview-card-subtitle">${escapeHtml(subtitle || '')}</p>
+                    </div>
+                    ${metadataHtml}
+                </div>
+                ${buildOverviewStatsHtml(stats)}
+        `;
+    }
+
     function buildFsmPortfolioOverviewModel(rows, activePortfolios) {
         const safeRows = Array.isArray(rows) ? rows : [];
         const safePortfolios = Array.isArray(activePortfolios) ? activePortfolios : [];
@@ -14767,21 +14803,17 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                     }
                 }
             });
-            buttonCard.innerHTML = `
-                <div class="gpv-fsm-overview-card-header">
-                    <div>
-                        <h2 class="gpv-fsm-overview-card-title">${escapeHtml(card.label)}</h2>
-                        <p class="gpv-fsm-overview-card-subtitle">${escapeHtml(`${card.holdingsCount} holding${card.holdingsCount === 1 ? '' : 's'}`)}</p>
-                    </div>
-                    <span class="gpv-health-badge ${escapeHtml(card.health?.className || 'gpv-health--healthy')}">${escapeHtml(card.health?.label || 'Healthy')}</span>
-                </div>
-                ${buildOverviewStatsHtml([
+            buttonCard.innerHTML = buildOverviewCardHtml({
+                title: card.label,
+                subtitle: `${card.holdingsCount} holding${card.holdingsCount === 1 ? '' : 's'}`,
+                badgeHtml: `<span class="gpv-health-badge ${escapeHtml(card.health?.className || 'gpv-health--healthy')}">${escapeHtml(card.health?.label || 'Healthy')}</span>`,
+                stats: [
                     { label: 'Total value', value: card.totalDisplay },
                     { label: 'Target assigned', value: card.targetAssignedDisplay },
                     { label: 'Drift', value: card.driftDisplay, valueClass: card.driftClass || '' },
                     { label: 'Profit', value: card.profitDisplay || '-', valueClass: card.profitClass || '' }
-                ])}
-            `;
+                ]
+            });
             if (Array.isArray(card.health?.reasons) && card.health.reasons.length > 0) {
                 buttonCard.appendChild(createHealthReasonList(card.health.reasons, { limit: 2 }));
             }
@@ -16636,20 +16668,16 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                             rerender();
                         }
                     });
-                    card.innerHTML = `
-                        <div class="gpv-fsm-overview-card-header">
-                            <div>
-                                <h2 class="gpv-fsm-overview-card-title">${escapeHtml(`Portfolio ${portfolioNo}`)}</h2>
-                                <p class="gpv-fsm-overview-card-subtitle">${escapeHtml(`${portfolioRows.length} holding${portfolioRows.length === 1 ? '' : 's'}`)}</p>
-                            </div>
-                            <span class="gpv-fsm-overview-card-tag">${escapeHtml(sectionTitle)}</span>
-                        </div>
-                        ${buildOverviewStatsHtml([
+                    card.innerHTML = buildOverviewCardHtml({
+                        title: `Portfolio ${portfolioNo}`,
+                        subtitle: `${portfolioRows.length} holding${portfolioRows.length === 1 ? '' : 's'}`,
+                        tagHtml: `<span class="gpv-fsm-overview-card-tag">${escapeHtml(sectionTitle)}</span>`,
+                        stats: [
                             { label: 'Total value', value: formatMoney(summary.total) },
                             { label: 'Profit', value: summary.profitDisplay || '-', valueClass: summary.profitClass || '' },
                             { label: 'Status', value: statusText }
-                        ])}
-                    `;
+                        ]
+                    });
                     grid.appendChild(card);
                 });
                 section.appendChild(grid);
@@ -16741,72 +16769,97 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         updateReadinessView();
     }
 
-    function showOverlay() {
-
-        const isFsmRoute = isFsmInvestmentsRoute(window.location.href, window.location.origin);
-        if (isFsmRoute) {
-            const readinessState = getFsmReadinessState();
-            if (!readinessState.ready) {
-                logDebug('[Goal Portfolio Viewer] FSM holdings not available yet');
-                renderDataReadinessOverlay({
+    function getOverlayPlatformDescriptor() {
+        const href = window.location.href;
+        const origin = window.location.origin;
+        const descriptors = [
+            {
+                id: 'fsm',
+                matchesRoute: () => isFsmInvestmentsRoute(href, origin),
+                getReadinessState: getFsmReadinessState,
+                getPendingLogMessage: () => '[Goal Portfolio Viewer] FSM holdings not available yet',
+                getReadinessOverlayConfig: () => ({
                     title: 'Portfolio Viewer (FSM)',
                     description: 'Waiting for FSM holdings response. This updates automatically when data arrives.',
                     getItems: () => [{
                         label: 'FSM holdings data',
                         ready: getFsmReadinessState().ready
-                    }],
-                    isReady: () => getFsmReadinessState().ready,
-                    onReady: () => showOverlay()
-                });
-                return;
-            }
-            renderFsmOverlay(readinessState.fsmHoldings);
-            return;
-        }
-
-        const isOcbcRoute = isOcbcDashboardRoute(window.location.href, window.location.origin)
-            || isOcbcPortfolioHoldingsRoute(window.location.href, window.location.origin);
-        if (isOcbcRoute) {
-            const readinessState = getOcbcReadinessState();
-            if (!readinessState.ready) {
-                renderDataReadinessOverlay({
+                    }]
+                }),
+                render: readinessState => {
+                    renderFsmOverlay(readinessState.fsmHoldings);
+                }
+            },
+            {
+                id: 'ocbc',
+                matchesRoute: () => (
+                    isOcbcDashboardRoute(href, origin)
+                    || isOcbcPortfolioHoldingsRoute(href, origin)
+                ),
+                getReadinessState: getOcbcReadinessState,
+                getReadinessOverlayConfig: () => ({
                     title: 'Portfolio Viewer (OCBC)',
                     description: 'Waiting for OCBC portfolio holdings response. This updates automatically when data arrives.',
                     getItems: () => [{
                         label: 'OCBC portfolio holdings data',
                         ready: getOcbcReadinessState().ready
-                    }],
-                    isReady: () => getOcbcReadinessState().ready,
-                    onReady: () => showOverlay()
-                });
-                return;
+                    }]
+                }),
+                render: readinessState => {
+                    renderOcbcOverlay(readinessState.ocbcHoldings, {
+                        holdingsByPortfolio: readinessState.holdingsByPortfolio,
+                        latestPortfolioNos: readinessState.latestPortfolioNos
+                    });
+                }
+            },
+            {
+                id: 'endowus',
+                matchesRoute: () => true,
+                getReadinessState: getEndowusReadinessState,
+                getPendingLogMessage: () => '[Goal Portfolio Viewer] Not all API data available yet',
+                getReadinessOverlayConfig: () => ({
+                    title: 'Portfolio Viewer',
+                    description: 'Fetching Endowus portfolio data. This view updates automatically as data arrives.',
+                    getItems: () => {
+                        const current = getEndowusReadinessState();
+                        return [
+                            { label: 'Goal performance', ready: current.hasPerformance },
+                            { label: 'Investible balances', ready: current.hasInvestible },
+                            { label: 'Goal summaries', ready: current.hasSummary }
+                        ];
+                    }
+                }),
+                render: readinessState => {
+                    renderEndowusOverlay(readinessState);
+                }
             }
-            renderOcbcOverlay(readinessState.ocbcHoldings, {
-                holdingsByPortfolio: readinessState.holdingsByPortfolio,
-                latestPortfolioNos: readinessState.latestPortfolioNos
-            });
-            return;
-        }
+        ];
 
-        const readinessState = getEndowusReadinessState();
+        return descriptors.find(descriptor => descriptor.matchesRoute()) || descriptors[descriptors.length - 1];
+    }
+
+    function showOverlay() {
+        const platform = getOverlayPlatformDescriptor();
+        const readinessState = platform.getReadinessState();
         if (!readinessState.ready) {
-            logDebug('[Goal Portfolio Viewer] Not all API data available yet');
+            const pendingLogMessage = typeof platform.getPendingLogMessage === 'function'
+                ? platform.getPendingLogMessage()
+                : '';
+            if (pendingLogMessage) {
+                logDebug(pendingLogMessage);
+            }
+            const readinessOverlayConfig = platform.getReadinessOverlayConfig();
             renderDataReadinessOverlay({
-                title: 'Portfolio Viewer',
-                description: 'Fetching Endowus portfolio data. This view updates automatically as data arrives.',
-                getItems: () => {
-                    const current = getEndowusReadinessState();
-                    return [
-                        { label: 'Goal performance', ready: current.hasPerformance },
-                        { label: 'Investible balances', ready: current.hasInvestible },
-                        { label: 'Goal summaries', ready: current.hasSummary }
-                    ];
-                },
-                isReady: () => getEndowusReadinessState().ready,
+                ...readinessOverlayConfig,
+                isReady: () => platform.getReadinessState().ready,
                 onReady: () => showOverlay()
             });
             return;
         }
+        platform.render(readinessState);
+    }
+
+    function renderEndowusOverlay(readinessState) {
         let mergedInvestmentDataState = readinessState.mergedInvestmentDataState;
         logDebug('[Goal Portfolio Viewer] Data merged successfully');
 
@@ -16822,7 +16875,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 }
             }
         }
-        
+
         // Add sync settings button
         const syncBtn = createOverlaySyncButton('endowus', {
             onUnavailable: () => {
@@ -17382,6 +17435,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
         window.__gpvTestingHooks = {
             injectStyles,
             showOverlay,
+            getOverlayPlatformDescriptor,
             startUrlMonitoring,
             init,
             getEndowusBucketConfigSignature,
@@ -17431,6 +17485,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             isFsmInvestmentsRoute,
             isOcbcDashboardRoute,
             isOcbcPortfolioHoldingsRoute,
+            getOverlayPlatformDescriptor: testingHooks?.getOverlayPlatformDescriptor,
             normalizeOcbcHoldingsPayload,
             calculateFixedTargetPercent,
             calculateRemainingTargetPercent,

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.16",
+  "version": "2.14.17",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",


### PR DESCRIPTION
## Summary
- Centralize platform overlay routing/readiness/render dispatch behind descriptor-driven flow for Endowus, FSM, and OCBC.
- Share FSM/OCBC overview card markup and small FSM/OCBC store migration cleanup helpers while preserving platform-specific behavior.
- Add route/readiness descriptor coverage in initialization tests and bump userscript/workspace versions to `2.14.17`.
- Follow-up passes share FSM/OCBC overview card construction, remove duplicated FSM selection/detail transitions, preserve OCBC native button semantics, and deduplicate OCBC sub-portfolio resolution.

## Change Brief
This change reduces duplicated user-flow control logic in the Tampermonkey userscript by making platform selection, readiness metadata, and ready-state rendering table-driven. It extracts common overview card structure for FSM/OCBC, small shared store-read helpers for repeated legacy-cleanup/allocation-model migration paths, and a shared OCBC sub-portfolio resolution helper used by both planning and rendering loops.

## Risks & Tradeoffs
- The first refactor added descriptor scaffolding, so total PR raw LOC is not lower; later passes reduce duplicated userscript source in targeted areas while adding safety assertions.
- Platform-specific storage migrations remain mostly explicit to avoid changing legacy compatibility behavior.
- `buildOverviewCardHtml` accepts trusted HTML snippets from current internal call sites; callers continue escaping user-visible values before interpolation.
- Native button keyboard activation is left to browser semantics; custom keydown handling remains only for non-native selectable cards.

## Acceptance Criteria
- FSM routes still open FSM readiness/portfolio views.
- OCBC dashboard/portfolio routes still open OCBC readiness/overview/detail views.
- Endowus remains the fallback overlay flow and keeps existing readiness behavior.
- FSM/OCBC overview cards retain their existing visible content and health/status metadata.
- Existing migration behavior for FSM/OCBC allocation model persistence remains unchanged.
- OCBC overview cards remain native `button` elements without redundant role/tabindex attributes.
- OCBC planning/rendering use the same persisted sub-portfolio resolution behavior as before.
- Version metadata remains aligned and above `main`.

## Verification Matrix
| Check | Scope | Result |
| --- | --- | --- |
| `node -e "global.GM_getValue=(k,f)=>f; global.GM_setValue=()=>{}; global.GM_deleteValue=()=>{}; require('./tampermonkey/goal_portfolio_viewer.user.js'); console.log('ok')"` | Node export/load compatibility | Passed |
| `corepack pnpm --filter ./tampermonkey test -- __tests__/init.test.js --runInBand` | Focused overlay route/readiness/a11y/OCBC allocation tests | Passed, 95 tests |
| `corepack pnpm --filter ./tampermonkey test -- --runInBand` | Full Tampermonkey Jest suite | Passed, 579 tests |
| `corepack pnpm --filter ./tampermonkey lint` | Tampermonkey lint | Passed |
| `node scripts/check-version-bump.js origin/main` | Version alignment/bump | Passed, `2.14.16 -> 2.14.17` |
| `git diff --check` | Whitespace sanity | Passed |
| GitHub CI after final push | PR checks | Passed: Detect changed paths, Version Bump, Lint, Dependency Audit, E2E Demo, Test on Node.js 20.x; Worker Unit Tests skipped |

## Self-Review Evidence
- Reviewed route precedence: FSM first, OCBC second, Endowus fallback.
- Confirmed browser-only descriptor export is routed through testing hooks to avoid pure Node `ReferenceError` regressions.
- Confirmed shared overview card helper preserves FSM non-native keyboard card behavior and OCBC native button behavior.
- Confirmed OCBC sub-portfolio resolution extraction preserves ordering, ambiguity guard behavior, and array safety.
- Confirmed review-fix loop findings were addressed and post-fix fresh-context review found no blocking or important issues.
- Confirmed final branch status is clean after pushing latest commit.

## Review Response Matrix
| Finding | Severity | Disposition | Fix Location | Verification Evidence | Residual Risk |
| --- | --- | --- | --- | --- | --- |
| Descriptor test could pass with stale module state | Medium | Fixed | `tampermonkey/__tests__/init.test.js` | Fresh module helper per route; focused init suite and full Jest suite passed | Low |
| Descriptor readiness mapping lacked focused assertions | Medium | Fixed | `tampermonkey/__tests__/init.test.js` | Added title/item assertions for Endowus/FSM/OCBC; focused init suite and full Jest suite passed | Low |
| Overview card helper rendered only one metadata slot | Low | Fixed | `tampermonkey/goal_portfolio_viewer.user.js` | Helper now renders both trusted metadata snippets; full Jest and lint passed | Low |
| OCBC overview card helper conversion needed a11y regression coverage | Blocking | Fixed | `tampermonkey/goal_portfolio_viewer.user.js`, `tampermonkey/__tests__/init.test.js` | Preserved native button element/type, asserted no explicit role/tabindex, focused/full tests and lint passed; post-fix review closed | Low |
| Native buttons received custom role/tabindex/keydown behavior | Important | Fixed | `tampermonkey/goal_portfolio_viewer.user.js` | Native buttons now skip role/tabindex and custom keydown; focused/full tests and lint passed; post-fix review closed | Low |
| OCBC sub-portfolio helper had inconsistent row guarding | Blocking | Fixed | `tampermonkey/goal_portfolio_viewer.user.js` | Added `safePortfolioRows`; focused/full tests and lint passed; post-fix review closed | Low |

## Skill Alignment Notes
- Refactoring: bounded extraction of common overlay/readiness/card/store/OCBC sub-portfolio scaffolding while preserving behavior.
- QA: focused route/readiness/a11y/OCBC coverage plus full Tampermonkey Jest and lint verification.
- Code review: fresh-context review before and after fixes; review-fix loops closed.
- CI triage: inspected failed Version Bump logs, classified as release metadata requirement, remediated with aligned version bump.

## CI Failure Triage
### Version Bump
Check: Version Bump  
Run/Job: https://github.com/laurenceputra/goal-portfolio-viewer/actions/runs/25952690243/job/76293488231  
Classification: release/version metadata requirement  
Evidence: CI log reported `Version must be bumped above 2.14.16; current version is 2.14.16.`  
Remediation: bumped `package.json`, `tampermonkey/package.json`, and userscript `@version` to `2.14.17`.  
Verification: `node scripts/check-version-bump.js origin/main` passed locally; final GitHub `Version Bump` check passed.  
Residual Risk: Low.  
Status: Closed.

## Final PR Completion
Latest pushed commit: `f84a6789d57cbed25d565e35f43d36ed7dfb28a9`  
Required check status after final push: passed (`Detect changed paths`, `Version Bump`, `Lint`, `Dependency Audit`, `E2E Demo`, `Test on Node.js 20.x`).  
Expected skipped checks: `Worker Unit Tests` skipped because changed-path detection did not include worker files.  
Local verification evidence: focused init tests, full Tampermonkey Jest suite, Tampermonkey lint, version bump check, Node load check, and whitespace check all passed.  
Open review-fix loops: none.  
Open CI-triage loops: none.  
Final status: ready.