### PR TITLE
Refactor sync store handling and align test contracts

### DIFF
--- a/demo/e2e-tests.js
+++ b/demo/e2e-tests.js
@@ -33,6 +33,7 @@ const REGRESSION_DIR = path.join(__dirname, 'regression');
 const REGRESSION_BASELINE_DIR = path.join(REGRESSION_DIR, 'baseline');
 const REGRESSION_ACTUAL_DIR = path.join(REGRESSION_DIR, 'actual');
 const REGRESSION_DIFF_DIR = path.join(REGRESSION_DIR, 'diff');
+const E2E_FSM_GROWTH_ID = 'ESG003|sub:ESG3';
 
 function assertCondition(condition, message) {
     if (!condition) {
@@ -810,8 +811,7 @@ async function captureFsmFlow(page, summary, outputDir) {
         { timeout: 5000 }
     );
 
-    await page.evaluate(async () => {
-        const growthId = 'ESG003|sub:ESG3';
+    await page.evaluate(async growthId => {
         if (typeof window.GM_setValue !== 'function') {
             throw new Error('Demo bridge missing: window.GM_setValue is not available');
         }
@@ -884,7 +884,7 @@ async function captureFsmFlow(page, summary, outputDir) {
                 throw new Error(`Demo bridge verification failed for ${key}.allocation.targetsByCode[${growthId}]: expected 64.5, received ${String(seededTarget)}`);
             }
         }
-    });
+    }, E2E_FSM_GROWTH_ID);
     await clickButtonByRole(page, /back to portfolios/i);
     const coreOverviewCard = page.locator('.gpv-fsm-overview-card').filter({ hasText: /core/i }).first();
     await coreOverviewCard.click();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-portfolio-viewer",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Goal Portfolio Viewer workspace",
   "private": true,
   "packageManager": "pnpm@9.12.3",

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -732,6 +732,16 @@ describe('SyncManager', () => {
         })).rejects.toThrow('HTTPS');
     });
 
+    test('enable rejects invalid sync user IDs', async () => {
+        const { SyncManager } = loadModule();
+
+        await expect(SyncManager.enable({
+            serverUrl: 'https://sync.example.com',
+            userId: 'invalid user',
+            password: 'password123'
+        })).rejects.toThrow('Invalid userId format');
+    });
+
     test('getStatus treats stored insecure sync URL as unconfigured without throwing', () => {
         storage.set('sync_enabled', true);
         storage.set('sync_server_url', 'http://sync.example.com');
@@ -742,6 +752,20 @@ describe('SyncManager', () => {
         const { SyncManager } = loadModule();
 
         expect(() => SyncManager.getStatus()).not.toThrow();
+        expect(SyncManager.getStatus()).toEqual(expect.objectContaining({
+            isConfigured: false
+        }));
+    });
+
+    test('getStatus treats stored invalid sync user ID as unconfigured', () => {
+        storage.set('sync_enabled', true);
+        storage.set('sync_server_url', 'https://sync.example.com');
+        storage.set('sync_user_id', 'invalid user');
+        storage.set('sync_refresh_token', 'refresh-token');
+        storage.set('sync_refresh_token_expiry', Date.now() + 120_000);
+
+        const { SyncManager } = loadModule();
+
         expect(SyncManager.getStatus()).toEqual(expect.objectContaining({
             isConfigured: false
         }));
@@ -1945,6 +1969,54 @@ describe('SyncManager', () => {
         const { SyncManager } = loadModule();
         await expect(SyncManager.register('https://sync.example.com', 'user@example.com', 'password123')).resolves.toEqual({ success: true });
         expect(global.GM_xmlhttpRequest).toHaveBeenCalled();
+    });
+
+    test('register rejects invalid userId before making network requests', async () => {
+        global.GM_xmlhttpRequest = jest.fn();
+        fetchMock.mockImplementation(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) }));
+
+        const { SyncManager } = loadModule();
+        await expect(SyncManager.register('https://sync.example.com', 'bad user', 'password123')).rejects.toThrow('Invalid userId format');
+        expect(global.GM_xmlhttpRequest).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('login rejects invalid userId before making network requests', async () => {
+        global.GM_xmlhttpRequest = jest.fn();
+        fetchMock.mockImplementation(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) }));
+
+        const { SyncManager } = loadModule();
+        await expect(SyncManager.login('https://sync.example.com', 'bad user', 'password123')).rejects.toThrow('Invalid userId format');
+        expect(global.GM_xmlhttpRequest).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('performSync classifies payload-too-large errors with user guidance', async () => {
+        seedConfiguredState();
+        const { SyncManager } = loadModule();
+        unlockSync(SyncManager);
+
+        global.GM_xmlhttpRequest = jest.fn(({ url, method, onload }) => {
+            if (url.includes('/sync') && method === 'POST') {
+                onload({
+                    status: 413,
+                    responseText: JSON.stringify({
+                        success: false,
+                        error: 'PAYLOAD_TOO_LARGE',
+                        message: 'Payload too large'
+                    }),
+                    responseHeaders: ''
+                });
+                return;
+            }
+            onload({ status: 200, responseText: '{}', responseHeaders: '' });
+        });
+
+        await expect(SyncManager.performSync({ direction: 'upload' })).rejects.toThrow('Payload too large');
+        expect(SyncManager.getStatus().lastErrorMeta).toEqual(expect.objectContaining({
+            category: 'payload',
+            primaryAction: 'Review sync data'
+        }));
     });
 
     describe('token helpers', () => {

--- a/tampermonkey/__tests__/syncManager.test.js
+++ b/tampermonkey/__tests__/syncManager.test.js
@@ -159,6 +159,19 @@ describe('SyncManager', () => {
         }));
     }
 
+    test('getSyncRequestContext normalizes and validates stored sync identity', () => {
+        storage.set('sync', JSON.stringify({
+            serverUrl: 'https://sync.example.com/',
+            userId: ' user@example.com '
+        }));
+
+        const moduleExports = loadModule();
+        expect(moduleExports.getSyncRequestContext()).toEqual({
+            serverUrl: 'https://sync.example.com',
+            userId: 'user@example.com'
+        });
+    });
+
     test('legacy flat sync keys migrate full sync schema into sync store and are removed', () => {
         storage.set('sync_enabled', true);
         storage.set('sync_server_url', 'https://sync.example.com');

--- a/tampermonkey/__tests__/uiModels.test.js
+++ b/tampermonkey/__tests__/uiModels.test.js
@@ -25,6 +25,9 @@ const {
     collectAllGoalIds,
     buildGoalTargetById,
     buildGoalFixedById,
+    loadGoalAllocationConfig,
+    loadBucketAllocationConfig,
+    loadAllBucketAllocationConfig,
     buildMergedInvestmentData,
     buildBucketPlanningModel,
     getBucketViewModePreference,
@@ -902,6 +905,40 @@ describe('collectGoalIds and buildGoalTargetById', () => {
     test('should build goal fixed map with getter', () => {
         const map = buildGoalFixedById(['a', 'b'], id => id === 'b');
         expect(map).toEqual({ b: true });
+    });
+
+    test('should load goal allocation config with deduplicated normalized ids', () => {
+        const config = loadGoalAllocationConfig([' a ', 'b', 'a', '', null], {
+            getTarget: id => (id === 'a' ? 20 : null),
+            getFixed: id => id === 'b'
+        });
+        expect(config).toEqual({
+            goalIds: ['a', 'b'],
+            goalTargetById: { a: 20 },
+            goalFixedById: { b: true }
+        });
+    });
+
+    test('should load bucket allocation config from bucket goals', () => {
+        const bucketMap = createBucketMapFixture();
+        const config = loadBucketAllocationConfig(bucketMap.Retirement, {
+            getTarget: id => (id === 'g2' ? 35 : null),
+            getFixed: id => id === 'g1'
+        });
+        expect(config.goalIds.sort()).toEqual(['g1', 'g2', 'g3']);
+        expect(config.goalTargetById).toEqual({ g2: 35 });
+        expect(config.goalFixedById).toEqual({ g1: true });
+    });
+
+    test('should load all bucket allocation config across buckets', () => {
+        const bucketMap = createBucketMapFixture();
+        const config = loadAllBucketAllocationConfig(bucketMap, {
+            getTarget: id => (id === 'g3' ? 15 : null),
+            getFixed: id => id === 'g1'
+        });
+        expect(config.goalIds.sort()).toEqual(['g1', 'g2', 'g3']);
+        expect(config.goalTargetById).toEqual({ g3: 15 });
+        expect(config.goalFixedById).toEqual({ g1: true });
     });
 });
 

--- a/tampermonkey/__tests__/utils.test.js
+++ b/tampermonkey/__tests__/utils.test.js
@@ -49,7 +49,12 @@ const {
     summarizePerformanceMetrics,
     derivePerformanceWindows,
     parseJsonSafely,
-    normalizeOcbcHoldingsPayload
+    normalizeOcbcHoldingsPayload,
+    groupOcbcHoldingsByPortfolio,
+    flattenOcbcHoldingsByPortfolio,
+    normalizeOcbcHoldingsByPortfolioForStore,
+    mergeOcbcHoldingsByPortfolio,
+    buildOcbcHoldingsByPortfolioFromPayload
 } = require('../goal_portfolio_viewer.user.js');
 
 describe('storage key helpers', () => {
@@ -757,6 +762,61 @@ describe('normalizeOcbcHoldingsPayload', () => {
         expect(result.assets[0].legacyCodeAliases).not.toContain('P-ALIASES:POSITION-LEGACY');
         expect(result.assets[0].legacyCodeAliases).not.toContain('P-ALIASES:TRANCHE-LEGACY');
         expect(result.assets[0].legacyCodeAliases).not.toContain('P-ALIASES:SUB-LEGACY');
+    });
+
+    test('builds canonical OCBC by-portfolio holdings from payload', () => {
+        const payload = {
+            data: [{
+                portfolioNo: 'P-CANON',
+                assets: [{
+                    assetClassDesc: 'Managed Funds',
+                    subAssets: [{
+                        subAssetClassDesc: 'Global Equity',
+                        holdings: [{ isin: 'ISIN-1', marketValueReferenceCcy: 100 }]
+                    }]
+                }],
+                liabilities: [{
+                    assetClassDesc: 'Liabilities',
+                    subAssets: [{
+                        subAssetClassDesc: 'Margin',
+                        holdings: [{ description: 'Margin', positionId: 'L-1', marketValueReferenceCcy: -20 }]
+                    }]
+                }]
+            }]
+        };
+
+        const byPortfolio = buildOcbcHoldingsByPortfolioFromPayload(payload);
+        expect(Object.keys(byPortfolio)).toEqual(['P-CANON']);
+        expect(byPortfolio['P-CANON'].assets).toHaveLength(1);
+        expect(byPortfolio['P-CANON'].liabilities).toHaveLength(1);
+        expect(flattenOcbcHoldingsByPortfolio(byPortfolio)).toEqual(normalizeOcbcHoldingsPayload(payload));
+    });
+
+    test('groups, normalizes, and merges OCBC holdings by portfolio consistently', () => {
+        const grouped = groupOcbcHoldingsByPortfolio({
+            assets: [{ code: 'P-1:A', portfolioNo: 'P-1' }],
+            liabilities: [{ code: 'P-2:L', portfolioNo: 'P-2' }]
+        });
+        expect(grouped).toEqual({
+            'P-1': { assets: [{ code: 'P-1:A', portfolioNo: 'P-1' }], liabilities: [], lastSeenAt: null },
+            'P-2': { assets: [], liabilities: [{ code: 'P-2:L', portfolioNo: 'P-2' }], lastSeenAt: null }
+        });
+
+        const normalized = normalizeOcbcHoldingsByPortfolioForStore({
+            ' P-1 ': { assets: [{ code: 'P-1:A', portfolioNo: 'P-1' }], liabilities: 'invalid', lastSeenAt: 0 }
+        });
+        expect(normalized).toEqual({
+            'P-1': { assets: [{ code: 'P-1:A', portfolioNo: 'P-1' }], liabilities: [], lastSeenAt: null }
+        });
+
+        const merged = mergeOcbcHoldingsByPortfolio(grouped, {
+            'P-1': { assets: [{ code: 'P-1:B', portfolioNo: 'P-1' }], liabilities: [] }
+        }, 1234);
+        expect(merged['P-1']).toEqual({
+            assets: [{ code: 'P-1:B', portfolioNo: 'P-1' }],
+            liabilities: [],
+            lastSeenAt: 1234
+        });
     });
 });
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1049,10 +1049,43 @@
         };
     }
 
-    function normalizeOcbcHoldingsPayload(data) {
+    function createEmptyOcbcHoldings() {
+        return { assets: [], liabilities: [] };
+    }
+
+    function normalizeOcbcPortfolioHoldingsEntry(entry, { defaultLastSeenAt = null } = {}) {
+        const source = entry && typeof entry === 'object' && !Array.isArray(entry) ? entry : {};
+        const lastSeenAt = typeof source.lastSeenAt === 'number' && source.lastSeenAt > 0
+            ? source.lastSeenAt
+            : defaultLastSeenAt;
+        return {
+            assets: Array.isArray(source.assets) ? source.assets : [],
+            liabilities: Array.isArray(source.liabilities) ? source.liabilities : [],
+            lastSeenAt: typeof lastSeenAt === 'number' && lastSeenAt > 0 ? lastSeenAt : null
+        };
+    }
+
+    function ensureOcbcHoldingsByPortfolioEntry(target, rawPortfolioNo, options = {}) {
+        const grouped = target && typeof target === 'object' && !Array.isArray(target) ? target : {};
+        const portfolioNo = utils.normalizeString(rawPortfolioNo, '-');
+        if (!grouped[portfolioNo]) {
+            grouped[portfolioNo] = normalizeOcbcPortfolioHoldingsEntry({}, options);
+        }
+        return grouped[portfolioNo];
+    }
+
+    function appendOcbcRowByPortfolio(target, section, row, options = {}) {
+        if (!row || (section !== 'assets' && section !== 'liabilities')) {
+            return target;
+        }
+        const entry = ensureOcbcHoldingsByPortfolioEntry(target, row.portfolioNo, options);
+        entry[section].push(row);
+        return target;
+    }
+
+    function buildOcbcHoldingsByPortfolioFromPayload(data) {
         const groups = Array.isArray(data?.data) ? data.data : [];
-        const assets = [];
-        const liabilities = [];
+        const grouped = {};
         let assetIndex = 0;
         let liabilityIndex = 0;
 
@@ -1078,12 +1111,11 @@
                             if (!normalized) {
                                 return;
                             }
+                            appendOcbcRowByPortfolio(grouped, sectionType, normalized);
                             if (isAssets) {
                                 assetIndex += 1;
-                                assets.push(normalized);
                             } else {
                                 liabilityIndex += 1;
-                                liabilities.push(normalized);
                             }
                         });
                     });
@@ -1093,44 +1125,36 @@
 
         flattenSectionRows('assets', groups);
         flattenSectionRows('liabilities', groups);
-        return { assets, liabilities };
+        return normalizeOcbcHoldingsByPortfolioForStore(grouped);
+    }
+
+    function normalizeOcbcHoldingsPayload(data) {
+        return flattenOcbcHoldingsByPortfolio(buildOcbcHoldingsByPortfolioFromPayload(data));
     }
 
     function groupOcbcHoldingsByPortfolio(holdings) {
-        const source = holdings && typeof holdings === 'object' ? holdings : { assets: [], liabilities: [] };
+        const source = holdings && typeof holdings === 'object' ? holdings : createEmptyOcbcHoldings();
         const grouped = {};
-        function appendRows(section, rows) {
-            (Array.isArray(rows) ? rows : []).forEach(row => {
-                const portfolioNo = utils.normalizeString(row?.portfolioNo, '-');
-                if (!grouped[portfolioNo]) {
-                    grouped[portfolioNo] = { assets: [], liabilities: [], lastSeenAt: null };
-                }
-                grouped[portfolioNo][section].push(row);
-            });
-        }
-        appendRows('assets', source.assets);
-        appendRows('liabilities', source.liabilities);
-        return grouped;
+        (Array.isArray(source.assets) ? source.assets : []).forEach(row => {
+            appendOcbcRowByPortfolio(grouped, 'assets', row);
+        });
+        (Array.isArray(source.liabilities) ? source.liabilities : []).forEach(row => {
+            appendOcbcRowByPortfolio(grouped, 'liabilities', row);
+        });
+        return normalizeOcbcHoldingsByPortfolioForStore(grouped);
     }
 
     function flattenOcbcHoldingsByPortfolio(holdingsByPortfolio) {
         const source = holdingsByPortfolio && typeof holdingsByPortfolio === 'object' && !Array.isArray(holdingsByPortfolio)
             ? holdingsByPortfolio
             : {};
-        const assets = [];
-        const liabilities = [];
+        const flattened = createEmptyOcbcHoldings();
         Object.values(source).forEach(entry => {
-            if (!entry || typeof entry !== 'object') {
-                return;
-            }
-            if (Array.isArray(entry.assets)) {
-                assets.push(...entry.assets);
-            }
-            if (Array.isArray(entry.liabilities)) {
-                liabilities.push(...entry.liabilities);
-            }
+            const normalizedEntry = normalizeOcbcPortfolioHoldingsEntry(entry);
+            flattened.assets.push(...normalizedEntry.assets);
+            flattened.liabilities.push(...normalizedEntry.liabilities);
         });
-        return { assets, liabilities };
+        return flattened;
     }
 
     function normalizeOcbcHoldingsByPortfolioForStore(data) {
@@ -1138,14 +1162,7 @@
         const normalized = {};
         Object.entries(source).forEach(([rawPortfolioNo, entry]) => {
             const portfolioNo = utils.normalizeString(rawPortfolioNo, '-');
-            if (!entry || typeof entry !== 'object') {
-                return;
-            }
-            normalized[portfolioNo] = {
-                assets: Array.isArray(entry.assets) ? entry.assets : [],
-                liabilities: Array.isArray(entry.liabilities) ? entry.liabilities : [],
-                lastSeenAt: typeof entry.lastSeenAt === 'number' && entry.lastSeenAt > 0 ? entry.lastSeenAt : null
-            };
+            normalized[portfolioNo] = normalizeOcbcPortfolioHoldingsEntry(entry);
         });
         return normalized;
     }
