### PR TITLE
refactor(fsm): debounce projection detail refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.14.17",
+  "version": "2.14.18",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",
   "pnpm": {
     "overrides": {
       "ajv": "^6.14.0",
-      "brace-expansion": "^5.0.5",
+      "brace-expansion": "^5.0.6",
       "flatted": "^3.4.2",
       "minimatch": "^10.2.3",
       "picomatch": "^2.3.2",
       "test-exclude": "^7.0.1",
-      "undici": "^7.24.0"
+      "undici": "^7.24.0",
+      "ws": "^8.20.1"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,13 @@ settings:
 
 overrides:
   ajv: ^6.14.0
-  brace-expansion: ^5.0.5
+  brace-expansion: ^5.0.6
   flatted: ^3.4.2
   minimatch: ^10.2.3
   picomatch: ^2.3.2
   test-exclude: ^7.0.1
   undici: ^7.24.0
+  ws: ^8.20.1
 
 importers:
 
@@ -910,8 +911,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2097,20 +2098,8 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3027,7 +3016,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.3
 
@@ -3908,7 +3897,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.19.0
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -3991,7 +3980,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.25.0
       workerd: 1.20260205.0
-      ws: 8.18.0
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -3999,7 +3988,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minipass@7.1.2: {}
 
@@ -4411,9 +4400,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@8.18.0: {}
-
-  ws@8.19.0: {}
+  ws@8.20.1: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/tampermonkey/__tests__/fsm-profit-models.test.js
+++ b/tampermonkey/__tests__/fsm-profit-models.test.js
@@ -34,6 +34,7 @@ describe('FSM profit models', () => {
     });
 
     afterEach(() => {
+        jest.useRealTimers();
         teardownDom();
     });
 
@@ -420,6 +421,7 @@ describe('FSM profit models', () => {
     });
 
     test('FSM projected amount updates planning split and is isolated per portfolio', () => {
+        jest.useFakeTimers();
         const { init, showOverlay, getFsmHoldingIdentity } = require('../goal_portfolio_viewer.user.js');
         const holdings = [
             { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1000 },
@@ -459,6 +461,7 @@ describe('FSM profit models', () => {
         projectionInput.focus();
         projectionInput.value = '1000';
         projectionInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+        jest.advanceTimersByTime(250);
 
         overlay = document.querySelector('#gpv-overlay');
         expect(document.activeElement).toBe(getProjectionInput(overlay));
@@ -494,6 +497,7 @@ describe('FSM profit models', () => {
     });
 
     test('FSM negative projected amount is rejected and not persisted', () => {
+        jest.useFakeTimers();
         const { init, showOverlay, getFsmHoldingIdentity } = require('../goal_portfolio_viewer.user.js');
         const holdings = [
             { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1000 },
@@ -531,6 +535,7 @@ describe('FSM profit models', () => {
         const projectionInput = getProjectionInput(overlay);
         projectionInput.value = '-100';
         projectionInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+        jest.advanceTimersByTime(250);
 
         overlay = document.querySelector('#gpv-overlay');
         expect(overlay.textContent).not.toContain('Projected Investment:');
@@ -559,5 +564,57 @@ describe('FSM profit models', () => {
         overlay = document.querySelector('#gpv-overlay');
         expect(getProjectionInput(overlay).value).toBe('');
         expect(overlay.textContent).not.toContain('Projected Investment:');
+    });
+
+    test('FSM projected amount refresh is debounced while typing', () => {
+        jest.useFakeTimers();
+        const { init, showOverlay, getFsmHoldingIdentity } = require('../goal_portfolio_viewer.user.js');
+        const holdings = [
+            { code: 'AAA', subcode: 'AAPL', name: 'Fund A', productType: 'UNIT_TRUST', currentValueLcy: 1000 },
+            { code: 'BBB', subcode: 'BOND', name: 'Fund B', productType: 'UNIT_TRUST', currentValueLcy: 1000 }
+        ];
+        const portfolioId = 'income';
+        const firstHoldingId = getFsmHoldingIdentity(holdings[0]);
+        const secondHoldingId = getFsmHoldingIdentity(holdings[1]);
+        mockStorageWithFsmConfig({
+            holdings,
+            portfolios: [{ id: portfolioId, name: 'Income', archived: false }],
+            assignments: {
+                [firstHoldingId]: portfolioId,
+                [secondHoldingId]: portfolioId
+            },
+            extra: {
+                [`fsm_target_pct_${firstHoldingId}`]: 50,
+                [`fsm_target_pct_${secondHoldingId}`]: 50
+            }
+        });
+
+        init();
+        showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const portfolioCard = Array.from(overlay.querySelectorAll('.gpv-fsm-overview-card')).find(card => (
+            card.querySelector('.gpv-fsm-overview-card-title')?.textContent.trim() === 'Income'
+        ));
+        portfolioCard.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const projectionInput = getProjectionInput(overlay);
+
+        projectionInput.value = '1';
+        projectionInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+        jest.advanceTimersByTime(200);
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).not.toContain('Projected Investment: SGD\u00A01.00');
+
+        projectionInput.value = '1000';
+        projectionInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+        jest.advanceTimersByTime(249);
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).not.toContain('Projected Investment: SGD\u00A01,000.00');
+
+        jest.advanceTimersByTime(1);
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).toContain('Projected Investment: SGD\u00A01,000.00');
     });
 });

--- a/tampermonkey/__tests__/handlers.test.js
+++ b/tampermonkey/__tests__/handlers.test.js
@@ -512,6 +512,18 @@ describe('handlers and cache', () => {
         });
         expect(projectedInvestmentsState[`${bucket}|${goalType}`]).toBeUndefined();
 
+        input.value = '200';
+        handleProjectedInvestmentChange({
+            input,
+            bucket,
+            goalType,
+            typeSection,
+            mergedInvestmentDataState,
+            projectedInvestmentsState
+        });
+        expect(projectedInvestmentsState[`${bucket}|${goalType}`]).toBe(200);
+        expect(jest.getTimerCount()).toBe(1);
+
         projectedInvestmentsState[`${bucket}|${goalType}`] = 300;
         input.value = 'invalid';
         handleProjectedInvestmentChange({
@@ -524,6 +536,7 @@ describe('handlers and cache', () => {
         });
         expect(projectedInvestmentsState[`${bucket}|${goalType}`]).toBe(300);
         expect(input.classList.contains('gpv-input-flash--error')).toBe(true);
+        expect(jest.getTimerCount()).toBe(0);
 
         jest.runOnlyPendingTimers();
         jest.useRealTimers();

--- a/tampermonkey/__tests__/init.test.js
+++ b/tampermonkey/__tests__/init.test.js
@@ -5198,6 +5198,81 @@ describe('initialization and URL monitoring', () => {
         expect(detailHeader?.nextElementSibling).toBe(planningPanel);
     });
 
+    test('Endowus projected investment refresh is debounced while typing', () => {
+        jest.useFakeTimers();
+        teardownDom();
+        setupDom({ url: 'https://app.sg.endowus.com/dashboard' });
+
+        storage = new Map();
+        global.GM_setValue = jest.fn((key, value) => storage.set(key, value));
+        global.GM_getValue = jest.fn((key, fallback = null) => (
+            storage.has(key) ? storage.get(key) : fallback
+        ));
+        global.GM_deleteValue = jest.fn(key => storage.delete(key));
+        global.GM_cookie = { list: jest.fn((_, cb) => cb ? cb([]) : []) };
+        global.alert = jest.fn();
+        global.fetch = jest.fn(() => Promise.resolve({ clone: () => ({}), json: () => Promise.resolve({}), ok: true, status: 200 }));
+        window.fetch = global.fetch;
+        global.history = window.history;
+
+        class FakeXHR {
+            constructor() {
+                this._headers = {};
+                this.responseText = '{}';
+            }
+            open(method, url) {
+                this._url = url;
+                return true;
+            }
+            setRequestHeader(header, value) {
+                this._headers[header] = value;
+            }
+            addEventListener() {}
+            send() {}
+        }
+        global.XMLHttpRequest = FakeXHR;
+
+        storage.set('api_summary', JSON.stringify([
+            { goalId: 'g1', goalName: 'Investment - Core', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION' }
+        ]));
+        storage.set('api_investible', JSON.stringify([
+            { goalId: 'g1', goalName: 'Investment - Core', investmentGoalType: 'GENERAL_WEALTH_ACCUMULATION', totalInvestmentAmount: { display: { amount: 1000 } } }
+        ]));
+        storage.set('api_performance', JSON.stringify([
+            { goalId: 'g1', totalCumulativeReturn: { amount: 0 }, simpleRateOfReturnPercent: 0 }
+        ]));
+
+        const exportsModule = require('../goal_portfolio_viewer.user.js');
+        exportsModule.init();
+        exportsModule.showOverlay();
+
+        let overlay = document.querySelector('#gpv-overlay');
+        const bucketCard = Array.from(overlay.querySelectorAll('.gpv-bucket-card')).find(card =>
+            card.textContent.includes('Investment')
+        );
+        bucketCard.click();
+
+        overlay = document.querySelector('#gpv-overlay');
+        const projectionInput = overlay.querySelector('input.gpv-projected-input');
+        projectionInput.value = '1';
+        projectionInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+        jest.advanceTimersByTime(200);
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).not.toContain('Projected Investment: SGD\u00A01.00');
+
+        projectionInput.value = '1000';
+        projectionInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+        jest.advanceTimersByTime(249);
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).not.toContain('Projected Investment: SGD\u00A01.00');
+        expect(overlay.textContent).not.toContain('Projected Investment: SGD\u00A01,000.00');
+
+        jest.advanceTimersByTime(1);
+        overlay = document.querySelector('#gpv-overlay');
+        expect(overlay.textContent).not.toContain('Projected Investment: SGD\u00A01.00');
+        expect(overlay.textContent).toContain('Projected Investment: SGD\u00A01,000.00');
+    });
+
     test('FSM row allocation and drift use selected scope totals', () => {
         teardownDom();
         setupDom({ url: 'https://secure.fundsupermart.com/fsmone/holdings/investments' });

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -9913,6 +9913,7 @@ let GoalTargetStore;
     };
 
     const FSM_PROJECTION_BUCKET = '__fsm__';
+    const FSM_PROJECTION_REFRESH_DEBOUNCE_MS = 250;
 
     function isFsmProjectedScope(selectedScope, activePortfolioIds) {
         if (!selectedScope || selectedScope === FSM_ALL_PORTFOLIO_ID || selectedScope === FSM_UNASSIGNED_PORTFOLIO_ID) {
@@ -15213,7 +15214,8 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             nextFocusTarget = null;
         };
 
-        const buildViewState = () => {
+        const buildViewState = (options = {}) => {
+            const includeOverviewModel = options.includeOverviewModel !== false;
             const rows = buildFsmRowsWithAssignment(fsmHoldings, assignmentByCode);
             const activePortfolioIds = activePortfolios().map(item => item.id);
             const activePortfolioSet = new Set(activePortfolioIds);
@@ -15300,98 +15302,24 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                 projectedAmount,
                 planning,
                 selectedScopeLabel: selectedScopeOption?.label || 'All',
-                overviewModel: buildFsmPortfolioOverviewModel(rows, activePortfolios())
+                overviewModel: includeOverviewModel ? buildFsmPortfolioOverviewModel(rows, activePortfolios()) : null
             };
         };
 
-        const rerender = () => {
-            const viewState = buildViewState();
+        let fsmProjectionRefreshTimer = null;
 
-            managerSection.innerHTML = '';
-
-            const managerSummary = buildFsmManagerSummary({
-                activePortfolioCount: viewState.activePortfolioIds.length,
-                unassignedCount: viewState.unassignedCount,
-                isExpanded: isPortfolioManagerExpanded,
-                onToggle: () => {
-                    isPortfolioManagerExpanded = !isPortfolioManagerExpanded;
-                    rerender();
-                }
-            });
-            managerSection.appendChild(managerSummary);
-
-            if (isPortfolioManagerExpanded) {
-                const manager = buildFsmManagerPanel({
-                    activePortfolios: activePortfolios(),
-                    editingPortfolioId,
-                    onCreate: name => {
-                        const id = buildPortfolioId(name, portfolios.map(item => item.id));
-                        portfolios = [...portfolios, { id, name, archived: false }];
-                        bulkPortfolioId = id;
-                        saveFsmPortfolioConfig(portfolios, assignmentByCode);
-                        rerender();
-                    },
-                    onStartRename: id => {
-                        editingPortfolioId = id;
-                        rerender();
-                    },
-                    onSaveRename: (id, nextName) => {
-                        portfolios = portfolios.map(portfolio => portfolio.id === id
-                            ? { ...portfolio, name: nextName }
-                            : portfolio);
-                        editingPortfolioId = null;
-                        saveFsmPortfolioConfig(portfolios, assignmentByCode);
-                        rerender();
-                    },
-                    onCancelRename: () => {
-                        editingPortfolioId = null;
-                        rerender();
-                    },
-                    onArchive: id => {
-                        portfolios = portfolios.map(portfolio => portfolio.id === id
-                            ? { ...portfolio, archived: true }
-                            : portfolio);
-                        Object.keys(assignmentByCode).forEach(code => {
-                            if (assignmentByCode[code] === id) {
-                                assignmentByCode[code] = FSM_UNASSIGNED_PORTFOLIO_ID;
-                            }
-                        });
-                        saveFsmPortfolioConfig(portfolios, assignmentByCode);
-                        if (selectedScope === id) {
-                            selectedScope = FSM_UNASSIGNED_PORTFOLIO_ID;
-                        }
-                        rerender();
-                    }
-                });
-                managerSection.appendChild(manager);
+        const clearFsmProjectionRefreshTimer = () => {
+            if (!fsmProjectionRefreshTimer) {
+                return;
             }
+            clearTimeout(fsmProjectionRefreshTimer);
+            fsmProjectionRefreshTimer = null;
+        };
 
+        const renderFsmDetailSections = viewState => {
             summarySection.innerHTML = '';
             bodySection.innerHTML = '';
 
-            if (viewMode === 'overview') {
-                headerBackBtn.hidden = true;
-                headerBackBtn.disabled = true;
-                toolbarSection.hidden = true;
-                setElementsDisabled(detailToolbarControls, true);
-                summarySection.appendChild(buildFsmSummaryRow(viewState.overviewModel.allSummary, {
-                    showDrift: false,
-                    showProfit: true,
-                    showFixed: false
-                }));
-                bodySection.appendChild(buildFsmOverviewPanel({
-                    overviewModel: viewState.overviewModel,
-                    onSelectScope: openFsmDetail,
-                    onOpenAll: () => openFsmDetail(FSM_ALL_PORTFOLIO_ID)
-                }));
-                focusAfterRender();
-                return;
-            }
-
-            headerBackBtn.hidden = false;
-            headerBackBtn.disabled = false;
-            toolbarSection.hidden = false;
-            setElementsDisabled(detailToolbarControls, false);
             summarySection.appendChild(buildFsmSummaryRow(viewState.summary, {
                 showDrift: viewState.showDrift,
                 showProfit: true
@@ -15405,7 +15333,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                         if (value === '') {
                             clearProjectedInvestment(state.projectedInvestments, FSM_PROJECTION_BUCKET, selectedScope);
                             nextFocusTarget = 'projection';
-                            rerender();
+                            scheduleFsmProjectionRefresh();
                             return;
                         }
                         const amount = parseFloat(value);
@@ -15416,13 +15344,13 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
                         if (amount === 0) {
                             clearProjectedInvestment(state.projectedInvestments, FSM_PROJECTION_BUCKET, selectedScope);
                             nextFocusTarget = 'projection';
-                            rerender();
+                            scheduleFsmProjectionRefresh();
                             return;
                         }
                         setProjectedInvestment(state.projectedInvestments, FSM_PROJECTION_BUCKET, selectedScope, amount);
                         flashInputBorder(input, 'success');
                         nextFocusTarget = 'projection';
-                        rerender();
+                        scheduleFsmProjectionRefresh();
                     }
                 }));
             }
@@ -15541,6 +15469,114 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             focusAfterRender();
         };
 
+        const refreshFsmProjectionDetail = () => {
+            if (viewMode !== 'detail') {
+                return;
+            }
+            const viewState = buildViewState({ includeOverviewModel: false });
+            renderFsmDetailSections(viewState);
+        };
+
+        const scheduleFsmProjectionRefresh = () => {
+            clearFsmProjectionRefreshTimer();
+            fsmProjectionRefreshTimer = setTimeout(() => {
+                fsmProjectionRefreshTimer = null;
+                refreshFsmProjectionDetail();
+            }, FSM_PROJECTION_REFRESH_DEBOUNCE_MS);
+        };
+
+        const rerender = () => {
+            clearFsmProjectionRefreshTimer();
+            const viewState = buildViewState();
+
+            managerSection.innerHTML = '';
+
+            const managerSummary = buildFsmManagerSummary({
+                activePortfolioCount: viewState.activePortfolioIds.length,
+                unassignedCount: viewState.unassignedCount,
+                isExpanded: isPortfolioManagerExpanded,
+                onToggle: () => {
+                    isPortfolioManagerExpanded = !isPortfolioManagerExpanded;
+                    rerender();
+                }
+            });
+            managerSection.appendChild(managerSummary);
+
+            if (isPortfolioManagerExpanded) {
+                const manager = buildFsmManagerPanel({
+                    activePortfolios: activePortfolios(),
+                    editingPortfolioId,
+                    onCreate: name => {
+                        const id = buildPortfolioId(name, portfolios.map(item => item.id));
+                        portfolios = [...portfolios, { id, name, archived: false }];
+                        bulkPortfolioId = id;
+                        saveFsmPortfolioConfig(portfolios, assignmentByCode);
+                        rerender();
+                    },
+                    onStartRename: id => {
+                        editingPortfolioId = id;
+                        rerender();
+                    },
+                    onSaveRename: (id, nextName) => {
+                        portfolios = portfolios.map(portfolio => portfolio.id === id
+                            ? { ...portfolio, name: nextName }
+                            : portfolio);
+                        editingPortfolioId = null;
+                        saveFsmPortfolioConfig(portfolios, assignmentByCode);
+                        rerender();
+                    },
+                    onCancelRename: () => {
+                        editingPortfolioId = null;
+                        rerender();
+                    },
+                    onArchive: id => {
+                        portfolios = portfolios.map(portfolio => portfolio.id === id
+                            ? { ...portfolio, archived: true }
+                            : portfolio);
+                        Object.keys(assignmentByCode).forEach(code => {
+                            if (assignmentByCode[code] === id) {
+                                assignmentByCode[code] = FSM_UNASSIGNED_PORTFOLIO_ID;
+                            }
+                        });
+                        saveFsmPortfolioConfig(portfolios, assignmentByCode);
+                        if (selectedScope === id) {
+                            selectedScope = FSM_UNASSIGNED_PORTFOLIO_ID;
+                        }
+                        rerender();
+                    }
+                });
+                managerSection.appendChild(manager);
+            }
+
+            summarySection.innerHTML = '';
+            bodySection.innerHTML = '';
+
+            if (viewMode === 'overview') {
+                headerBackBtn.hidden = true;
+                headerBackBtn.disabled = true;
+                toolbarSection.hidden = true;
+                setElementsDisabled(detailToolbarControls, true);
+                summarySection.appendChild(buildFsmSummaryRow(viewState.overviewModel.allSummary, {
+                    showDrift: false,
+                    showProfit: true,
+                    showFixed: false
+                }));
+                bodySection.appendChild(buildFsmOverviewPanel({
+                    overviewModel: viewState.overviewModel,
+                    onSelectScope: openFsmDetail,
+                    onOpenAll: () => openFsmDetail(FSM_ALL_PORTFOLIO_ID)
+                }));
+                focusAfterRender();
+                return;
+            }
+
+            headerBackBtn.hidden = false;
+            headerBackBtn.disabled = false;
+            toolbarSection.hidden = false;
+            setElementsDisabled(detailToolbarControls, false);
+            renderFsmDetailSections(viewState);
+        };
+
         const unsubscribeOverlayUpdates = subscribeDataUpdates(() => {
             if (!overlay.isConnected) {
                 return;
@@ -15553,6 +15589,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             rerender();
         });
         cleanupCallbacks.push(unsubscribeOverlayUpdates);
+        cleanupCallbacks.push(clearFsmProjectionRefreshTimer);
 
         rerender();
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.14.17
+// @version      2.14.18
 // @description  View and organize your investment portfolio with a modern interface across Endowus, FSM, and OCBC holdings. Includes bucket analytics and optional cross-device sync for configuration.
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -9732,6 +9732,55 @@ let GoalTargetStore;
         input.addEventListener('animationend', onAnimationEnd);
     }
 
+    const PROJECTION_REFRESH_DEBOUNCE_MS = 250;
+    const projectionRefreshTimersBySection = new WeakMap();
+
+    function clearProjectionRefreshTimer(typeSection) {
+        if (!typeSection) {
+            return;
+        }
+        const timerId = projectionRefreshTimersBySection.get(typeSection);
+        if (!timerId) {
+            return;
+        }
+        clearTimeout(timerId);
+        projectionRefreshTimersBySection.delete(typeSection);
+    }
+
+    function scheduleProjectionRefresh({
+        typeSection,
+        bucket,
+        goalType,
+        mergedInvestmentDataState,
+        projectedInvestmentsState
+    }) {
+        if (!typeSection) {
+            return;
+        }
+        clearProjectionRefreshTimer(typeSection);
+        const timerId = setTimeout(() => {
+            projectionRefreshTimersBySection.delete(typeSection);
+            const tbody = typeSection.querySelector(`.${CLASS_NAMES.goalTable} tbody`);
+            if (!tbody) {
+                return;
+            }
+            refreshGoalTypeSection({
+                typeSection,
+                bucket,
+                goalType,
+                mergedInvestmentDataState,
+                projectedInvestmentsState
+            });
+            refreshBucketPlanningPanel({
+                typeSection,
+                bucket,
+                mergedInvestmentDataState,
+                projectedInvestmentsState
+            });
+        }, PROJECTION_REFRESH_DEBOUNCE_MS);
+        projectionRefreshTimersBySection.set(typeSection, timerId);
+    }
+
     /**
      * Handle changes to goal target percentage input
      * @param {HTMLInputElement} input - Input element
@@ -9875,6 +9924,7 @@ let GoalTargetStore;
             
             // Validate input
             if (isNaN(amount)) {
+                clearProjectionRefreshTimer(typeSection);
                 // Invalid number - show error feedback
                 flashInputBorder(input, 'error');
                 return;
@@ -9886,24 +9936,14 @@ let GoalTargetStore;
             // Show success feedback
             flashInputBorder(input, 'success');
         }
-        
-        // Recalculate all diffs in this goal type section
-        const tbody = typeSection.querySelector(`.${CLASS_NAMES.goalTable} tbody`);
-        if (tbody) {
-            refreshGoalTypeSection({
-                typeSection,
-                bucket,
-                goalType,
-                mergedInvestmentDataState,
-                projectedInvestmentsState
-            });
-            refreshBucketPlanningPanel({
-                typeSection,
-                bucket,
-                mergedInvestmentDataState,
-                projectedInvestmentsState
-            });
-        }
+
+        scheduleProjectionRefresh({
+            typeSection,
+            bucket,
+            goalType,
+            mergedInvestmentDataState,
+            projectedInvestmentsState
+        });
     }
 
     const EventHandlers = {
@@ -9913,7 +9953,7 @@ let GoalTargetStore;
     };
 
     const FSM_PROJECTION_BUCKET = '__fsm__';
-    const FSM_PROJECTION_REFRESH_DEBOUNCE_MS = 250;
+    const FSM_PROJECTION_REFRESH_DEBOUNCE_MS = PROJECTION_REFRESH_DEBOUNCE_MS;
 
     function isFsmProjectedScope(selectedScope, activePortfolioIds) {
         if (!selectedScope || selectedScope === FSM_ALL_PORTFOLIO_ID || selectedScope === FSM_UNASSIGNED_PORTFOLIO_ID) {

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.14.17",
+  "version": "2.14.18",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",


### PR DESCRIPTION
## Change Brief
- **Problem:** FSM projection input in detail view rerendered the full overlay on every keystroke, making typing visibly laggier than Endowus. Endowus also still refreshed projection-driven UI immediately on every keystroke rather than sharing the same debounce timing.
- **Goal:** Align FSM and Endowus on a shared debounced projection-refresh model that preserves targeted refreshes while avoiding unnecessary UI churn during typing.
- **Change type:** Performance-focused behavior refactor with CI-remediation follow-up.
- **Affected repo surfaces:** `tampermonkey/goal_portfolio_viewer.user.js`, `tampermonkey/__tests__/fsm-profit-models.test.js`, `tampermonkey/__tests__/handlers.test.js`, `tampermonkey/__tests__/init.test.js`, `package.json`, `tampermonkey/package.json`, `pnpm-lock.yaml`
- **Spec-Clarity Gate:** pass
- **Open questions:** none

## Risks & Tradeoffs
- **Behavior risk:** Debouncing delays projection-driven recalculation by 250ms; this is intentional to reduce UI churn while typing.
- **Render lifecycle risk:** Partial detail refresh must preserve existing validation, per-portfolio projection isolation, focus behavior, and stale-timer cancellation when inputs become invalid.
- **Dependency override risk:** Overriding patched transitive versions (`brace-expansion`, `ws`) can theoretically affect downstream packages, though local verification and CI stayed green.
- **Chosen direction:** Reuse each surface’s existing targeted refresh primitives and align both flows on a shared debounce constant (`PROJECTION_REFRESH_DEBOUNCE_MS = 250`) rather than rewriting overlay/detail architecture.
- **Rejected alternative:** Debouncing full overlay `rerender()` only. That would reduce frequency but still keep unnecessary manager/overview rebuild work.

## Acceptance Criteria
- FSM projection input no longer triggers full overlay rerender on every keystroke.
- FSM and Endowus projection refreshes both occur only after the user pauses typing for the debounce window.
- Both surfaces continue using targeted refreshes rather than broad rerenders.
- FSM projected values remain isolated per portfolio scope.
- Empty/zero input clears projected amount; invalid negative/invalid input preserves validation behavior.
- Stale debounced projection output does not render after a superseding or invalid later input.
- Version metadata is bumped consistently for this behavior change.
- Dependency audit passes with patched transitive dependencies.
- Existing Tampermonkey tests and lint continue to pass.

## Verification Matrix
| Acceptance Criterion | Verification | Evidence |
| --- | --- | --- |
| FSM no longer rerenders whole overlay on projection typing | Code inspection + focused FSM tests | `renderFsmDetailSections(...)`, debounced `scheduleFsmProjectionRefresh()`, passing `fsm-profit-models.test.js` |
| FSM refresh only after typing pause | Automated test | `FSM projected amount refresh is debounced while typing` |
| Endowus refresh only after typing pause | Automated test | `Endowus projected investment refresh is debounced while typing` |
| Stale projection output is suppressed after superseding/invalid input | Automated tests | `handlers.test.js` timer cancellation assertion + `init.test.js` stale `1.00` suppression assertions |
| Per-portfolio isolation preserved | Automated test | `FSM projected amount updates planning split and is isolated per portfolio` |
| Empty/zero clears and invalid input still validated | Automated tests | `FSM negative projected amount is rejected and not persisted`, `handleProjectedInvestmentChange clears on zero or invalid input` |
| Version metadata bumped consistently | File inspection + CI remediation | `package.json`, `tampermonkey/package.json`, userscript `@version` all updated to `2.14.18` |
| Dependency audit passes | Automated command + CI | `corepack pnpm audit`, `Dependency Audit` check |
| No broader regression in tampermonkey surface | Automated suite + lint + CI | local Jest/lint runs + green `Test on Node.js 20.x` / `Lint` / `E2E Demo` |

## Self-Review Evidence
- Inspected diff for targeted-only scope and reuse-first alignment.
- Inspected CI failure logs for `Version Bump` and `Dependency Audit` before remediation.
- Ran fresh-context code review and completed review-fix loop for debounce timer edge cases.
- Commands run:
  - `node -c tampermonkey/goal_portfolio_viewer.user.js`
  - `corepack pnpm install --frozen-lockfile`
  - `corepack pnpm --filter ./tampermonkey test -- --runInBand fsm-profit-models.test.js`
  - `corepack pnpm --filter ./tampermonkey test -- --runInBand handlers.test.js init.test.js fsm-profit-models.test.js`
  - `corepack pnpm --filter ./tampermonkey lint`
  - `corepack pnpm --filter ./tampermonkey test -- --runInBand`
  - `corepack pnpm audit`
  - `corepack pnpm install`
  - `corepack pnpm install --frozen-lockfile`
- Outcomes:
  - Syntax check passed.
  - Focused FSM projection tests passed.
  - Focused Endowus/FSM/handler debounce tests passed.
  - Lint passed.
  - Full Tampermonkey Jest suite passed (`13` suites, `580` tests).
  - Audit passed after dependency override + lockfile refresh.
  - Final PR CI checks are green.
- Follow-up notes:
  - Existing console warnings in `init.test.js` about mocked performance fetch cloning remain pre-existing and non-blocking for this change.

## Skill Alignment Notes
- **performance-optimization:** used to assess why FSM typing lagged and choose a lower-churn refresh strategy.
- **ci-failure-triage:** used after CI reported failed `Version Bump` and `Dependency Audit` checks.
- **review-fix-loop:** used after fresh-context review found an important stale-timer gap in the Endowus debounce change.
- **code-review:** applied via fresh-context code-review subagents after implementation and after review-fix loop.
- **qa-testing:** covered through focused and broad automated verification.
- **pr-completion:** implicitly satisfied for current status reporting by confirming latest pushed commit and green checks; no separate skill load was required for this update.

## Review Response Matrix
| Finding | Severity | Disposition | Fix Location | Verification Evidence | Residual Risk |
| --- | --- | --- | --- | --- | --- |
| Endowus stale debounced refresh could still fire after later invalid input | important | fixed | `tampermonkey/goal_portfolio_viewer.user.js`, `tampermonkey/__tests__/handlers.test.js`, `tampermonkey/__tests__/init.test.js` | fresh review, focused Jest run for `handlers.test.js init.test.js fsm-profit-models.test.js`, green CI | low |

## CI Failure Triage
Check: `Version Bump`
Run/Job: https://github.com/laurenceputra/goal-portfolio-viewer/actions/runs/26101499331/job/76753506683
Classification: `lint/format` / release-policy enforcement
Evidence: CI log reported `Version must be bumped above 2.14.17; current version is 2.14.17.`
Remediation: bumped aligned versions in root package, tampermonkey package, and userscript metadata to `2.14.18`.
Verification: local file inspection and green rerun in CI.
Residual Risk: low.
Status: closed.

Check: `Dependency Audit`
Run/Job: https://github.com/laurenceputra/goal-portfolio-viewer/actions/runs/26101499331/job/76753506708
Classification: `dependency/security`
Evidence: CI audit reported vulnerable `brace-expansion@5.0.5` and `ws@8.19.0` / `ws@8.18.0`.
Remediation: updated root `pnpm.overrides` to force patched `brace-expansion@^5.0.6` and `ws@^8.20.1`, then refreshed `pnpm-lock.yaml`.
Verification: `corepack pnpm audit` returned `No known vulnerabilities found` locally and `Dependency Audit` passed in CI.
Residual Risk: low; transitive override changes can theoretically affect downstream packages, but lint/tests and CI remained green.
Status: closed.

## Final PR Completion
- **Latest pushed commit:** `dcd85f30eec05f5a040887cb4e653674ef9b9555`
- **Required check status after the final push:** all green
  - `Dependency Audit` ✅
  - `Detect changed paths` ✅
  - `E2E Demo` ✅
  - `Lint` ✅
  - `Test on Node.js 20.x` ✅
  - `Version Bump` ✅
  - `Worker Unit Tests` ✅
- **Expected skipped checks and rationale:** none on the final run.
- **Local verification evidence:** focused FSM tests, focused Endowus/FSM debounce tests, full tampermonkey Jest suite, lint, syntax check, and audit all passed.