@@ -1154,11 +1171,7 @@
         const merged = normalizeOcbcHoldingsByPortfolioForStore(currentByPortfolio);
         const normalizedNext = normalizeOcbcHoldingsByPortfolioForStore(nextByPortfolio);
         Object.entries(normalizedNext).forEach(([portfolioNo, entry]) => {
-            merged[portfolioNo] = {
-                assets: Array.isArray(entry.assets) ? entry.assets : [],
-                liabilities: Array.isArray(entry.liabilities) ? entry.liabilities : [],
-                lastSeenAt: typeof entry.lastSeenAt === 'number' && entry.lastSeenAt > 0 ? entry.lastSeenAt : now
-            };
+            merged[portfolioNo] = normalizeOcbcPortfolioHoldingsEntry(entry, { defaultLastSeenAt: now });
         });
         return merged;
     }
@@ -3797,6 +3810,28 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         return Storage.writeJson(key, store, context || `Error saving ${key} store`);
     }
 
+    function restoreStorageSnapshots(snapshotByKey, contextSuffix = 'sync config data') {
+        Object.entries(snapshotByKey || {}).forEach(([key, snapshot]) => {
+            if (snapshot?.exists) {
+                Storage.set(key, snapshot.value, `Error rolling back ${key} ${contextSuffix}`);
+                return;
+            }
+            Storage.remove(key, `Error rolling back ${key} ${contextSuffix}`);
+        });
+    }
+
+    function writePlatformStoresOrRollback(writes, snapshotByKey) {
+        const safeWrites = Array.isArray(writes) ? writes : [];
+        for (const write of safeWrites) {
+            const didWrite = writePlatformStore(write.key, write.store, write.context);
+            if (didWrite) {
+                continue;
+            }
+            restoreStorageSnapshots(snapshotByKey);
+            throw new Error(write.failureMessage || `Failed to save ${write.key} sync config data`);
+        }
+    }
+
     function normalizeSyncStore(data) {
         return data && typeof data === 'object' && !Array.isArray(data) ? { ...data } : {};
     }
@@ -5229,33 +5264,26 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             })
         });
 
-        const restoreNamespacedSnapshots = () => {
-            Object.entries(rawSnapshotByKey).forEach(([key, snapshot]) => {
-                if (snapshot.exists) {
-                    Storage.set(key, snapshot.value, `Error rolling back ${key} sync config data`);
-                    return;
-                }
-                Storage.remove(key, `Error rolling back ${key} sync config data`);
-            });
-        };
-
-        const endowusResult = writePlatformStore(STORAGE_KEYS.endowus, updatedEndowusStore, 'Error saving Endowus store');
-        if (!endowusResult) {
-            restoreNamespacedSnapshots();
-            throw new Error('Failed to save Endowus sync config data');
-        }
-
-        const fsmResult = writePlatformStore(STORAGE_KEYS.fsm, updatedFsmStore, 'Error saving FSM store');
-        if (!fsmResult) {
-            restoreNamespacedSnapshots();
-            throw new Error('Failed to save FSM sync config data');
-        }
-
-        const ocbcResult = writePlatformStore(STORAGE_KEYS.ocbc, updatedOcbcStore, 'Error saving OCBC store');
-        if (!ocbcResult) {
-            restoreNamespacedSnapshots();
-            throw new Error('Failed to save OCBC sync config data');
-        }
+        writePlatformStoresOrRollback([
+            {
+                key: STORAGE_KEYS.endowus,
+                store: updatedEndowusStore,
+                context: 'Error saving Endowus store',
+                failureMessage: 'Failed to save Endowus sync config data'
+            },
+            {
+                key: STORAGE_KEYS.fsm,
+                store: updatedFsmStore,
+                context: 'Error saving FSM store',
+                failureMessage: 'Failed to save FSM sync config data'
+            },
+            {
+                key: STORAGE_KEYS.ocbc,
+                store: updatedOcbcStore,
+                context: 'Error saving OCBC store',
+                failureMessage: 'Failed to save OCBC sync config data'
+            }
+        ], rawSnapshotByKey);
 
         logDebug('[Goal Portfolio Viewer] Applied sync config data', {
             endowusTargets: Object.keys(endowusTargets).length,
@@ -5348,6 +5376,42 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             error.retryAfterSeconds = retryAfterSeconds;
         }
         return error;
+    }
+
+    function getSyncRequestContext() {
+        const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
+        const userId = utils.normalizeString(Storage.get(SYNC_STORAGE_KEYS.userId, null), '');
+        if (!userId) {
+            throw new Error('Sync not configured');
+        }
+        return {
+            serverUrl,
+            userId: assertValidSyncUserId(userId)
+        };
+    }
+
+    async function requestSyncApi(path, options = {}) {
+        const context = options.context || getSyncRequestContext();
+        const requiresAuth = options.requiresAuth !== false;
+        const headers = {
+            ...(options.headers || {})
+        };
+        if (requiresAuth) {
+            headers.Authorization = `Bearer ${await getAccessToken()}`;
+        }
+        const response = await requestJson(`${context.serverUrl}${path}`, {
+            ...options,
+            headers
+        });
+        if (options.allowNotFound === true && response.status === 404) {
+            return { response, data: null, context };
+        }
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            throw createApiError(response, errorData, options.errorMessage || `Request failed: ${response.status}`);
+        }
+        const data = await response.json().catch(() => ({}));
+        return { response, data, context };
     }
 
     function buildRequestError(message, code) {
@@ -5491,13 +5555,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      * Upload config to server
      */
     async function uploadConfig(config, options = {}) {
-        const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
-        const userId = utils.normalizeString(Storage.get(SYNC_STORAGE_KEYS.userId, null), '');
-
-        if (!userId) {
-            throw new Error('Sync not configured');
-        }
-        assertValidSyncUserId(userId);
+        const context = getSyncRequestContext();
 
         const masterKey = requireSessionKey();
 
@@ -5505,71 +5563,46 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         const plaintext = JSON.stringify(config);
         const encryptedData = await SyncEncryption.encryptWithMasterKey(plaintext, masterKey);
 
-        const accessToken = await getAccessToken();
-
         // Prepare payload
         const payload = {
             encryptedData,
             deviceId: getDeviceId(),
             timestamp: config.timestamp,
             version: config.version,
-            userId
+            userId: context.userId
         };
         if (options.force === true) {
             payload.force = true;
         }
 
-        // Upload to server (POST /sync)
-        const response = await requestJson(`${serverUrl}/sync`, {
+        const { data } = await requestSyncApi('/sync', {
+            context,
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${accessToken}`
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify(payload)
+            body: JSON.stringify(payload),
+            errorMessage: 'Upload failed'
         });
-
-        if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}));
-            throw createApiError(response, errorData, `Upload failed: ${response.status}`);
-        }
-
-        return response.json();
+        return data;
     }
 
     /**
      * Download config from server
      */
     async function downloadConfig() {
-        const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
-        const userId = utils.normalizeString(Storage.get(SYNC_STORAGE_KEYS.userId, null), '');
-
-        if (!userId) {
-            throw new Error('Sync not configured');
-        }
-        assertValidSyncUserId(userId);
-
-        const accessToken = await getAccessToken();
-
-        // Download from server
-        const response = await requestJson(`${serverUrl}/sync/${userId}`, {
+        const context = getSyncRequestContext();
+        const { data: serverData } = await requestSyncApi(`/sync/${context.userId}`, {
+            context,
             method: 'GET',
-            headers: {
-                'Authorization': `Bearer ${accessToken}`
-            }
+            allowNotFound: true,
+            errorMessage: 'Download failed'
         });
 
-        if (response.status === 404) {
+        if (serverData === null) {
             // No data on server yet
             return null;
         }
-
-        if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}));
-            throw createApiError(response, errorData, `Download failed: ${response.status}`);
-        }
-
-        const serverData = await response.json();
 
         // Server returns: { success: true, data: { encryptedData, deviceId, timestamp, version } }
         const { data } = serverData || {};
@@ -6227,6 +6260,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             setSyncStatus: status => {
                 syncStatus = status;
             },
+            getSyncRequestContext,
             hashConfigData,
             getAutoSyncIntervalMs,
             isStartupSyncDue,
@@ -6849,8 +6883,7 @@ let GoalTargetStore;
                 return { valid: isValid, reason: isValid ? null : 'Invalid portfolio group format in OCBC payload' };
             },
             handle: data => {
-                const normalized = normalizeOcbcHoldingsPayload(data);
-                const nextByPortfolio = groupOcbcHoldingsByPortfolio(normalized);
+                const nextByPortfolio = buildOcbcHoldingsByPortfolioFromPayload(data);
                 const now = Date.now();
                 Object.keys(nextByPortfolio).forEach(portfolioNo => {
                     nextByPortfolio[portfolioNo].lastSeenAt = now;
@@ -17283,6 +17316,11 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             isOcbcPortfolioHoldingsRoute,
             getOverlayPlatformDescriptor: testingHooks?.getOverlayPlatformDescriptor,
             normalizeOcbcHoldingsPayload,
+            groupOcbcHoldingsByPortfolio,
+            flattenOcbcHoldingsByPortfolio,
+            normalizeOcbcHoldingsByPortfolioForStore,
+            mergeOcbcHoldingsByPortfolio,
+            buildOcbcHoldingsByPortfolioFromPayload,
             calculateFixedTargetPercent,
             calculateRemainingTargetPercent,
             isRemainingTargetAboveThreshold,
@@ -17353,6 +17391,7 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             createSequentialRequestQueue,
             SyncEncryption,
             SyncManager,
+            getSyncRequestContext: SyncManager.__test?.getSyncRequestContext,
             GoalTargetStore,
             createSyncSettingsHTML: syncUiExports?.createSyncSettingsHTML,
             setupSyncSettingsListeners: syncUiExports?.setupSyncSettingsListeners,

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Goal Portfolio Viewer
 // @namespace    https://github.com/laurenceputra/goal-portfolio-viewer
-// @version      2.15.0
+// @version      2.15.1
 // @description  View and organize your investment portfolio with a modern interface across Endowus, FSM, and OCBC holdings. Includes bucket analytics and optional cross-device sync for configuration.
 // @author       laurenceputra
 // @match        https://app.sg.endowus.com/*

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -126,6 +126,33 @@
         /^[a-zA-Z0-9_-]{3,50}$/
     ]);
     const SYNC_USER_ID_VALIDATION_MESSAGE = 'Invalid userId format. Use email or alphanumeric with underscores/hyphens (3-50 chars)';
+    const SYNC_ERROR_CODE_BY_STATUS = Object.freeze({
+        400: 'BAD_REQUEST',
+        401: 'UNAUTHORIZED',
+        403: 'FORBIDDEN',
+        404: 'NOT_FOUND',
+        409: 'CONFLICT',
+        413: 'PAYLOAD_TOO_LARGE',
+        429: 'RATE_LIMIT_EXCEEDED'
+    });
+    const SYNC_ERROR_CATEGORY_BY_CODE = Object.freeze({
+        RATE_LIMIT_EXCEEDED: 'rate_limit',
+        CONFLICT: 'conflict',
+        PAYLOAD_TOO_LARGE: 'payload',
+        BAD_REQUEST: 'bad_request',
+        SYNC_IN_PROGRESS: 'in_progress'
+    });
+    const SYNC_ERROR_GUIDANCE_BY_CATEGORY = Object.freeze({
+        auth: Object.freeze({ userMessage: 'Authentication failed. Please log in again to refresh your session.', primaryAction: 'Login again' }),
+        network: Object.freeze({ userMessage: 'Network issue detected. Check connection and retry sync.', primaryAction: 'Retry sync' }),
+        in_progress: Object.freeze({ userMessage: 'Sync already in progress. Please wait for it to finish before retrying.', primaryAction: 'Wait for sync' }),
+        crypto: Object.freeze({ userMessage: 'Sync is locked. Enter your password and save settings to unlock encryption key.', primaryAction: 'Unlock sync' }),
+        parse: Object.freeze({ userMessage: 'Unexpected server response. Retry and check sync server health if it persists.', primaryAction: 'Retry sync' }),
+        payload: Object.freeze({ userMessage: 'Sync payload is too large for the server limit. Reduce synced data and retry.', primaryAction: 'Review sync data' }),
+        bad_request: Object.freeze({ userMessage: 'Sync request was rejected. Check your sync settings and try again.', primaryAction: 'Review settings' }),
+        conflict: Object.freeze({ userMessage: 'Sync conflict detected. Review local and remote changes before continuing.', primaryAction: 'Resolve conflict' }),
+        server: Object.freeze({ userMessage: 'Sync server issue detected. Please retry in a moment.', primaryAction: 'Retry sync' })
+    });
     const FSM_HOLDING_ID_SEPARATOR = '|sub:';
 
     const utils = {
@@ -217,21 +244,14 @@
         }
     };
 
-    function normalizeSyncUserId(userId) {
-        return utils.normalizeString(userId, '');
-    }
-
     function isValidSyncUserId(userId) {
-        const normalizedUserId = normalizeSyncUserId(userId);
-        if (!normalizedUserId) {
-            return false;
-        }
-        return SYNC_USER_ID_PATTERNS.some(pattern => pattern.test(normalizedUserId));
+        const normalizedUserId = utils.normalizeString(userId, '');
+        return Boolean(normalizedUserId && SYNC_USER_ID_PATTERNS.some(pattern => pattern.test(normalizedUserId)));
     }
 
     function assertValidSyncUserId(userId) {
-        const normalizedUserId = normalizeSyncUserId(userId);
-        if (!isValidSyncUserId(normalizedUserId)) {
+        const normalizedUserId = utils.normalizeString(userId, '');
+        if (!normalizedUserId || !SYNC_USER_ID_PATTERNS.some(pattern => pattern.test(normalizedUserId))) {
             throw new Error(SYNC_USER_ID_VALIDATION_MESSAGE);
         }
         return normalizedUserId;
@@ -5236,21 +5256,10 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     function categorizeSyncError(error) {
         const message = String(error?.message || 'Unknown error');
         const code = String(error?.code || '').toUpperCase();
+        const mappedCategory = SYNC_ERROR_CATEGORY_BY_CODE[code];
 
-        if (code === 'RATE_LIMIT_EXCEEDED') {
-            return 'rate_limit';
-        }
-        if (code === 'CONFLICT') {
-            return 'conflict';
-        }
-        if (code === 'PAYLOAD_TOO_LARGE') {
-            return 'payload';
-        }
-        if (code === 'BAD_REQUEST') {
-            return 'bad_request';
-        }
-        if (code === 'SYNC_IN_PROGRESS') {
-            return 'in_progress';
+        if (mappedCategory) {
+            return mappedCategory;
         }
         if (code === 'UNAUTHORIZED' || code === 'FORBIDDEN' || code.includes('AUTH') || /unauthorized|forbidden|token|login/i.test(message)) {
             return 'auth';
@@ -5276,20 +5285,6 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     function getSyncErrorGuidance(error) {
         const category = categorizeSyncError(error);
         const retryAfter = Number(error?.retryAfterSeconds);
-        if (category === 'auth') {
-            return {
-                category,
-                userMessage: 'Authentication failed. Please log in again to refresh your session.',
-                primaryAction: 'Login again'
-            };
-        }
-        if (category === 'network') {
-            return {
-                category,
-                userMessage: 'Network issue detected. Check connection and retry sync.',
-                primaryAction: 'Retry sync'
-            };
-        }
         if (category === 'rate_limit') {
             return {
                 category,
@@ -5299,90 +5294,18 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 primaryAction: 'Retry later'
             };
         }
-        if (category === 'in_progress') {
-            return {
-                category,
-                userMessage: 'Sync already in progress. Please wait for it to finish before retrying.',
-                primaryAction: 'Wait for sync'
-            };
-        }
-        if (category === 'crypto') {
-            return {
-                category,
-                userMessage: 'Sync is locked. Enter your password and save settings to unlock encryption key.',
-                primaryAction: 'Unlock sync'
-            };
-        }
-        if (category === 'parse') {
-            return {
-                category,
-                userMessage: 'Unexpected server response. Retry and check sync server health if it persists.',
-                primaryAction: 'Retry sync'
-            };
-        }
-        if (category === 'payload') {
-            return {
-                category,
-                userMessage: 'Sync payload is too large for the server limit. Reduce synced data and retry.',
-                primaryAction: 'Review sync data'
-            };
-        }
-        if (category === 'bad_request') {
-            return {
-                category,
-                userMessage: 'Sync request was rejected. Check your sync settings and try again.',
-                primaryAction: 'Review settings'
-            };
-        }
-        if (category === 'conflict') {
-            return {
-                category,
-                userMessage: 'Sync conflict detected. Review local and remote changes before continuing.',
-                primaryAction: 'Resolve conflict'
-            };
-        }
+        const guidance = SYNC_ERROR_GUIDANCE_BY_CATEGORY[category] || SYNC_ERROR_GUIDANCE_BY_CATEGORY.server;
         return {
             category,
-            userMessage: 'Sync server issue detected. Please retry in a moment.',
-            primaryAction: 'Retry sync'
+            userMessage: guidance.userMessage,
+            primaryAction: guidance.primaryAction
         };
-    }
-
-    function getDefaultErrorCodeForStatus(status) {
-        const numericStatus = Number(status);
-        if (!Number.isFinite(numericStatus)) {
-            return null;
-        }
-        if (numericStatus === 400) {
-            return 'BAD_REQUEST';
-        }
-        if (numericStatus === 401) {
-            return 'UNAUTHORIZED';
-        }
-        if (numericStatus === 403) {
-            return 'FORBIDDEN';
-        }
-        if (numericStatus === 404) {
-            return 'NOT_FOUND';
-        }
-        if (numericStatus === 409) {
-            return 'CONFLICT';
-        }
-        if (numericStatus === 413) {
-            return 'PAYLOAD_TOO_LARGE';
-        }
-        if (numericStatus === 429) {
-            return 'RATE_LIMIT_EXCEEDED';
-        }
-        if (numericStatus >= 500) {
-            return 'INTERNAL_ERROR';
-        }
-        return null;
     }
 
     function createApiError(response, errorData, fallbackMessage) {
         const message = (errorData && (errorData.message || errorData.error)) || fallbackMessage;
         const error = new Error(message);
+        const responseStatus = Number(response?.status);
         if (response && typeof response.status === 'number') {
             error.status = response.status;
         }
@@ -5390,7 +5313,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             error.code = errorData.error;
         }
         if (!error.code) {
-            error.code = getDefaultErrorCodeForStatus(response?.status);
+            error.code = SYNC_ERROR_CODE_BY_STATUS[responseStatus] || (responseStatus >= 500 ? 'INTERNAL_ERROR' : null);
         }
         if (response?.parseError) {
             error.code = 'PARSE_ERROR';
@@ -5548,14 +5471,12 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function uploadConfig(config, options = {}) {
         const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
-        const userId = normalizeSyncUserId(Storage.get(SYNC_STORAGE_KEYS.userId, null));
+        const userId = utils.normalizeString(Storage.get(SYNC_STORAGE_KEYS.userId, null), '');
 
         if (!userId) {
             throw new Error('Sync not configured');
         }
-        if (!isValidSyncUserId(userId)) {
-            throw new Error(SYNC_USER_ID_VALIDATION_MESSAGE);
-        }
+        assertValidSyncUserId(userId);
 
         const masterKey = requireSessionKey();
 
@@ -5600,14 +5521,12 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function downloadConfig() {
         const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
-        const userId = normalizeSyncUserId(Storage.get(SYNC_STORAGE_KEYS.userId, null));
+        const userId = utils.normalizeString(Storage.get(SYNC_STORAGE_KEYS.userId, null), '');
 
         if (!userId) {
             throw new Error('Sync not configured');
         }
-        if (!isValidSyncUserId(userId)) {
-            throw new Error(SYNC_USER_ID_VALIDATION_MESSAGE);
-        }
+        assertValidSyncUserId(userId);
 
         const accessToken = await getAccessToken();
 
@@ -5725,32 +5644,34 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         }
     }
 
-    function markSyncing() {
-        syncStatus = SYNC_STATUS.syncing;
-        notifySyncUiUpdate();
-    }
-
-    function markSyncSuccess(logMessage) {
-        syncStatus = SYNC_STATUS.success;
-        lastError = null;
-        lastErrorMeta = null;
-        if (logMessage) {
-            logDebug(logMessage);
+    function setSyncState(status, {
+        logMessage = '',
+        error = null,
+        errorLogPrefix = '[Goal Portfolio Viewer] Sync failed:',
+        updateUi = false
+    } = {}) {
+        syncStatus = status;
+        if (status === SYNC_STATUS.success) {
+            lastError = null;
+            lastErrorMeta = null;
+            if (logMessage) {
+                logDebug(logMessage);
+            }
+        } else if (status === SYNC_STATUS.error && error) {
+            console.error(errorLogPrefix, error);
+            lastError = error.message;
+            const guidance = getSyncErrorGuidance(error);
+            lastErrorMeta = {
+                category: guidance.category,
+                userMessage: guidance.userMessage,
+                primaryAction: guidance.primaryAction,
+                retryAfterSeconds: Number(error?.retryAfterSeconds) || null,
+                lastAttemptAt: Date.now()
+            };
         }
-    }
-
-    function markSyncError(error, logMessage = '[Goal Portfolio Viewer] Sync failed:') {
-        console.error(logMessage, error);
-        syncStatus = SYNC_STATUS.error;
-        lastError = error.message;
-        const guidance = getSyncErrorGuidance(error);
-        lastErrorMeta = {
-            category: guidance.category,
-            userMessage: guidance.userMessage,
-            primaryAction: guidance.primaryAction,
-            retryAfterSeconds: Number(error?.retryAfterSeconds) || null,
-            lastAttemptAt: Date.now()
-        };
+        if (updateUi) {
+            notifySyncUiUpdate();
+        }
     }
 
     /**
@@ -5775,7 +5696,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
         requireSessionKey();
 
-        markSyncing();
+        setSyncState(SYNC_STATUS.syncing, { updateUi: true });
 
         try {
             const localConfig = collectConfigData();
@@ -5790,17 +5711,17 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             if (direction === 'upload') {
                 await uploadConfig(localConfig);
                 recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
-                markSyncSuccess('[Goal Portfolio Viewer] Sync upload successful');
+                setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Sync upload successful' });
             } else if (direction === 'download') {
                 const serverData = await downloadConfig();
                 if (!serverData) {
                     recordSuccessfulSync();
-                    markSyncSuccess('[Goal Portfolio Viewer] No server data to download');
+                    setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] No server data to download' });
                 } else {
                     applyConfigData(serverData.config);
                     const serverHash = await hashConfigData(serverData.config);
                     recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
-                    markSyncSuccess('[Goal Portfolio Viewer] Sync download successful');
+                    setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Sync download successful' });
                 }
             } else {
                 const serverData = await downloadConfig();
@@ -5808,20 +5729,20 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 if (!serverData) {
                     await uploadConfig(localConfig);
                     recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
-                    markSyncSuccess('[Goal Portfolio Viewer] No server data, uploaded local config');
+                    setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] No server data, uploaded local config' });
                 } else {
                     const serverHash = await hashConfigData(serverData.config);
 
                     if (!hasLastDataTimestamp) {
                         applyConfigData(serverData.config);
                         recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
-                        markSyncSuccess('[Goal Portfolio Viewer] Missing sync metadata, bootstrapped from server snapshot');
+                        setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Missing sync metadata, bootstrapped from server snapshot' });
                     } else if (localHash && serverHash && localHash === serverHash) {
                         recordSuccessfulSync({
                             dataTimestamp: Math.max(localConfig.timestamp, serverData.metadata.timestamp),
                             hash: localHash
                         });
-                        markSyncSuccess('[Goal Portfolio Viewer] Local and server content identical, sync already up to date');
+                        setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Local and server content identical, sync already up to date' });
                     } else {
                         const conflict = await detectConflict(localConfig, serverData, localHash, serverHash);
 
@@ -5836,14 +5757,14 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                         if (localConfig.timestamp > serverData.metadata.timestamp) {
                             await uploadConfig(localConfig);
                             recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
-                            markSyncSuccess('[Goal Portfolio Viewer] Local config newer, uploaded to server');
+                            setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Local config newer, uploaded to server' });
                         } else if (localConfig.timestamp < serverData.metadata.timestamp) {
                             applyConfigData(serverData.config);
                             recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
-                            markSyncSuccess('[Goal Portfolio Viewer] Server config newer, applied locally');
+                            setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Server config newer, applied locally' });
                         } else {
                             recordSuccessfulSync();
-                            markSyncSuccess('[Goal Portfolio Viewer] Sync already up to date');
+                            setSyncState(SYNC_STATUS.success, { logMessage: '[Goal Portfolio Viewer] Sync already up to date' });
                         }
                     }
                 }
@@ -5852,8 +5773,11 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             notifySyncUiUpdate();
             return { status: 'success' };
         } catch (error) {
-            markSyncError(error, '[Goal Portfolio Viewer] Sync failed:');
-            notifySyncUiUpdate();
+            setSyncState(SYNC_STATUS.error, {
+                error,
+                errorLogPrefix: '[Goal Portfolio Viewer] Sync failed:',
+                updateUi: true
+            });
             throw error;
         }
     }
@@ -5863,7 +5787,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function resolveConflict(resolution, conflict) {
         try {
-            markSyncing();
+            setSyncState(SYNC_STATUS.syncing, { updateUi: true });
 
             if (resolution === 'local') {
                 // Upload local, overwrite server
@@ -5902,16 +5826,18 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 throw new Error('Invalid resolution');
             }
 
-            markSyncSuccess();
-            notifySyncUiUpdate();
+            setSyncState(SYNC_STATUS.success, { updateUi: true });
             
             // Refresh the portfolio view
             if (typeof document !== 'undefined') {
                 document.dispatchEvent(new CustomEvent('gpv-show-portfolio'));
             }
         } catch (error) {
-            markSyncError(error, '[Goal Portfolio Viewer] Conflict resolution failed:');
-            notifySyncUiUpdate();
+            setSyncState(SYNC_STATUS.error, {
+                error,
+                errorLogPrefix: '[Goal Portfolio Viewer] Conflict resolution failed:',
+                updateUi: true
+            });
             throw error;
         }
     }
@@ -6091,7 +6017,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function enable(config) {
         const normalizedServerUrl = utils.normalizeServerUrl(config?.serverUrl);
-        const normalizedUserId = normalizeSyncUserId(config?.userId);
+        const normalizedUserId = utils.normalizeString(config?.userId, '');
         if (!config || !normalizedServerUrl || !normalizedUserId) {
             throw new Error('Invalid sync configuration: serverUrl and userId required');
         }
@@ -6146,7 +6072,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function register(serverUrl, userId, password) {
         const normalizedServerUrl = utils.normalizeServerUrl(serverUrl);
-        const normalizedUserId = normalizeSyncUserId(userId);
+        const normalizedUserId = utils.normalizeString(userId, '');
         if (!normalizedServerUrl || !normalizedUserId || !password) {
             throw new Error('serverUrl, userId, and password are required');
         }
@@ -6191,7 +6117,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function login(serverUrl, userId, password) {
         const normalizedServerUrl = utils.normalizeServerUrl(serverUrl);
-        const normalizedUserId = normalizeSyncUserId(userId);
+        const normalizedUserId = utils.normalizeString(userId, '');
         if (!normalizedServerUrl || !normalizedUserId || !password) {
             throw new Error('serverUrl, userId, and password are required');
         }
@@ -6528,49 +6454,39 @@ function buildOcbcConflictDiffItems(conflict) {
     const remoteOcbc = getOcbcSyncView(conflict.remote);
     const rows = [];
 
-    const localAllocationBuckets = formatOcbcAllocationBucketsDisplay(localOcbc.allocationBuckets);
-    const remoteAllocationBuckets = formatOcbcAllocationBucketsDisplay(remoteOcbc.allocationBuckets);
-    pushConflictDiffSectionRow(rows, {
-        section: 'definition',
-        settingName: 'Allocation Buckets',
-        localValue: localAllocationBuckets,
-        remoteValue: remoteAllocationBuckets
-    });
-
-    const localSubPortfolios = formatOcbcSubPortfoliosDisplay(localOcbc.subPortfolios);
-    const remoteSubPortfolios = formatOcbcSubPortfoliosDisplay(remoteOcbc.subPortfolios);
-    pushConflictDiffSectionRow(rows, {
-        section: 'definition',
-        settingName: 'Sub-portfolios',
-        localValue: localSubPortfolios,
-        remoteValue: remoteSubPortfolios
-    });
-
-    const localAssignmentByCode = formatOcbcAssignmentByCodeDisplay(localOcbc.assignmentByCode);
-    const remoteAssignmentByCode = formatOcbcAssignmentByCodeDisplay(remoteOcbc.assignmentByCode);
-    pushConflictDiffSectionRow(rows, {
-        section: 'assignment',
-        settingName: 'Code assignments',
-        localValue: localAssignmentByCode,
-        remoteValue: remoteAssignmentByCode
-    });
-
-    const localOrderByScope = formatOcbcOrderByScopeDisplay(localOcbc.orderByScope);
-    const remoteOrderByScope = formatOcbcOrderByScopeDisplay(remoteOcbc.orderByScope);
-    pushConflictDiffSectionRow(rows, {
-        section: 'assignment',
-        settingName: 'Display order',
-        localValue: localOrderByScope,
-        remoteValue: remoteOrderByScope
-    });
-
-    const localTargetsByScope = formatOcbcTargetsByScopeDisplay(localOcbc.targetsByScope);
-    const remoteTargetsByScope = formatOcbcTargetsByScopeDisplay(remoteOcbc.targetsByScope);
-    pushConflictDiffSectionRow(rows, {
-        section: 'target',
-        settingName: 'Allocation targets',
-        localValue: localTargetsByScope,
-        remoteValue: remoteTargetsByScope
+    [
+        {
+            section: 'definition',
+            settingName: 'Allocation Buckets',
+            localValue: formatOcbcAllocationBucketsDisplay(localOcbc.allocationBuckets),
+            remoteValue: formatOcbcAllocationBucketsDisplay(remoteOcbc.allocationBuckets)
+        },
+        {
+            section: 'definition',
+            settingName: 'Sub-portfolios',
+            localValue: formatOcbcSubPortfoliosDisplay(localOcbc.subPortfolios),
+            remoteValue: formatOcbcSubPortfoliosDisplay(remoteOcbc.subPortfolios)
+        },
+        {
+            section: 'assignment',
+            settingName: 'Code assignments',
+            localValue: formatOcbcAssignmentByCodeDisplay(localOcbc.assignmentByCode),
+            remoteValue: formatOcbcAssignmentByCodeDisplay(remoteOcbc.assignmentByCode)
+        },
+        {
+            section: 'assignment',
+            settingName: 'Display order',
+            localValue: formatOcbcOrderByScopeDisplay(localOcbc.orderByScope),
+            remoteValue: formatOcbcOrderByScopeDisplay(remoteOcbc.orderByScope)
+        },
+        {
+            section: 'target',
+            settingName: 'Allocation targets',
+            localValue: formatOcbcTargetsByScopeDisplay(localOcbc.targetsByScope),
+            remoteValue: formatOcbcTargetsByScopeDisplay(remoteOcbc.targetsByScope)
+        }
+    ].forEach(descriptor => {
+        pushConflictDiffSectionRow(rows, descriptor);
     });
 
     return rows;
@@ -6588,6 +6504,7 @@ function buildFsmConflictDiffItems(conflict, options = {}) {
         : buildFsmHoldingsNameMap(fsmHoldings || getFsmHoldingsFromStorage());
     const localPortfolioNameById = buildFsmPortfolioNameMap(localFsm.portfolios || []);
     const remotePortfolioNameById = buildFsmPortfolioNameMap(remoteFsm.portfolios || []);
+    const formatInstrumentStateDisplay = (target, fixed) => `Target ${formatSyncTarget(target)} · Fixed ${formatSyncFixed(fixed)}`;
 
     const rows = [];
     const codes = new Set([
@@ -6610,8 +6527,8 @@ function buildFsmConflictDiffItems(conflict, options = {}) {
         rows.push({
             section: 'instrument',
             settingName: `Instrument ${formatFsmInstrumentLabel(code, holdingsByCode)}`,
-            localDisplay: `Target ${formatSyncTarget(localTarget)} · Fixed ${formatSyncFixed(localFixed)}`,
-            remoteDisplay: `Target ${formatSyncTarget(remoteTarget)} · Fixed ${formatSyncFixed(remoteFixed)}`
+            localDisplay: formatInstrumentStateDisplay(localTarget, localFixed),
+            remoteDisplay: formatInstrumentStateDisplay(remoteTarget, remoteFixed)
         });
     });
 

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -1427,21 +1427,22 @@ function buildDiffCellData(currentAmount, targetPercent, adjustedTypeTotal) {
         };
     }
 
-    function buildGoalTypeAllocationContext({
+    function buildGoalTypeAllocationState({
         bucketName,
         goalType,
         group,
-        projectedInvestments,
+        projectedInvestmentsState,
         goalTargets,
         goalFixed
     }) {
         if (!group) {
             return null;
         }
-        const endingBalanceAmount = group.endingBalanceAmount || 0;
-        const projectedAmount = getProjectedInvestmentValue(projectedInvestments, bucketName, goalType);
-        const adjustedTotal = endingBalanceAmount + projectedAmount;
         const goals = Array.isArray(group.goals) ? group.goals : [];
+        const goalIds = goals.map(goal => goal?.goalId).filter(Boolean);
+        const endingBalanceAmount = group.endingBalanceAmount || 0;
+        const projectedAmount = getProjectedInvestmentValue(projectedInvestmentsState, bucketName, goalType);
+        const adjustedTotal = endingBalanceAmount + projectedAmount;
         const allocationModel = computeGoalTypeViewState(
             goals,
             endingBalanceAmount,
@@ -1450,11 +1451,46 @@ function buildDiffCellData(currentAmount, targetPercent, adjustedTypeTotal) {
             goalFixed
         );
         return {
+            group,
+            goals,
+            goalIds,
             endingBalanceAmount,
             projectedAmount,
             adjustedTotal,
             allocationModel
         };
+    }
+
+    function buildGoalTypeBaseViewModel({ goalType, group, allocationState }) {
+        const allocationModel = allocationState?.allocationModel || {};
+        const typeReturn = group.totalCumulativeReturn === null
+            ? null
+            : toFiniteNumber(group.totalCumulativeReturn, null);
+        return {
+            goalType,
+            displayName: getDisplayGoalType(goalType),
+            endingBalanceAmount: allocationState?.endingBalanceAmount || 0,
+            endingBalanceDisplay: formatMoney(group.endingBalanceAmount),
+            totalReturn: typeReturn,
+            returnDisplay: formatMoney(typeReturn),
+            growthDisplay: formatGrowthPercentFromEndingBalance(
+                typeReturn,
+                group.endingBalanceAmount
+            ),
+            returnClass: getReturnClass(typeReturn),
+            projectedAmount: allocationState?.projectedAmount || 0,
+            adjustedTotal: allocationState?.adjustedTotal || 0,
+            allocationDriftDisplay: allocationModel.allocationDriftDisplay,
+            allocationDriftClass: allocationModel.allocationDriftClass,
+            allocationDriftAvailable: allocationModel.allocationDriftAvailable,
+            goals: Array.isArray(allocationModel.goalModels)
+                ? allocationModel.goalModels.map(goal => buildBucketDetailGoalRow(goal))
+                : []
+        };
+    }
+
+    function buildSummaryGoalTypeModel({ goalType, group, allocationState }) {
+        return buildGoalTypeBaseViewModel({ goalType, group, allocationState });
     }
 
     function buildBucketHealth(goalTypeModels) {
@@ -1465,86 +1501,105 @@ function buildDiffCellData(currentAmount, targetPercent, adjustedTypeTotal) {
         });
     }
 
-    function buildSummaryViewModel(bucketMap, projectedInvestmentsState, goalTargetById, goalFixedById) {
-        if (!bucketMap || typeof bucketMap !== 'object') {
-            return { buckets: [], showAllocationDriftHint: false, attentionItems: [] };
+    function buildBucketGoalTypeModels({
+        bucketName,
+        bucketObj,
+        projectedInvestmentsState,
+        goalTargetById,
+        goalFixedById,
+        buildGoalTypeModel
+    }) {
+        if (!bucketObj || typeof bucketObj !== 'object' || typeof buildGoalTypeModel !== 'function') {
+            return { goalTypeModels: [], showAllocationDriftHint: false };
         }
         const projectedInvestments = projectedInvestmentsState || {};
         const goalTargets = goalTargetById || {};
         const goalFixed = goalFixedById || {};
         let showAllocationDriftHint = false;
-        const buckets = Object.keys(bucketMap)
-            .sort()
-            .map(bucketName => {
-                const bucketObj = bucketMap[bucketName];
-                const base = buildBucketBase(bucketName, bucketObj);
-                if (!base) {
+        const orderedTypes = sortGoalTypes(Object.keys(bucketObj).filter(key => key !== '_meta'));
+        const goalTypeModels = orderedTypes
+            .map(goalType => {
+                const group = bucketObj[goalType];
+                const allocationState = buildGoalTypeAllocationState({
+                    bucketName,
+                    goalType,
+                    group,
+                    projectedInvestmentsState: projectedInvestments,
+                    goalTargets,
+                    goalFixed
+                });
+                if (!allocationState) {
                     return null;
                 }
-                const { orderedTypes, bucketTotalReturn, endingBalanceTotal } = base;
-                const goalTypeModels = orderedTypes
-                    .map(goalType => {
-                        const group = base.bucketObj[goalType];
-                        const allocationContext = buildGoalTypeAllocationContext({
-                            bucketName,
-                            goalType,
-                            group,
-                            projectedInvestments,
-                            goalTargets,
-                            goalFixed
-                        });
-                        if (!allocationContext) {
-                            return null;
-                        }
-                        const {
-                            endingBalanceAmount,
-                            projectedAmount,
-                            adjustedTotal,
-                            allocationModel
-                        } = allocationContext;
-                        const typeReturn = group.totalCumulativeReturn === null
-                            ? null
-                            : toFiniteNumber(group.totalCumulativeReturn, null);
-                        if (allocationModel.allocationDriftAvailable === false) {
-                            showAllocationDriftHint = true;
-                        }
-                        return enrichGoalTypeWithPlanning({
-                            goalType,
-                            displayName: getDisplayGoalType(goalType),
-                            endingBalanceAmount,
-                            endingBalanceDisplay: formatMoney(group.endingBalanceAmount),
-                            totalReturn: typeReturn,
-                            returnDisplay: formatMoney(typeReturn),
-                            growthDisplay: formatGrowthPercentFromEndingBalance(
-                                typeReturn,
-                                group.endingBalanceAmount
-                            ),
-                            returnClass: getReturnClass(typeReturn),
-                            allocationDriftDisplay: allocationModel.allocationDriftDisplay,
-                            allocationDriftClass: allocationModel.allocationDriftClass,
-                            allocationDriftAvailable: allocationModel.allocationDriftAvailable,
-                            goals: allocationModel.goalModels.map(goal => buildBucketDetailGoalRow(goal)),
-                            adjustedTotal,
-                            projectedAmount
-                        });
-                    })
-                    .filter(Boolean);
-                return {
-                    bucketName,
-                    endingBalanceAmount: endingBalanceTotal,
-                    totalReturn: bucketTotalReturn,
-                    endingBalanceDisplay: formatMoney(endingBalanceTotal),
-                    returnDisplay: formatMoney(bucketTotalReturn),
-                    growthDisplay: formatGrowthPercentFromEndingBalance(
-                        bucketTotalReturn,
-                        endingBalanceTotal
-                    ),
-                    returnClass: getReturnClass(bucketTotalReturn),
-                    goalTypes: goalTypeModels,
-                    health: buildBucketHealth(goalTypeModels)
-                };
+                if (allocationState.allocationModel.allocationDriftAvailable === false) {
+                    showAllocationDriftHint = true;
+                }
+                return enrichGoalTypeWithPlanning(buildGoalTypeModel({
+                    goalType,
+                    group,
+                    allocationState
+                }));
             })
             .filter(Boolean);
+        return {
+            goalTypeModels,
+            showAllocationDriftHint
+        };
+    }
+
+    function buildBucketViewModel({
+        bucketName,
+        bucketObj,
+        projectedInvestmentsState,
+        goalTargetById,
+        goalFixedById,
+        buildGoalTypeModel
+    }) {
+        const base = buildBucketBase(bucketName, bucketObj);
+        if (!base) {
+            return null;
+        }
+        const { goalTypeModels, showAllocationDriftHint } = buildBucketGoalTypeModels({
+            bucketName,
+            bucketObj: base.bucketObj,
+            projectedInvestmentsState,
+            goalTargetById,
+            goalFixedById,
+            buildGoalTypeModel
+        });
+        return {
+            bucketName,
+            endingBalanceAmount: base.endingBalanceTotal,
+            totalReturn: base.bucketTotalReturn,
+            endingBalanceDisplay: formatMoney(base.endingBalanceTotal),
+            returnDisplay: formatMoney(base.bucketTotalReturn),
+            growthDisplay: formatGrowthPercentFromEndingBalance(
+                base.bucketTotalReturn,
+                base.endingBalanceTotal
+            ),
+            returnClass: getReturnClass(base.bucketTotalReturn),
+            goalTypes: goalTypeModels,
+            showAllocationDriftHint,
+            health: buildBucketHealth(goalTypeModels)
+        };
+    }
+
+    function buildSummaryViewModel(bucketMap, projectedInvestmentsState, goalTargetById, goalFixedById) {
+        if (!bucketMap || typeof bucketMap !== 'object') {
+            return { buckets: [], showAllocationDriftHint: false, attentionItems: [] };
+        }
+        const buckets = Object.keys(bucketMap)
+            .sort()
+            .map(bucketName => buildBucketViewModel({
+                bucketName,
+                bucketObj: bucketMap[bucketName],
+                projectedInvestmentsState,
+                goalTargetById,
+                goalFixedById,
+                buildGoalTypeModel: buildSummaryGoalTypeModel
+            }))
+            .filter(Boolean);
+        const showAllocationDriftHint = buckets.some(bucket => bucket.showAllocationDriftHint === true);
         return {
             buckets,
             showAllocationDriftHint,
@@ -1567,83 +1622,25 @@ function buildBucketDetailViewModel({
         if (!base) {
             return null;
         }
-        const projectedInvestments = projectedInvestmentsState || {};
-        const goalTargets = goalTargetById || {};
-        const goalFixed = goalFixedById || {};
-        const { orderedTypes, bucketTotalReturn, endingBalanceTotal } = base;
-        let showAllocationDriftHint = false;
-
-    const goalTypeModels = orderedTypes
-        .map(goalType => {
-            const group = base.bucketObj[goalType];
-            const allocationContext = buildGoalTypeAllocationContext({
-                bucketName,
-                goalType,
-                group,
-                projectedInvestments,
-                goalTargets,
-                goalFixed
-            });
-            if (!allocationContext) {
-                return null;
-            }
-            const { projectedAmount, allocationModel } = allocationContext;
-            if (allocationModel.allocationDriftAvailable === false) {
-                showAllocationDriftHint = true;
-            }
-            return enrichGoalTypeWithPlanning(buildBucketDetailGoalTypeModel({
-                goalType,
-                group,
-                projectedAmount,
-                allocationModel
-            }));
-        })
-        .filter(Boolean);
-
-    return {
-        bucketName,
-        endingBalanceAmount: endingBalanceTotal,
-        totalReturn: bucketTotalReturn,
-        endingBalanceDisplay: formatMoney(endingBalanceTotal),
-        returnDisplay: formatMoney(bucketTotalReturn),
-        growthDisplay: formatGrowthPercentFromEndingBalance(
-            bucketTotalReturn,
-            endingBalanceTotal
-        ),
-        returnClass: getReturnClass(bucketTotalReturn),
-        goalTypes: goalTypeModels,
-        showAllocationDriftHint,
-        health: buildBucketHealth(goalTypeModels)
-    };
+        return buildBucketViewModel({
+            bucketName,
+            bucketObj: base.bucketObj,
+            projectedInvestmentsState,
+            goalTargetById,
+            goalFixedById,
+            buildGoalTypeModel: buildBucketDetailGoalTypeModel
+        });
 }
 
-function buildBucketDetailGoalTypeModel({ goalType, group, projectedAmount, allocationModel }) {
-    const typeReturn = group.totalCumulativeReturn === null
-        ? null
-        : toFiniteNumber(group.totalCumulativeReturn, null);
-    const endingBalanceAmount = group.endingBalanceAmount || 0;
+function buildBucketDetailGoalTypeModel({ goalType, group, allocationState }) {
+    const allocationModel = allocationState?.allocationModel || {};
+    const baseModel = buildGoalTypeBaseViewModel({ goalType, group, allocationState });
     return {
-        goalType,
-        displayName: getDisplayGoalType(goalType),
-        endingBalanceAmount,
-        endingBalanceDisplay: formatMoney(group.endingBalanceAmount),
-        totalReturn: typeReturn,
-        returnDisplay: formatMoney(typeReturn),
-        growthDisplay: formatGrowthPercentFromEndingBalance(
-            typeReturn,
-            group.endingBalanceAmount
-        ),
-        returnClass: getReturnClass(typeReturn),
-        projectedAmount,
-        adjustedTotal: endingBalanceAmount + projectedAmount,
+        ...baseModel,
         remainingTargetPercent: allocationModel.remainingTargetPercent,
         remainingTargetDisplay: formatPercent(allocationModel.remainingTargetPercent),
         remainingTargetIsHigh: isRemainingTargetAboveThreshold(allocationModel.remainingTargetPercent),
-        allocationDriftDisplay: allocationModel.allocationDriftDisplay,
-        allocationDriftClass: allocationModel.allocationDriftClass,
-        allocationDriftAvailable: allocationModel.allocationDriftAvailable,
-        goalModelsById: allocationModel.goalModelsById,
-        goals: allocationModel.goalModels.map(goal => buildBucketDetailGoalRow(goal))
+        goalModelsById: allocationModel.goalModelsById || {}
     };
 }
 
@@ -2239,6 +2236,30 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             getFixedFn,
             value => value === true
         );
+    }
+
+    function loadGoalAllocationConfig(goalIds, {
+        getTarget = GoalTargetStore.getTarget,
+        getFixed = GoalTargetStore.getFixed
+    } = {}) {
+        const normalizedGoalIds = Array.from(new Set(
+            (Array.isArray(goalIds) ? goalIds : [])
+                .map(goalId => utils.normalizeString(goalId, ''))
+                .filter(Boolean)
+        ));
+        return {
+            goalIds: normalizedGoalIds,
+            goalTargetById: buildGoalTargetById(normalizedGoalIds, getTarget),
+            goalFixedById: buildGoalFixedById(normalizedGoalIds, getFixed)
+        };
+    }
+
+    function loadBucketAllocationConfig(bucketObj, getters = {}) {
+        return loadGoalAllocationConfig(collectGoalIds(bucketObj), getters);
+    }
+
+    function loadAllBucketAllocationConfig(bucketMap, getters = {}) {
+        return loadGoalAllocationConfig(collectAllGoalIds(bucketMap), getters);
     }
 
 
@@ -9446,20 +9467,17 @@ let GoalTargetStore;
         if (!group) {
             return null;
         }
-        const goals = Array.isArray(group.goals) ? group.goals : [];
-        const goalIds = goals.map(goal => goal.goalId).filter(Boolean);
-        const goalTargets = buildGoalTargetById(goalIds, GoalTargetStore.getTarget);
-        const goalFixed = buildGoalFixedById(goalIds, GoalTargetStore.getFixed);
-        const totalTypeAmount = group.endingBalanceAmount || 0;
-        const projectedAmount = getProjectedInvestmentValue(projectedInvestmentsState, bucket, goalType);
-        const adjustedTotal = totalTypeAmount + projectedAmount;
-        return computeGoalTypeViewState(
-            goals,
-            totalTypeAmount,
-            adjustedTotal,
-            goalTargets,
-            goalFixed
+        const { goalTargetById, goalFixedById } = loadGoalAllocationConfig(
+            Array.isArray(group.goals) ? group.goals.map(goal => goal?.goalId).filter(Boolean) : []
         );
+        return buildGoalTypeAllocationState({
+            bucketName: bucket,
+            goalType,
+            group,
+            projectedInvestmentsState,
+            goalTargets: goalTargetById,
+            goalFixed: goalFixedById
+        })?.allocationModel || null;
     }
 
     function refreshGoalTypeSection({
@@ -9536,8 +9554,7 @@ let GoalTargetStore;
             bucketName: bucket,
             bucketMap: mergedInvestmentDataState,
             projectedInvestmentsState,
-            goalTargetById: buildGoalTargetById(collectGoalIds(mergedInvestmentDataState?.[bucket]), GoalTargetStore.getTarget),
-            goalFixedById: buildGoalFixedById(collectGoalIds(mergedInvestmentDataState?.[bucket]), GoalTargetStore.getFixed)
+            ...loadBucketAllocationConfig(mergedInvestmentDataState?.[bucket])
         });
         if (!bucketViewModel) {
             return;
@@ -13735,9 +13752,7 @@ syncUi.update = function updateSyncUI() {
             return null;
         }
         if (selection === 'SUMMARY') {
-            const goalIds = collectAllGoalIds(mergedInvestmentDataState);
-            const goalTargetById = buildGoalTargetById(goalIds, GoalTargetStore.getTarget);
-            const goalFixedById = buildGoalFixedById(goalIds, GoalTargetStore.getFixed);
+            const { goalTargetById, goalFixedById } = loadAllBucketAllocationConfig(mergedInvestmentDataState);
             return {
                 kind: 'SUMMARY',
                 viewModel: buildSummaryViewModel(
@@ -13752,9 +13767,7 @@ syncUi.update = function updateSyncUI() {
         if (!bucketObj) {
             return null;
         }
-        const goalIds = collectGoalIds(bucketObj);
-        const goalTargetById = buildGoalTargetById(goalIds, GoalTargetStore.getTarget);
-        const goalFixedById = buildGoalFixedById(goalIds, GoalTargetStore.getFixed);
+        const { goalTargetById, goalFixedById } = loadBucketAllocationConfig(bucketObj);
         const viewModel = buildBucketDetailViewModel({
             bucketName: selection,
             bucketMap: mergedInvestmentDataState,
@@ -17293,6 +17306,9 @@ function createReadinessView({ title, description, items, tone = 'pending' }) {
             collectAllGoalIds,
             buildGoalTargetById,
             buildGoalFixedById,
+            loadGoalAllocationConfig,
+            loadBucketAllocationConfig,
+            loadAllBucketAllocationConfig,
             getBucketViewModePreference,
             setBucketViewModePreference,
             getCollapseState,

--- a/tampermonkey/goal_portfolio_viewer.user.js
+++ b/tampermonkey/goal_portfolio_viewer.user.js
@@ -121,6 +121,11 @@
     };
     const SYNC_METADATA_VERSION = 2;
     const SYNC_REQUEST_TIMEOUT_MS = 15000;
+    const SYNC_USER_ID_PATTERNS = Object.freeze([
+        /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+        /^[a-zA-Z0-9_-]{3,50}$/
+    ]);
+    const SYNC_USER_ID_VALIDATION_MESSAGE = 'Invalid userId format. Use email or alphanumeric with underscores/hyphens (3-50 chars)';
     const FSM_HOLDING_ID_SEPARATOR = '|sub:';
 
     const utils = {
@@ -211,6 +216,26 @@
             return bucket || 'Uncategorized';
         }
     };
+
+    function normalizeSyncUserId(userId) {
+        return utils.normalizeString(userId, '');
+    }
+
+    function isValidSyncUserId(userId) {
+        const normalizedUserId = normalizeSyncUserId(userId);
+        if (!normalizedUserId) {
+            return false;
+        }
+        return SYNC_USER_ID_PATTERNS.some(pattern => pattern.test(normalizedUserId));
+    }
+
+    function assertValidSyncUserId(userId) {
+        const normalizedUserId = normalizeSyncUserId(userId);
+        if (!isValidSyncUserId(normalizedUserId)) {
+            throw new Error(SYNC_USER_ID_VALIDATION_MESSAGE);
+        }
+        return normalizedUserId;
+    }
 
     function getFsmHoldingIdentity(rowOrCode, maybeSubcode) {
         const isRow = rowOrCode && typeof rowOrCode === 'object';
@@ -4150,51 +4175,77 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         };
     }
 
-    // Precedence rule: when both exist, v4 namespaced values win; flat legacy keys only fill gaps.
-    function readEndowusStore() {
-        const legacyKeys = listLegacyPlatformKeys(LEGACY_PLATFORM_STORAGE_KEYS.endowus);
-        const rawStored = Storage.readJson(STORAGE_KEYS.endowus, data => data && typeof data === 'object' && !Array.isArray(data));
-        const normalized = rawStored ? normalizeEndowusStore(rawStored) : normalizeEndowusStore({});
-        const migrated = mergeMissingEndowusLegacyData(normalized);
-        const { value: cleanedNormalized, didMutate } = cleanupEndowusLocalStore(migrated.store);
-        const shouldWrite = !rawStored || didMutate || migrated.didMerge || legacyKeys.length > 0 || rawStored.version !== PLATFORM_STORE_VERSION;
+    function readPlatformStore({
+        storageKey,
+        normalizeStore,
+        legacyStorageKeys,
+        mergeLegacyData,
+        finalizeStore,
+        existingWriteContext,
+        initialWriteContext
+    }) {
+        const legacyKeys = listLegacyPlatformKeys(legacyStorageKeys);
+        const rawStored = Storage.readJson(storageKey, data => data && typeof data === 'object' && !Array.isArray(data));
+        const normalized = rawStored ? normalizeStore(rawStored) : normalizeStore({});
+        const migrated = typeof mergeLegacyData === 'function'
+            ? mergeLegacyData(normalized)
+            : { store: normalized, didMerge: false };
+        const finalized = typeof finalizeStore === 'function'
+            ? finalizeStore(migrated.store)
+            : { value: migrated.store, didMutate: false };
+        const nextStore = normalizeStore(finalized?.value || migrated.store);
+        const didMutate = finalized?.didMutate === true;
+        const shouldWrite = !rawStored
+            || didMutate
+            || migrated.didMerge
+            || legacyKeys.length > 0
+            || rawStored.version !== PLATFORM_STORE_VERSION;
         if (shouldWrite) {
-            const didWrite = writePlatformStore(STORAGE_KEYS.endowus, cleanedNormalized, rawStored ? 'Error writing cleaned Endowus store' : 'Error writing Endowus store');
+            const didWrite = writePlatformStore(
+                storageKey,
+                nextStore,
+                rawStored ? existingWriteContext : initialWriteContext
+            );
             if (didWrite) {
                 removeLegacyPlatformKeys(legacyKeys);
             }
         }
-        return cleanedNormalized;
+        return nextStore;
+    }
+
+    // Precedence rule: when both exist, v4 namespaced values win; flat legacy keys only fill gaps.
+    function readEndowusStore() {
+        return readPlatformStore({
+            storageKey: STORAGE_KEYS.endowus,
+            normalizeStore: normalizeEndowusStore,
+            legacyStorageKeys: LEGACY_PLATFORM_STORAGE_KEYS.endowus,
+            mergeLegacyData: mergeMissingEndowusLegacyData,
+            finalizeStore: cleanupEndowusLocalStore,
+            existingWriteContext: 'Error writing cleaned Endowus store',
+            initialWriteContext: 'Error writing Endowus store'
+        });
     }
 
     function readFsmStore() {
-        const legacyKeys = listLegacyPlatformKeys(LEGACY_PLATFORM_STORAGE_KEYS.fsm);
-        const rawStored = Storage.readJson(STORAGE_KEYS.fsm, data => data && typeof data === 'object' && !Array.isArray(data));
-        const normalized = rawStored ? normalizeFsmStore(rawStored) : normalizeFsmStore({});
-        const migrated = mergeMissingFsmLegacyData(normalized);
-        const shouldWrite = !rawStored || migrated.didMerge || legacyKeys.length > 0 || rawStored.version !== PLATFORM_STORE_VERSION;
-        if (shouldWrite) {
-            const didWrite = writePlatformStore(STORAGE_KEYS.fsm, migrated.store, rawStored ? 'Error writing migrated FSM v4 store' : 'Error writing FSM store');
-            if (didWrite) {
-                removeLegacyPlatformKeys(legacyKeys);
-            }
-        }
-        return migrated.store;
+        return readPlatformStore({
+            storageKey: STORAGE_KEYS.fsm,
+            normalizeStore: normalizeFsmStore,
+            legacyStorageKeys: LEGACY_PLATFORM_STORAGE_KEYS.fsm,
+            mergeLegacyData: mergeMissingFsmLegacyData,
+            existingWriteContext: 'Error writing migrated FSM v4 store',
+            initialWriteContext: 'Error writing FSM store'
+        });
     }
 
     function readOcbcStore() {
-        const legacyKeys = listLegacyPlatformKeys(LEGACY_PLATFORM_STORAGE_KEYS.ocbc);
-        const rawStored = Storage.readJson(STORAGE_KEYS.ocbc, data => data && typeof data === 'object' && !Array.isArray(data));
-        const normalized = rawStored ? normalizeOcbcStore(rawStored) : normalizeOcbcStore({});
-        const migrated = mergeMissingOcbcLegacyData(normalized);
-        const shouldWrite = !rawStored || migrated.didMerge || legacyKeys.length > 0 || rawStored.version !== PLATFORM_STORE_VERSION;
-        if (shouldWrite) {
-            const didWrite = writePlatformStore(STORAGE_KEYS.ocbc, migrated.store, rawStored ? 'Error writing migrated OCBC v4 store' : 'Error writing OCBC store');
-            if (didWrite) {
-                removeLegacyPlatformKeys(legacyKeys);
-            }
-        }
-        return migrated.store;
+        return readPlatformStore({
+            storageKey: STORAGE_KEYS.ocbc,
+            normalizeStore: normalizeOcbcStore,
+            legacyStorageKeys: LEGACY_PLATFORM_STORAGE_KEYS.ocbc,
+            mergeLegacyData: mergeMissingOcbcLegacyData,
+            existingWriteContext: 'Error writing migrated OCBC v4 store',
+            initialWriteContext: 'Error writing OCBC store'
+        });
     }
 
     function updatePlatformStore({ readStore, normalizeStore, storageKey, updater, context }) {
@@ -4864,7 +4915,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
     function isConfigured() {
         const serverUrl = getStoredServerUrl('', { enforceAllowed: false });
         const userId = Storage.get(SYNC_STORAGE_KEYS.userId, null);
-        return Boolean(serverUrl && utils.isAllowedSyncServerUrl(serverUrl) && userId && hasValidRefreshToken());
+        return Boolean(serverUrl && utils.isAllowedSyncServerUrl(serverUrl) && isValidSyncUserId(userId) && hasValidRefreshToken());
     }
 
     /**
@@ -5189,10 +5240,19 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         if (code === 'RATE_LIMIT_EXCEEDED') {
             return 'rate_limit';
         }
+        if (code === 'CONFLICT') {
+            return 'conflict';
+        }
+        if (code === 'PAYLOAD_TOO_LARGE') {
+            return 'payload';
+        }
+        if (code === 'BAD_REQUEST') {
+            return 'bad_request';
+        }
         if (code === 'SYNC_IN_PROGRESS') {
             return 'in_progress';
         }
-        if (code.includes('AUTH') || /unauthorized|forbidden|token|login/i.test(message)) {
+        if (code === 'UNAUTHORIZED' || code === 'FORBIDDEN' || code.includes('AUTH') || /unauthorized|forbidden|token|login/i.test(message)) {
             return 'auth';
         }
         if (code.includes('TIMEOUT') || /timeout/i.test(message)) {
@@ -5260,6 +5320,27 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 primaryAction: 'Retry sync'
             };
         }
+        if (category === 'payload') {
+            return {
+                category,
+                userMessage: 'Sync payload is too large for the server limit. Reduce synced data and retry.',
+                primaryAction: 'Review sync data'
+            };
+        }
+        if (category === 'bad_request') {
+            return {
+                category,
+                userMessage: 'Sync request was rejected. Check your sync settings and try again.',
+                primaryAction: 'Review settings'
+            };
+        }
+        if (category === 'conflict') {
+            return {
+                category,
+                userMessage: 'Sync conflict detected. Review local and remote changes before continuing.',
+                primaryAction: 'Resolve conflict'
+            };
+        }
         return {
             category,
             userMessage: 'Sync server issue detected. Please retry in a moment.',
@@ -5267,20 +5348,55 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         };
     }
 
+    function getDefaultErrorCodeForStatus(status) {
+        const numericStatus = Number(status);
+        if (!Number.isFinite(numericStatus)) {
+            return null;
+        }
+        if (numericStatus === 400) {
+            return 'BAD_REQUEST';
+        }
+        if (numericStatus === 401) {
+            return 'UNAUTHORIZED';
+        }
+        if (numericStatus === 403) {
+            return 'FORBIDDEN';
+        }
+        if (numericStatus === 404) {
+            return 'NOT_FOUND';
+        }
+        if (numericStatus === 409) {
+            return 'CONFLICT';
+        }
+        if (numericStatus === 413) {
+            return 'PAYLOAD_TOO_LARGE';
+        }
+        if (numericStatus === 429) {
+            return 'RATE_LIMIT_EXCEEDED';
+        }
+        if (numericStatus >= 500) {
+            return 'INTERNAL_ERROR';
+        }
+        return null;
+    }
+
     function createApiError(response, errorData, fallbackMessage) {
         const message = (errorData && (errorData.message || errorData.error)) || fallbackMessage;
         const error = new Error(message);
+        if (response && typeof response.status === 'number') {
+            error.status = response.status;
+        }
         if (errorData && errorData.error) {
             error.code = errorData.error;
+        }
+        if (!error.code) {
+            error.code = getDefaultErrorCodeForStatus(response?.status);
         }
         if (response?.parseError) {
             error.code = 'PARSE_ERROR';
             if (typeof response.rawText === 'string') {
                 error.rawResponse = response.rawText.slice(0, 500);
             }
-        }
-        if (response && response.status === 429) {
-            error.code = 'RATE_LIMIT_EXCEEDED';
         }
         const retryAfterHeader = response?.headers?.get('Retry-After');
         const retryAfterSeconds = Number(errorData?.retryAfter || retryAfterHeader);
@@ -5432,10 +5548,13 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function uploadConfig(config, options = {}) {
         const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
-        const userId = Storage.get(SYNC_STORAGE_KEYS.userId, null);
+        const userId = normalizeSyncUserId(Storage.get(SYNC_STORAGE_KEYS.userId, null));
 
         if (!userId) {
             throw new Error('Sync not configured');
+        }
+        if (!isValidSyncUserId(userId)) {
+            throw new Error(SYNC_USER_ID_VALIDATION_MESSAGE);
         }
 
         const masterKey = requireSessionKey();
@@ -5481,10 +5600,13 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function downloadConfig() {
         const serverUrl = getStoredServerUrl(SYNC_DEFAULTS.serverUrl);
-        const userId = Storage.get(SYNC_STORAGE_KEYS.userId, null);
+        const userId = normalizeSyncUserId(Storage.get(SYNC_STORAGE_KEYS.userId, null));
 
         if (!userId) {
             throw new Error('Sync not configured');
+        }
+        if (!isValidSyncUserId(userId)) {
+            throw new Error(SYNC_USER_ID_VALIDATION_MESSAGE);
         }
 
         const accessToken = await getAccessToken();
@@ -5597,6 +5719,40 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         }
     }
 
+    function notifySyncUiUpdate() {
+        if (typeof syncUi.update === 'function') {
+            syncUi.update();
+        }
+    }
+
+    function markSyncing() {
+        syncStatus = SYNC_STATUS.syncing;
+        notifySyncUiUpdate();
+    }
+
+    function markSyncSuccess(logMessage) {
+        syncStatus = SYNC_STATUS.success;
+        lastError = null;
+        lastErrorMeta = null;
+        if (logMessage) {
+            logDebug(logMessage);
+        }
+    }
+
+    function markSyncError(error, logMessage = '[Goal Portfolio Viewer] Sync failed:') {
+        console.error(logMessage, error);
+        syncStatus = SYNC_STATUS.error;
+        lastError = error.message;
+        const guidance = getSyncErrorGuidance(error);
+        lastErrorMeta = {
+            category: guidance.category,
+            userMessage: guidance.userMessage,
+            primaryAction: guidance.primaryAction,
+            retryAfterSeconds: Number(error?.retryAfterSeconds) || null,
+            lastAttemptAt: Date.now()
+        };
+    }
+
     /**
      * Perform sync operation
      */
@@ -5619,10 +5775,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
         requireSessionKey();
 
-        syncStatus = SYNC_STATUS.syncing;
-        if (typeof syncUi.update === 'function') {
-            syncUi.update();
-        }
+        markSyncing();
 
         try {
             const localConfig = collectConfigData();
@@ -5637,28 +5790,17 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
             if (direction === 'upload') {
                 await uploadConfig(localConfig);
                 recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
-
-                syncStatus = SYNC_STATUS.success;
-                lastError = null;
-                lastErrorMeta = null;
-                logDebug('[Goal Portfolio Viewer] Sync upload successful');
+                markSyncSuccess('[Goal Portfolio Viewer] Sync upload successful');
             } else if (direction === 'download') {
                 const serverData = await downloadConfig();
                 if (!serverData) {
                     recordSuccessfulSync();
-                    syncStatus = SYNC_STATUS.success;
-                    lastError = null;
-                    lastErrorMeta = null;
-                    logDebug('[Goal Portfolio Viewer] No server data to download');
+                    markSyncSuccess('[Goal Portfolio Viewer] No server data to download');
                 } else {
                     applyConfigData(serverData.config);
                     const serverHash = await hashConfigData(serverData.config);
                     recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
-
-                    syncStatus = SYNC_STATUS.success;
-                    lastError = null;
-                    lastErrorMeta = null;
-                    logDebug('[Goal Portfolio Viewer] Sync download successful');
+                    markSyncSuccess('[Goal Portfolio Viewer] Sync download successful');
                 }
             } else {
                 const serverData = await downloadConfig();
@@ -5666,32 +5808,20 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 if (!serverData) {
                     await uploadConfig(localConfig);
                     recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
-
-                    syncStatus = SYNC_STATUS.success;
-                    lastError = null;
-                    lastErrorMeta = null;
-                    logDebug('[Goal Portfolio Viewer] No server data, uploaded local config');
+                    markSyncSuccess('[Goal Portfolio Viewer] No server data, uploaded local config');
                 } else {
                     const serverHash = await hashConfigData(serverData.config);
 
                     if (!hasLastDataTimestamp) {
                         applyConfigData(serverData.config);
                         recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
-
-                        syncStatus = SYNC_STATUS.success;
-                        lastError = null;
-                        lastErrorMeta = null;
-                        logDebug('[Goal Portfolio Viewer] Missing sync metadata, bootstrapped from server snapshot');
+                        markSyncSuccess('[Goal Portfolio Viewer] Missing sync metadata, bootstrapped from server snapshot');
                     } else if (localHash && serverHash && localHash === serverHash) {
                         recordSuccessfulSync({
                             dataTimestamp: Math.max(localConfig.timestamp, serverData.metadata.timestamp),
                             hash: localHash
                         });
-
-                        syncStatus = SYNC_STATUS.success;
-                        lastError = null;
-                        lastErrorMeta = null;
-                        logDebug('[Goal Portfolio Viewer] Local and server content identical, sync already up to date');
+                        markSyncSuccess('[Goal Portfolio Viewer] Local and server content identical, sync already up to date');
                     } else {
                         const conflict = await detectConflict(localConfig, serverData, localHash, serverHash);
 
@@ -5706,49 +5836,24 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                         if (localConfig.timestamp > serverData.metadata.timestamp) {
                             await uploadConfig(localConfig);
                             recordSuccessfulSync({ dataTimestamp: localConfig.timestamp, hash: localHash });
-
-                            syncStatus = SYNC_STATUS.success;
-                            lastError = null;
-                            lastErrorMeta = null;
-                            logDebug('[Goal Portfolio Viewer] Local config newer, uploaded to server');
+                            markSyncSuccess('[Goal Portfolio Viewer] Local config newer, uploaded to server');
                         } else if (localConfig.timestamp < serverData.metadata.timestamp) {
                             applyConfigData(serverData.config);
                             recordSuccessfulSync({ dataTimestamp: serverData.metadata.timestamp, hash: serverHash });
-
-                            syncStatus = SYNC_STATUS.success;
-                            lastError = null;
-                            lastErrorMeta = null;
-                            logDebug('[Goal Portfolio Viewer] Server config newer, applied locally');
+                            markSyncSuccess('[Goal Portfolio Viewer] Server config newer, applied locally');
                         } else {
                             recordSuccessfulSync();
-                            syncStatus = SYNC_STATUS.success;
-                            lastError = null;
-                            lastErrorMeta = null;
-                            logDebug('[Goal Portfolio Viewer] Sync already up to date');
+                            markSyncSuccess('[Goal Portfolio Viewer] Sync already up to date');
                         }
                     }
                 }
             }
 
-            if (typeof syncUi.update === 'function') {
-                syncUi.update();
-            }
+            notifySyncUiUpdate();
             return { status: 'success' };
         } catch (error) {
-            console.error('[Goal Portfolio Viewer] Sync failed:', error);
-            syncStatus = SYNC_STATUS.error;
-            lastError = error.message;
-            const guidance = getSyncErrorGuidance(error);
-            lastErrorMeta = {
-                category: guidance.category,
-                userMessage: guidance.userMessage,
-                primaryAction: guidance.primaryAction,
-                retryAfterSeconds: Number(error?.retryAfterSeconds) || null,
-                lastAttemptAt: Date.now()
-            };
-            if (typeof syncUi.update === 'function') {
-                syncUi.update();
-            }
+            markSyncError(error, '[Goal Portfolio Viewer] Sync failed:');
+            notifySyncUiUpdate();
             throw error;
         }
     }
@@ -5758,10 +5863,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function resolveConflict(resolution, conflict) {
         try {
-            syncStatus = SYNC_STATUS.syncing;
-            if (typeof syncUi.update === 'function') {
-                syncUi.update();
-            }
+            markSyncing();
 
             if (resolution === 'local') {
                 // Upload local, overwrite server
@@ -5800,32 +5902,16 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 throw new Error('Invalid resolution');
             }
 
-            syncStatus = SYNC_STATUS.success;
-            lastError = null;
-            lastErrorMeta = null;
-            if (typeof syncUi.update === 'function') {
-                syncUi.update();
-            }
+            markSyncSuccess();
+            notifySyncUiUpdate();
             
             // Refresh the portfolio view
             if (typeof document !== 'undefined') {
                 document.dispatchEvent(new CustomEvent('gpv-show-portfolio'));
             }
         } catch (error) {
-            console.error('[Goal Portfolio Viewer] Conflict resolution failed:', error);
-            syncStatus = SYNC_STATUS.error;
-            lastError = error.message;
-            const guidance = getSyncErrorGuidance(error);
-            lastErrorMeta = {
-                category: guidance.category,
-                userMessage: guidance.userMessage,
-                primaryAction: guidance.primaryAction,
-                retryAfterSeconds: Number(error?.retryAfterSeconds) || null,
-                lastAttemptAt: Date.now()
-            };
-            if (typeof syncUi.update === 'function') {
-                syncUi.update();
-            }
+            markSyncError(error, '[Goal Portfolio Viewer] Conflict resolution failed:');
+            notifySyncUiUpdate();
             throw error;
         }
     }
@@ -6005,10 +6091,12 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function enable(config) {
         const normalizedServerUrl = utils.normalizeServerUrl(config?.serverUrl);
-        if (!config || !normalizedServerUrl || !config.userId) {
+        const normalizedUserId = normalizeSyncUserId(config?.userId);
+        if (!config || !normalizedServerUrl || !normalizedUserId) {
             throw new Error('Invalid sync configuration: serverUrl and userId required');
         }
         utils.assertAllowedSyncServerUrl(normalizedServerUrl);
+        assertValidSyncUserId(normalizedUserId);
 
         if (config.masterKey) {
             setSessionMasterKey(config.masterKey);
@@ -6025,14 +6113,14 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
         const previousUserId = Storage.get(SYNC_STORAGE_KEYS.userId, null);
         const previousServerUrl = Storage.get(SYNC_STORAGE_KEYS.serverUrl, null);
-        if ((previousUserId && previousUserId !== config.userId) ||
+        if ((previousUserId && previousUserId !== normalizedUserId) ||
             (previousServerUrl && previousServerUrl !== normalizedServerUrl)) {
             clearTokens();
         }
 
         Storage.set(SYNC_STORAGE_KEYS.enabled, true);
         Storage.set(SYNC_STORAGE_KEYS.serverUrl, normalizedServerUrl);
-        Storage.set(SYNC_STORAGE_KEYS.userId, config.userId);
+        Storage.set(SYNC_STORAGE_KEYS.userId, normalizedUserId);
         
         if (config.autoSync !== undefined) {
             Storage.set(SYNC_STORAGE_KEYS.autoSync, config.autoSync);
@@ -6058,17 +6146,19 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function register(serverUrl, userId, password) {
         const normalizedServerUrl = utils.normalizeServerUrl(serverUrl);
-        if (!normalizedServerUrl || !userId || !password) {
+        const normalizedUserId = normalizeSyncUserId(userId);
+        if (!normalizedServerUrl || !normalizedUserId || !password) {
             throw new Error('serverUrl, userId, and password are required');
         }
         utils.assertAllowedSyncServerUrl(normalizedServerUrl);
+        assertValidSyncUserId(normalizedUserId);
 
         if (password.length < 8) {
             throw new Error('Password must be at least 8 characters');
         }
 
         // Hash password for authentication
-        const passwordHash = await SyncEncryption.hashPasswordForAuth(password, userId);
+        const passwordHash = await SyncEncryption.hashPasswordForAuth(password, normalizedUserId);
 
         // Call register endpoint
         const response = await requestJson(`${normalizedServerUrl}/auth/register`, {
@@ -6077,7 +6167,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                userId,
+                userId: normalizedUserId,
                 passwordHash
             })
         });
@@ -6089,7 +6179,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
         }
 
         Storage.set(SYNC_STORAGE_KEYS.serverUrl, normalizedServerUrl);
-        Storage.set(SYNC_STORAGE_KEYS.userId, userId);
+        Storage.set(SYNC_STORAGE_KEYS.userId, normalizedUserId);
         const masterKey = await SyncEncryption.deriveMasterKey(password);
         setSessionMasterKey(masterKey);
 
@@ -6101,13 +6191,15 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
      */
     async function login(serverUrl, userId, password) {
         const normalizedServerUrl = utils.normalizeServerUrl(serverUrl);
-        if (!normalizedServerUrl || !userId || !password) {
+        const normalizedUserId = normalizeSyncUserId(userId);
+        if (!normalizedServerUrl || !normalizedUserId || !password) {
             throw new Error('serverUrl, userId, and password are required');
         }
         utils.assertAllowedSyncServerUrl(normalizedServerUrl);
+        assertValidSyncUserId(normalizedUserId);
 
         // Hash password for authentication
-        const passwordHash = await SyncEncryption.hashPasswordForAuth(password, userId);
+        const passwordHash = await SyncEncryption.hashPasswordForAuth(password, normalizedUserId);
 
         // Call login endpoint
         const response = await requestJson(`${normalizedServerUrl}/auth/login`, {
@@ -6116,7 +6208,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                userId,
+                userId: normalizedUserId,
                 passwordHash
             })
         });
@@ -6136,7 +6228,7 @@ function buildNeedsAttentionItemsForFsmOverview(overviewModel) {
 
         storeTokens(result.tokens);
         Storage.set(SYNC_STORAGE_KEYS.serverUrl, normalizedServerUrl);
-        Storage.set(SYNC_STORAGE_KEYS.userId, userId);
+        Storage.set(SYNC_STORAGE_KEYS.userId, normalizedUserId);
 
         if (isEnabled()) {
             startAutoSync();
@@ -6438,58 +6530,48 @@ function buildOcbcConflictDiffItems(conflict) {
 
     const localAllocationBuckets = formatOcbcAllocationBucketsDisplay(localOcbc.allocationBuckets);
     const remoteAllocationBuckets = formatOcbcAllocationBucketsDisplay(remoteOcbc.allocationBuckets);
-    if (JSON.stringify(localAllocationBuckets) !== JSON.stringify(remoteAllocationBuckets)) {
-        rows.push({
-            section: 'definition',
-            settingName: 'Allocation Buckets',
-            localDisplay: formatSyncValue(localAllocationBuckets),
-            remoteDisplay: formatSyncValue(remoteAllocationBuckets)
-        });
-    }
+    pushConflictDiffSectionRow(rows, {
+        section: 'definition',
+        settingName: 'Allocation Buckets',
+        localValue: localAllocationBuckets,
+        remoteValue: remoteAllocationBuckets
+    });
 
     const localSubPortfolios = formatOcbcSubPortfoliosDisplay(localOcbc.subPortfolios);
     const remoteSubPortfolios = formatOcbcSubPortfoliosDisplay(remoteOcbc.subPortfolios);
-    if (JSON.stringify(localSubPortfolios) !== JSON.stringify(remoteSubPortfolios)) {
-        rows.push({
-            section: 'definition',
-            settingName: 'Sub-portfolios',
-            localDisplay: formatSyncValue(localSubPortfolios),
-            remoteDisplay: formatSyncValue(remoteSubPortfolios)
-        });
-    }
+    pushConflictDiffSectionRow(rows, {
+        section: 'definition',
+        settingName: 'Sub-portfolios',
+        localValue: localSubPortfolios,
+        remoteValue: remoteSubPortfolios
+    });
 
     const localAssignmentByCode = formatOcbcAssignmentByCodeDisplay(localOcbc.assignmentByCode);
     const remoteAssignmentByCode = formatOcbcAssignmentByCodeDisplay(remoteOcbc.assignmentByCode);
-    if (JSON.stringify(localAssignmentByCode) !== JSON.stringify(remoteAssignmentByCode)) {
-        rows.push({
-            section: 'assignment',
-            settingName: 'Code assignments',
-            localDisplay: formatSyncValue(localAssignmentByCode),
-            remoteDisplay: formatSyncValue(remoteAssignmentByCode)
-        });
-    }
+    pushConflictDiffSectionRow(rows, {
+        section: 'assignment',
+        settingName: 'Code assignments',
+        localValue: localAssignmentByCode,
+        remoteValue: remoteAssignmentByCode
+    });
 
     const localOrderByScope = formatOcbcOrderByScopeDisplay(localOcbc.orderByScope);
     const remoteOrderByScope = formatOcbcOrderByScopeDisplay(remoteOcbc.orderByScope);
-    if (JSON.stringify(localOrderByScope) !== JSON.stringify(remoteOrderByScope)) {
-        rows.push({
-            section: 'assignment',
-            settingName: 'Display order',
-            localDisplay: formatSyncValue(localOrderByScope),
-            remoteDisplay: formatSyncValue(remoteOrderByScope)
-        });
-    }
+    pushConflictDiffSectionRow(rows, {
+        section: 'assignment',
+        settingName: 'Display order',
+        localValue: localOrderByScope,
+        remoteValue: remoteOrderByScope
+    });
 
     const localTargetsByScope = formatOcbcTargetsByScopeDisplay(localOcbc.targetsByScope);
     const remoteTargetsByScope = formatOcbcTargetsByScopeDisplay(remoteOcbc.targetsByScope);
-    if (JSON.stringify(localTargetsByScope) !== JSON.stringify(remoteTargetsByScope)) {
-        rows.push({
-            section: 'target',
-            settingName: 'Allocation targets',
-            localDisplay: formatSyncValue(localTargetsByScope),
-            remoteDisplay: formatSyncValue(remoteTargetsByScope)
-        });
-    }
+    pushConflictDiffSectionRow(rows, {
+        section: 'target',
+        settingName: 'Allocation targets',
+        localValue: localTargetsByScope,
+        remoteValue: remoteTargetsByScope
+    });
 
     return rows;
 }
@@ -6535,14 +6617,12 @@ function buildFsmConflictDiffItems(conflict, options = {}) {
 
     const localPortfolios = normalizeFsmPortfolios(localFsm.portfolios || []).map(item => `${item.name} (${item.id})`).sort();
     const remotePortfolios = normalizeFsmPortfolios(remoteFsm.portfolios || []).map(item => `${item.name} (${item.id})`).sort();
-    if (JSON.stringify(localPortfolios) !== JSON.stringify(remotePortfolios)) {
-        rows.push({
-            section: 'definition',
-            settingName: 'Portfolio Definitions',
-            localDisplay: formatSyncValue(localPortfolios),
-            remoteDisplay: formatSyncValue(remotePortfolios)
-        });
-    }
+    pushConflictDiffSectionRow(rows, {
+        section: 'definition',
+        settingName: 'Portfolio Definitions',
+        localValue: localPortfolios,
+        remoteValue: remotePortfolios
+    });
 
     const assignmentCodes = new Set([
         ...Object.keys(localFsm.assignmentByCode || {}),
@@ -6583,13 +6663,38 @@ function buildFsmConflictDiffItems(conflict, options = {}) {
     return rows;
 }
 
-function buildConflictDiffSections(conflict, nameMapOverride = {}, fsmOptions = {}) {
-    return {
-        endowus: buildConflictDiffItemsForMap(conflict, nameMapOverride),
-        fsm: buildFsmConflictDiffItems(conflict, fsmOptions),
-        ocbc: buildOcbcConflictDiffItems(conflict)
-    };
-}
+    function buildConflictDiffSections(conflict, nameMapOverride = {}, fsmOptions = {}) {
+        return {
+            endowus: buildConflictDiffItemsForMap(conflict, nameMapOverride),
+            fsm: buildFsmConflictDiffItems(conflict, fsmOptions),
+            ocbc: buildOcbcConflictDiffItems(conflict)
+        };
+    }
+
+    function pushConflictDiffSectionRow(rows, {
+        section,
+        settingName,
+        localValue,
+        remoteValue,
+        localFormatter = formatSyncValue,
+        remoteFormatter = localFormatter,
+        compareUsingJson = true
+    }) {
+        const localDisplay = localFormatter(localValue);
+        const remoteDisplay = remoteFormatter(remoteValue);
+        const didChange = compareUsingJson
+            ? JSON.stringify(localValue) !== JSON.stringify(remoteValue)
+            : localDisplay !== remoteDisplay;
+        if (!didChange) {
+            return;
+        }
+        rows.push({
+            section,
+            settingName,
+            localDisplay,
+            remoteDisplay
+        });
+    }
 
 function buildConflictDiffItemsForMap(conflict, nameMapOverride = {}) {
     if (!conflict || !conflict.local || !conflict.remote) {

--- a/tampermonkey/package.json
+++ b/tampermonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tampermonkey",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Goal Portfolio Viewer userscript tooling",
   "private": true,
   "main": "goal_portfolio_viewer.user.js",

--- a/workers/src/auth.js
+++ b/workers/src/auth.js
@@ -7,6 +7,35 @@ import { getKvBinding } from './kv.js';
 
 const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
 const REFRESH_TOKEN_TTL_SECONDS = 60 * 24 * 60 * 60;
+const USER_ID_PATTERNS = Object.freeze([
+	/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+	/^[a-zA-Z0-9_-]{3,50}$/
+]);
+const USER_ID_VALIDATION_MESSAGE = 'Invalid userId format. Use email or alphanumeric with underscores/hyphens (3-50 chars)';
+
+function isValidUserId(userId) {
+	return typeof userId === 'string' && USER_ID_PATTERNS.some(pattern => pattern.test(userId));
+}
+
+function validateAuthRequest(userId, passwordHash) {
+	if (!userId || !passwordHash) {
+		return {
+			valid: false,
+			error: 'BAD_REQUEST',
+			message: 'userId and passwordHash required'
+		};
+	}
+
+	if (!isValidUserId(userId)) {
+		return {
+			valid: false,
+			error: 'BAD_REQUEST',
+			message: USER_ID_VALIDATION_MESSAGE
+		};
+	}
+
+	return { valid: true };
+}
 
 /**
  * Derive a slow hash from the incoming password hash for storage
@@ -79,7 +108,7 @@ function generateSalt() {
  * @returns {Promise<boolean>} - True if valid, false otherwise
  */
 export async function validatePassword(userId, passwordHash, env) {
-	if (!userId || !passwordHash) {
+	if (!userId || !passwordHash || !isValidUserId(userId)) {
 		return false;
 	}
 
@@ -257,14 +286,13 @@ export async function verifyRefreshToken(token, env) {
  * @returns {Promise<Object>} - { success: boolean, message: string }
  */
 export async function registerUser(userId, passwordHash, env) {
-	if (!userId || !passwordHash) {
-		return { success: false, message: 'userId and passwordHash required' };
-	}
-
-	// Validate userId format (email or alphanumeric)
-	if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(userId) && 
-	    !/^[a-zA-Z0-9_-]{3,50}$/.test(userId)) {
-		return { success: false, message: 'Invalid userId format. Use email or alphanumeric (3-50 chars)' };
+	const validation = validateAuthRequest(userId, passwordHash);
+	if (!validation.valid) {
+		return {
+			success: false,
+			error: validation.error,
+			message: validation.message
+		};
 	}
 
 	// Check if user already exists
@@ -305,10 +333,19 @@ export async function registerUser(userId, passwordHash, env) {
  * @returns {Promise<Object>} - { success: boolean, message: string }
  */
 export async function loginUser(userId, passwordHash, env) {
+	const validation = validateAuthRequest(userId, passwordHash);
+	if (!validation.valid) {
+		return {
+			success: false,
+			error: validation.error,
+			message: validation.message
+		};
+	}
+
 	const isValid = await validatePassword(userId, passwordHash, env);
 	
 	if (!isValid) {
-		return { success: false, message: 'Invalid credentials' };
+		return { success: false, error: 'UNAUTHORIZED', message: 'Invalid credentials' };
 	}
 
 	// Update last login time

--- a/workers/src/index.js
+++ b/workers/src/index.js
@@ -265,7 +265,7 @@ async function handleLogin(request, env) {
 		const { userId, passwordHash } = parsed.data;
 		const result = await credentials.loginUser(userId, passwordHash, env);
 		if (!result.success) {
-			return jsonResponseWithCors(result, 401, {}, env);
+			return jsonResponseWithCors(result, result.error === 'BAD_REQUEST' ? 400 : 401, {}, env);
 		}
 		const issuedTokens = await tokens.issueTokens(userId, env);
 		return jsonResponseWithCors({

--- a/workers/test/auth.test.js
+++ b/workers/test/auth.test.js
@@ -141,6 +141,18 @@ test('registerUser rejects invalid userId format', async () => {
   const result = await auth.credentials.registerUser('not an email', 'hashed', env);
 
   assert.equal(result.success, false);
+  assert.equal(result.error, 'BAD_REQUEST');
+  assert.match(result.message, /Invalid userId/i);
+});
+
+test('loginUser rejects invalid userId format', async () => {
+  const kv = createKvStore();
+  const env = { SYNC_KV: kv };
+
+  const result = await auth.credentials.loginUser('not an email', 'hashed', env);
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'BAD_REQUEST');
   assert.match(result.message, /Invalid userId/i);
 });
 

--- a/workers/test/handlers.test.js
+++ b/workers/test/handlers.test.js
@@ -2,11 +2,15 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { handleSync, handleGetSync, handleDeleteSync } from '../src/handlers.js';
+import { SyncContracts } from './helpers/contracts.js';
+
+const PRIMARY_USER_ID = SyncContracts.userIds.primary;
+const PRIMARY_SYNC_KEY = SyncContracts.kvKeys.syncUser(PRIMARY_USER_ID);
 
 function createKvMock(initialSyncData = null) {
   const store = new Map();
   if (initialSyncData) {
-    store.set('sync_user:user-1', JSON.stringify(initialSyncData));
+    store.set(PRIMARY_SYNC_KEY, JSON.stringify(initialSyncData));
   }
 
   return {
@@ -71,7 +75,7 @@ test('handleSync returns conflict when server data is newer', async () => {
 
   const response = await handleSync(
     {
-      userId: 'user-1',
+      userId: PRIMARY_USER_ID,
       deviceId: 'd1',
       encryptedData: 'v1',
       timestamp: 100,
@@ -93,7 +97,7 @@ test('handleSync allows force overwrite when server data is newer', async () => 
 
   const response = await handleSync(
     {
-      userId: 'user-1',
+      userId: PRIMARY_USER_ID,
       deviceId: 'd1',
       encryptedData: 'v1',
       timestamp: 100,
@@ -107,8 +111,8 @@ test('handleSync allows force overwrite when server data is newer', async () => 
   assert.equal(parsed.status, 200);
   assert.equal(parsed.body.success, true);
   assert.equal(parsed.body.timestamp, now + 1000);
-  assert.equal(env.SYNC_KV.store.has('sync_user:user-1'), true);
-  const stored = JSON.parse(env.SYNC_KV.store.get('sync_user:user-1'));
+  assert.equal(env.SYNC_KV.store.has(PRIMARY_SYNC_KEY), true);
+  const stored = JSON.parse(env.SYNC_KV.store.get(PRIMARY_SYNC_KEY));
   assert.equal(stored.timestamp, now + 1000);
 
   Date.now = originalDateNow;
@@ -119,7 +123,7 @@ test('handleSync stores payload when validation succeeds', async () => {
 
   const response = await handleSync(
     {
-      userId: 'user-1',
+      userId: PRIMARY_USER_ID,
       deviceId: 'd1',
       encryptedData: 'ciphertext',
       timestamp: Date.now(),
@@ -131,13 +135,13 @@ test('handleSync stores payload when validation succeeds', async () => {
   const parsed = await parseResponse(response);
   assert.equal(parsed.status, 200);
   assert.equal(parsed.body.success, true);
-  assert.equal(env.SYNC_KV.store.has('sync_user:user-1'), true);
+  assert.equal(env.SYNC_KV.store.has(PRIMARY_SYNC_KEY), true);
 });
 
 test('handleGetSync returns 404 when data is missing', async () => {
   const env = { SYNC_KV: createKvMock() };
 
-  const response = await handleGetSync('user-1', env);
+  const response = await handleGetSync(PRIMARY_USER_ID, env);
   const parsed = await parseResponse(response);
 
   assert.equal(parsed.status, 404);
@@ -147,10 +151,10 @@ test('handleGetSync returns 404 when data is missing', async () => {
 test('handleDeleteSync removes user config', async () => {
   const env = { SYNC_KV: createKvMock({ timestamp: 200, encryptedData: 'v2', deviceId: 'd2', version: 1 }) };
 
-  const response = await handleDeleteSync('user-1', env);
+  const response = await handleDeleteSync(PRIMARY_USER_ID, env);
   const parsed = await parseResponse(response);
 
   assert.equal(parsed.status, 200);
   assert.equal(parsed.body.success, true);
-  assert.equal(env.SYNC_KV.store.has('sync_user:user-1'), false);
+  assert.equal(env.SYNC_KV.store.has(PRIMARY_SYNC_KEY), false);
 });

--- a/workers/test/helpers/contracts.js
+++ b/workers/test/helpers/contracts.js
@@ -1,0 +1,25 @@
+export const SyncContracts = Object.freeze({
+  userIds: Object.freeze({
+    primary: 'user-1',
+    owner: 'owner-user',
+    other: 'other-user',
+    login: 'login-user',
+    refresh: 'refresh-user',
+    payload: 'payload-user',
+    route: 'route-user',
+    rateLimit: 'limit-user',
+    testerEmail: 'tester@example.com'
+  }),
+  kvKeys: Object.freeze({
+    syncUserPrefix: 'sync_user:',
+    syncUser(userId) {
+      return `sync_user:${userId}`;
+    },
+    rateLimit(ipOrUser, pathTemplate, method) {
+      return `ratelimit:${ipOrUser}:${pathTemplate}:${method}`;
+    }
+  }),
+  routes: Object.freeze({
+    syncPathTemplate: '/sync/:userId'
+  })
+});

--- a/workers/test/index.test.js
+++ b/workers/test/index.test.js
@@ -4,8 +4,28 @@ import { webcrypto } from 'node:crypto';
 
 import worker from '../src/index.js';
 import { tokens } from '../src/auth.js';
+import { SyncContracts } from './helpers/contracts.js';
 
 const MAX_PAYLOAD_SIZE = 64 * 1024;
+const {
+  userIds: {
+    testerEmail,
+    login: LOGIN_USER_ID,
+    refresh: REFRESH_USER_ID,
+    payload: PAYLOAD_USER_ID,
+    owner: OWNER_USER_ID,
+    other: OTHER_USER_ID,
+    route: ROUTE_USER_ID,
+    rateLimit: RATE_LIMIT_USER_ID
+  },
+  routes: {
+    syncPathTemplate: SYNC_PATH_TEMPLATE
+  }
+} = SyncContracts;
+
+function buildRateLimitKey(identity, method = 'GET') {
+  return SyncContracts.kvKeys.rateLimit(identity, SYNC_PATH_TEMPLATE, method);
+}
 
 if (!globalThis.crypto) {
   globalThis.crypto = webcrypto;
@@ -144,7 +164,7 @@ test('POST /auth/register supports success and validation failures', async () =>
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ userId: 'tester@example.com', passwordHash: 'hash' })
+    body: JSON.stringify({ userId: testerEmail, passwordHash: 'hash' })
   });
 
   const validResponse = await worker.fetch(validRequest, env, {});
@@ -175,7 +195,7 @@ test('POST /auth/login returns tokens on success', async () => {
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ userId: 'login-user', passwordHash: 'hash' })
+    body: JSON.stringify({ userId: LOGIN_USER_ID, passwordHash: 'hash' })
   });
   await worker.fetch(registerRequest, env, {});
 
@@ -184,7 +204,7 @@ test('POST /auth/login returns tokens on success', async () => {
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ userId: 'login-user', passwordHash: 'hash' })
+    body: JSON.stringify({ userId: LOGIN_USER_ID, passwordHash: 'hash' })
   });
 
   const loginResponse = await worker.fetch(loginRequest, env, {});
@@ -219,7 +239,7 @@ test('POST /auth/refresh handles missing, invalid, and valid tokens', async () =
 
   assert.equal(invalidParsed.status, 401);
 
-  const issuedTokens = await tokens.issueTokens('refresh-user', env);
+  const issuedTokens = await tokens.issueTokens(REFRESH_USER_ID, env);
   const validRequest = new Request('https://worker.example/auth/refresh', {
     method: 'POST',
     headers: {
@@ -236,7 +256,7 @@ test('POST /auth/refresh handles missing, invalid, and valid tokens', async () =
 
 test('POST /sync rejects payloads larger than MAX_PAYLOAD_SIZE', async () => {
   const env = createEnv();
-  const issuedTokens = await tokens.issueTokens('payload-user', env);
+  const issuedTokens = await tokens.issueTokens(PAYLOAD_USER_ID, env);
   const request = new Request('https://worker.example/sync', {
     method: 'POST',
     headers: {
@@ -244,7 +264,7 @@ test('POST /sync rejects payloads larger than MAX_PAYLOAD_SIZE', async () => {
       'Content-Type': 'application/json',
       'Content-Length': String(MAX_PAYLOAD_SIZE + 1)
     },
-    body: JSON.stringify({ userId: 'payload-user', data: 'ok' })
+    body: JSON.stringify({ userId: PAYLOAD_USER_ID, data: 'ok' })
   });
 
   const response = await worker.fetch(request, env, {});
@@ -256,7 +276,7 @@ test('POST /sync rejects payloads larger than MAX_PAYLOAD_SIZE', async () => {
 
 test('POST /sync rejects oversized payload without Content-Length', async () => {
   const env = createEnv();
-  const issuedTokens = await tokens.issueTokens('payload-user', env);
+  const issuedTokens = await tokens.issueTokens(PAYLOAD_USER_ID, env);
   const request = new Request('https://worker.example/sync', {
     method: 'POST',
     headers: {
@@ -311,12 +331,12 @@ test('POST /sync accepts payload exactly at MAX_PAYLOAD_SIZE boundary', async ()
 
 test('GET/DELETE /sync/:userId blocks access for mismatched authenticated user', async () => {
   const env = createEnv();
-  const issuedTokens = await tokens.issueTokens('owner-user', env);
+  const issuedTokens = await tokens.issueTokens(OWNER_USER_ID, env);
   const headers = {
     Authorization: `Bearer ${issuedTokens.accessToken}`
   };
 
-  const getRequest = new Request('https://worker.example/sync/other-user', {
+  const getRequest = new Request(`https://worker.example/sync/${OTHER_USER_ID}`, {
     method: 'GET',
     headers
   });
@@ -327,7 +347,7 @@ test('GET/DELETE /sync/:userId blocks access for mismatched authenticated user',
   assert.equal(getParsed.status, 403);
   assert.equal(getParsed.body.error, 'FORBIDDEN');
 
-  const deleteRequest = new Request('https://worker.example/sync/other-user', {
+  const deleteRequest = new Request(`https://worker.example/sync/${OTHER_USER_ID}`, {
     method: 'DELETE',
     headers
   });
@@ -340,7 +360,7 @@ test('GET/DELETE /sync/:userId blocks access for mismatched authenticated user',
 
 test('unknown authenticated route returns 404', async () => {
   const env = createEnv();
-  const issuedTokens = await tokens.issueTokens('route-user', env);
+  const issuedTokens = await tokens.issueTokens(ROUTE_USER_ID, env);
   const request = new Request('https://worker.example/unknown', {
     method: 'GET',
     headers: {
@@ -357,12 +377,12 @@ test('unknown authenticated route returns 404', async () => {
 
 test('rate limit is enforced for authenticated requests', async () => {
   const env = createEnv();
-  const issuedTokens = await tokens.issueTokens('limit-user', env);
-  const rateLimitKey = 'ratelimit:limit-user:/sync/:userId:GET';
+  const issuedTokens = await tokens.issueTokens(RATE_LIMIT_USER_ID, env);
+  const rateLimitKey = buildRateLimitKey(RATE_LIMIT_USER_ID, 'GET');
   const resetAt = Date.now() + 60_000;
   await env.SYNC_KV.put(rateLimitKey, JSON.stringify({ count: 60, resetAt }));
 
-  const request = new Request('https://worker.example/sync/limit-user', {
+  const request = new Request(`https://worker.example/sync/${RATE_LIMIT_USER_ID}`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${issuedTokens.accessToken}`

--- a/workers/test/index.test.js
+++ b/workers/test/index.test.js
@@ -186,6 +186,26 @@ test('POST /auth/register supports success and validation failures', async () =>
 
   assert.equal(invalidParsed.status, 400);
   assert.equal(invalidParsed.body.success, false);
+  assert.equal(invalidParsed.body.error, 'BAD_REQUEST');
+});
+
+test('POST /auth/login rejects invalid userId format with bad request', async () => {
+  const env = createEnv();
+  const request = new Request('https://worker.example/auth/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ userId: 'invalid user', passwordHash: 'hash' })
+  });
+
+  const response = await worker.fetch(request, env, {});
+  const parsed = await parseJsonResponse(response);
+
+  assert.equal(parsed.status, 400);
+  assert.equal(parsed.body.success, false);
+  assert.equal(parsed.body.error, 'BAD_REQUEST');
+  assert.match(parsed.body.message, /Invalid userId/i);
 });
 
 test('POST /auth/login returns tokens on success', async () => {

--- a/workers/test/ratelimit.test.js
+++ b/workers/test/ratelimit.test.js
@@ -2,6 +2,15 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { rateLimit } from '../src/ratelimit.js';
+import { SyncContracts } from './helpers/contracts.js';
+
+const CLIENT_IP = '1.2.3.4';
+const SYNC_PATH = '/sync';
+const SYNC_PATH_TEMPLATE = SyncContracts.routes.syncPathTemplate;
+
+function buildRateLimitKey(identity, pathTemplate, method) {
+  return SyncContracts.kvKeys.rateLimit(identity, pathTemplate, method);
+}
 
 function createKvMock() {
   const store = new Map();
@@ -31,9 +40,9 @@ function createRequest(method, headers = {}) {
 test('rateLimit allows first request and stores counter', async () => {
   const kv = createKvMock();
   const env = { SYNC_KV: kv };
-  const request = createRequest('POST', { 'CF-Connecting-IP': '1.2.3.4' });
+  const request = createRequest('POST', { 'CF-Connecting-IP': CLIENT_IP });
 
-  const result = await rateLimit(request, env, '/sync');
+  const result = await rateLimit(request, env, SYNC_PATH);
 
   assert.equal(result.allowed, true);
   assert.equal(kv.store.size, 1);
@@ -44,12 +53,12 @@ test('rateLimit blocks when limit is exceeded', async () => {
   const env = { SYNC_KV: kv };
   const now = Date.now();
   kv.store.set(
-    'ratelimit:1.2.3.4:/sync:POST',
+    buildRateLimitKey(CLIENT_IP, SYNC_PATH, 'POST'),
     JSON.stringify({ count: 10, resetAt: now + 30_000 })
   );
 
-  const request = createRequest('POST', { 'CF-Connecting-IP': '1.2.3.4' });
-  const result = await rateLimit(request, env, '/sync');
+  const request = createRequest('POST', { 'CF-Connecting-IP': CLIENT_IP });
+  const result = await rateLimit(request, env, SYNC_PATH);
 
   assert.equal(result.allowed, false);
   assert.ok(result.retryAfter > 0);
@@ -58,14 +67,14 @@ test('rateLimit blocks when limit is exceeded', async () => {
 test('rateLimit normalizes /sync/:userId path config', async () => {
   const kv = createKvMock();
   const env = { SYNC_KV: kv };
-  const request = createRequest('GET', { 'CF-Connecting-IP': '1.2.3.4' });
+  const request = createRequest('GET', { 'CF-Connecting-IP': CLIENT_IP });
 
   const result = await rateLimit(request, env, '/sync/alice');
 
   assert.equal(result.allowed, true);
   assert.equal(kv.store.size, 1);
   const [key] = [...kv.store.keys()];
-  assert.ok(key.includes('/sync/:userId:GET'));
+  assert.ok(key.includes(`${SYNC_PATH_TEMPLATE}:GET`));
 });
 
 test('rateLimit uses minimum KV TTL when remaining window is short', async () => {
@@ -73,15 +82,15 @@ test('rateLimit uses minimum KV TTL when remaining window is short', async () =>
   const env = { SYNC_KV: kv };
   const now = Date.now();
   kv.store.set(
-    'ratelimit:1.2.3.4:/sync:POST',
+    buildRateLimitKey(CLIENT_IP, SYNC_PATH, 'POST'),
     JSON.stringify({ count: 1, resetAt: now + 30_000 })
   );
 
-  const request = createRequest('POST', { 'CF-Connecting-IP': '1.2.3.4' });
-  const result = await rateLimit(request, env, '/sync');
+  const request = createRequest('POST', { 'CF-Connecting-IP': CLIENT_IP });
+  const result = await rateLimit(request, env, SYNC_PATH);
 
   assert.equal(result.allowed, true);
-  const options = kv.optionsByKey.get('ratelimit:1.2.3.4:/sync:POST');
+  const options = kv.optionsByKey.get(buildRateLimitKey(CLIENT_IP, SYNC_PATH, 'POST'));
   assert.ok(options);
   assert.equal(options.expirationTtl, 60);
 });

--- a/workers/test/storage.test.js
+++ b/workers/test/storage.test.js
@@ -6,6 +6,10 @@ import {
   getFromKV,
   putToKV
 } from '../src/storage.js';
+import { SyncContracts } from './helpers/contracts.js';
+
+const PRIMARY_USER_ID = SyncContracts.userIds.primary;
+const PRIMARY_SYNC_KEY = SyncContracts.kvKeys.syncUser(PRIMARY_USER_ID);
 
 function createKvMock(initial = {}) {
   const store = new Map(Object.entries(initial));
@@ -37,12 +41,12 @@ test('putToKV adds serverTimestamp metadata', async () => {
   Date.now = () => 1234567890;
 
   try {
-    await putToKV(env, 'user-1', { encryptedData: 'cipher', timestamp: 100, version: 1 });
+    await putToKV(env, PRIMARY_USER_ID, { encryptedData: 'cipher', timestamp: 100, version: 1 });
   } finally {
     Date.now = originalNow;
   }
 
-  const stored = JSON.parse(env.SYNC_KV.store.get('sync_user:user-1'));
+  const stored = JSON.parse(env.SYNC_KV.store.get(PRIMARY_SYNC_KEY));
   assert.equal(stored.encryptedData, 'cipher');
   assert.equal(stored.serverTimestamp, 1234567890);
 });
@@ -50,21 +54,21 @@ test('putToKV adds serverTimestamp metadata', async () => {
 test('getFromKV returns parsed JSON data', async () => {
   const env = {
     SYNC_KV: createKvMock({
-      'sync_user:user-1': JSON.stringify({ encryptedData: 'value', timestamp: 50 })
+      [PRIMARY_SYNC_KEY]: JSON.stringify({ encryptedData: 'value', timestamp: 50 })
     })
   };
 
-  const result = await getFromKV(env, 'user-1');
+  const result = await getFromKV(env, PRIMARY_USER_ID);
   assert.deepEqual(result, { encryptedData: 'value', timestamp: 50 });
 });
 
 test('deleteFromKV removes stored keys', async () => {
   const env = {
     SYNC_KV: createKvMock({
-      'sync_user:user-1': JSON.stringify({ encryptedData: 'value' })
+      [PRIMARY_SYNC_KEY]: JSON.stringify({ encryptedData: 'value' })
     })
   };
 
-  await deleteFromKV(env, 'user-1');
-  assert.equal(env.SYNC_KV.store.has('sync_user:user-1'), false);
+  await deleteFromKV(env, PRIMARY_USER_ID);
+  assert.equal(env.SYNC_KV.store.has(PRIMARY_SYNC_KEY), false);
 });


### PR DESCRIPTION
## Change Brief

- Problem: Sync and platform store handling had repeated logic in the userscript, error categorization was not fully aligned with worker responses, worker tests repeated contract literals in many files, the worker login path still returned an unauthorized response for malformed userId input instead of a validation error, and the userscript still had repeated goal-allocation/view-model and OCBC holdings helper flows.
- Goal: Reduce duplication while preserving behavior and UX, align sync validation and error handling contracts end to end, and consolidate repeated userscript logic around allocation state, bucket view models, sync request handling, and OCBC holdings normalization.
- Change type: Refactor, review-fix, test updates, and required patch version bump.
- Affected surfaces: tampermonkey, workers runtime and test suite, demo, and version metadata files.

## Risks & Tradeoffs

- Risk 1: Stricter sync userId validation can treat previously stored invalid IDs as unconfigured.
- Risk 2: Shared platform store and view-model helpers could regress migration, refresh, or rendering behavior if helper semantics drift.
- Risk 3: Canonicalizing OCBC holdings through by-portfolio helpers could regress assignment persistence if flatten/group behavior changes.
- Chosen direction: Reuse-first refactor with targeted regression tests while keeping APIs and UX flow unchanged, plus a narrow worker auth contract fix to keep malformed input distinct from credential failures.

## Acceptance Criteria

- [x] Platform store reads/writes for Endowus, FSM, and OCBC are deduplicated via shared helpers without behavior regressions.
- [x] Summary/detail userscript view models and goal allocation state are derived through shared builders without changing rendered behavior.
- [x] Goal target/fixed loading is centralized and reused across render and refresh paths.
- [x] OCBC holdings normalization has a canonical by-portfolio helper path with equivalent flattened behavior.
- [x] Sync userId validation is consistently enforced across enable, register, login, status, upload, and download paths.
- [x] Worker auth endpoints return `BAD_REQUEST` / HTTP 400 for malformed auth input while valid-shape credential failures remain `UNAUTHORIZED` / HTTP 401.
- [x] Worker test contract literals are centralized in shared helpers without runtime behavior changes.
- [x] Local lint, tests, smoke checks, and version bump validation pass for touched surfaces.

## Spec-Clarity Gate

- Status: `pass`
- Acceptance criteria source: existing sync behavior contracts, userscript rendering/state behavior, worker auth route behavior, and repository tests.
- Open questions: none

## Skill Alignment Notes

- Planning: scoped behavior-preserving refactor across userscript and tests, then reviewed the branch against `main` for correctness gaps and remaining duplication seams.
- Design: applied reuse-first helper extraction for repeated store, sync, allocation-state, bucket view-model, and OCBC holdings paths.
- Risk: focused on migration compatibility, validation strictness, auth response classification, sync UX consistency, and holdings assignment persistence.
- Implementation: applied directly per explicit no-delegation instruction.
- QA: targeted suites run for userscript UI-model, OCBC utility, and sync-manager paths, then full tampermonkey, workers, demo smoke, and version checks.
- Review: `review-fix-loop` noted from earlier important finding on worker auth validation behavior; fresh-context subagent review was skipped per explicit no-delegation instruction.
- PR Completion: completed after the final push and successful check watch for the latest refactor commits.

## Verification Matrix

| Acceptance Criterion | Verification Type | Command / Check | Result |
| --- | --- | --- | --- |
| Shared platform store helper preserves behavior | Automated | `corepack pnpm --filter ./tampermonkey test` | Pass |
| Shared summary/detail allocation/view-model builders preserve behavior | Automated | `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/uiModels.test.js` | Pass |
| Shared goal allocation config loaders preserve behavior | Automated | `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/uiModels.test.js` | Pass |
| Canonical OCBC by-portfolio normalization preserves flattened/runtime behavior | Automated | `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/utils.test.js` | Pass |
| Shared sync request/store-write helpers preserve sync behavior | Automated | `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/syncManager.test.js` | Pass |
| Sync userId validation enforcement | Automated | `corepack pnpm --filter ./tampermonkey test`, `corepack pnpm --filter ./workers test` | Pass |
| Worker auth malformed-input handling returns 400 while credential failures remain auth failures | Automated | `corepack pnpm --filter ./workers test` | Pass |
| Demo flow remains stable | Automated | `corepack pnpm --filter ./demo test:e2e:smoke` | Pass |
| Userscript lint gate | Automated | `corepack pnpm --filter ./tampermonkey lint` | Pass |
| Version bump policy | Automated | `node scripts/check-version-bump.js origin/main` | Pass |

## Self-Review Evidence

- Diff inspected: `git diff --stat origin/main...HEAD`, targeted `git diff` for userscript/test refactor files, and recent commits via `git log --oneline -10`.
- Commands run:
  - `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/uiModels.test.js`
  - `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/utils.test.js`
  - `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/syncManager.test.js`
  - `corepack pnpm --filter ./tampermonkey lint`
  - `corepack pnpm --filter ./tampermonkey test`
  - `corepack pnpm --filter ./workers test`
  - `corepack pnpm --filter ./demo test:e2e:smoke`
  - `node scripts/check-version-bump.js origin/main`
  - `gh pr checks 159 --watch`
- Outcomes: all commands passed. Existing negative-path Jest/output warnings remain expected in tests that intentionally exercise failure handling.
- Deferred follow-ups: none.

## Review Response Matrix

| Finding | Severity | Disposition | Fix Location | Verification Evidence | Residual Risk |
| --- | --- | --- | --- | --- | --- |
| Worker login/auth helpers treated malformed `userId` input as `401 Invalid credentials`, which diverged from register behavior and the updated sync validation contract. | important | fixed | `workers/src/auth.js`, `workers/src/index.js`, `workers/test/auth.test.js`, `workers/test/index.test.js` | Focused QA and broad QA pass: `corepack pnpm --filter ./workers test`, `corepack pnpm --filter ./tampermonkey lint`, `corepack pnpm --filter ./tampermonkey test`, `corepack pnpm --filter ./demo test:e2e:smoke`, `node scripts/check-version-bump.js origin/main`. | Low; worker auth validation and client-side sync validation now agree on malformed input handling. |

## CI Failure Triage

No CI failure triage required.

| Check | Run / Job | Classification | Evidence | Remediation | Verification | Residual Risk |
| --- | --- | --- | --- | --- | --- | --- |
| N/A | N/A | N/A | N/A | N/A | N/A | N/A |

## Final PR Completion

- Latest pushed commits: `7c380eb` (`Refactor sync and OCBC helper flows`), `0eb8a5b` (`Refactor shared userscript view model builders`)
- Required checks: `gh pr checks 159 --watch` completed with all reported checks passing after the final push.
  - Detect changed paths
  - Version Bump
  - Lint
  - Test on Node.js 20.x
  - Worker Unit Tests
  - Dependency Audit
  - E2E Demo
  - Deploy preview worker
- Expected skipped checks: none
- Local verification evidence:
  - `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/uiModels.test.js`
  - `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/utils.test.js`
  - `corepack pnpm --filter ./tampermonkey test -- --runTestsByPath __tests__/syncManager.test.js`
  - `corepack pnpm --filter ./tampermonkey lint`
  - `corepack pnpm --filter ./tampermonkey test`
  - `corepack pnpm --filter ./workers test`
  - `corepack pnpm --filter ./demo test:e2e:smoke`
  - `node scripts/check-version-bump.js origin/main`
- Open review-fix loops: none
- Open CI-triage loops: none
- Final status: `ready`
